### PR TITLE
Fix dropdowns on 404 page

### DIFF
--- a/consoleme/templates/error.html
+++ b/consoleme/templates/error.html
@@ -3,8 +3,6 @@
     <meta charset="UTF-8">
     <title>404 not found</title>
     </head>
-    <script type="text/javascript" src="/static/js/jquery-3.3.1.min.js"></script>
-    <script type="text/javascript" src="/static/js/jquery-ui.min.js"></script>
     <link href="/static/css/tabulator.min.css" rel="stylesheet">
     <script type="text/javascript" src="/static/js/tabulator.min.js"></script>
     <link href="/static/css/tabulator-midnight.css" rel="stylesheet">


### PR DESCRIPTION
Remove redundant jquery includes to fix nav bar dropdowns on 404 pages. `jquery-3.3.1.min.js` and `jquery-ui.min.js` are already included via `templates/header.html`.