### PR TITLE
Allow users to create self-serve temporary policies

### DIFF
--- a/consoleme/templates/static/js/SelfServiceForm.jsx
+++ b/consoleme/templates/static/js/SelfServiceForm.jsx
@@ -79,36 +79,36 @@ class SelfServiceForm extends Component {
       <div>
         {typeof arn === 'undefined' && <StepProgress page={page}/>}
         <div className={gridClass}>
-        <div className={columnClass}>
-          {typeof arn !== 'undefined' && <StepProgress page={page}/>}
-          {page !== 1 && <label style={{width: "100%", marginBottom: "10px"}}><b>Role ARN:</b> {this.state.choices.arn}</label>}
-          {page === 1 &&
-          <SelfServiceFormPage1
-            onSubmit={this.nextPage}
-            cancelRequest={this.cancelRequest}
-            toggleCheckbox={this.handleTemporaryCheckboxChange}
-            handleDateChange={this.handleDateChange}
-            is_temporary={this.state.is_temporary}
-            expiration_date={this.state.expiration_date}
-            arn={this.state.arn}
-          />}
-          {page === 2 &&
-          <SelfServiceFormPage2
-            choices={this.state.choices}
-            previousPage={this.previousPage}
-            onSubmit={this.nextPage}
-          />}
-          {page === 3 &&
-          <SelfServiceFormPage3
-            choices={this.state.choices}
-            previousPage={this.previousPage}
-            disableButton={this.disableButton}
-            state={this.state}
-            onSubmit={async (e) => {
-              await this.setPolicy(e);
-            }}
-          />}
-        </div>
+          <div className={columnClass}>
+            {typeof arn !== 'undefined' && <StepProgress page={page}/>}
+            {page !== 1 && <label style={{width: "100%", marginBottom: "10px"}}><b>Role ARN:</b> {this.state.choices.arn}</label>}
+            {page === 1 &&
+            <SelfServiceFormPage1
+              onSubmit={this.nextPage}
+              cancelRequest={this.cancelRequest}
+              toggleCheckbox={this.handleTemporaryCheckboxChange}
+              handleDateChange={this.handleDateChange}
+              is_temporary={this.state.is_temporary}
+              expiration_date={this.state.expiration_date}
+              arn={this.state.arn}
+            />}
+            {page === 2 &&
+            <SelfServiceFormPage2
+              choices={this.state.choices}
+              previousPage={this.previousPage}
+              onSubmit={this.nextPage}
+            />}
+            {page === 3 &&
+            <SelfServiceFormPage3
+              choices={this.state.choices}
+              previousPage={this.previousPage}
+              disableButton={this.disableButton}
+              state={this.state}
+              onSubmit={async (e) => {
+                await this.setPolicy(e);
+              }}
+            />}
+          </div>
         </div>
       </div>
     );

--- a/consoleme/templates/static/js/SelfServiceForm.jsx
+++ b/consoleme/templates/static/js/SelfServiceForm.jsx
@@ -20,6 +20,8 @@ class SelfServiceForm extends Component {
       account_id: props.account_id,
       policy_value: null,
       disableButton: false,
+      is_temporary: false,
+      expiration_date: "",
     };
   }
 
@@ -38,6 +40,14 @@ class SelfServiceForm extends Component {
 
   disableButton = () => {
     this.setState({disableButton: !disableButton});
+  };
+
+  handleTemporaryCheckboxChange = event => {
+    this.setState({is_temporary: !this.state.is_temporary})
+  };
+
+  handleDateChange = (event, value) => {
+    this.setState({expiration_date: value});
   };
 
   setPolicy = async (choices) => {
@@ -76,7 +86,11 @@ class SelfServiceForm extends Component {
           <SelfServiceFormPage1
             onSubmit={this.nextPage}
             cancelRequest={this.cancelRequest}
-            state={this.state}
+            toggleCheckbox={this.handleTemporaryCheckboxChange}
+            handleDateChange={this.handleDateChange}
+            is_temporary={this.state.is_temporary}
+            expiration_date={this.state.expiration_date}
+            arn={this.state.arn}
           />}
           {page === 2 &&
           <SelfServiceFormPage2

--- a/consoleme/templates/static/js/SelfServiceFormPage1.jsx
+++ b/consoleme/templates/static/js/SelfServiceFormPage1.jsx
@@ -74,7 +74,7 @@ function DetermineArn(props) {
 }
 
 const semanticCheckbox = ({input, label}) => (
-    <div className="ui checkbox" style={{paddingTop: "5px"}}>
+    <div className="ui checkbox">
         <input type="checkbox" readOnly="" tabIndex="0" {...input}/>
         <label style={{width: "auto"}}>{label}</label>
     </div>
@@ -112,12 +112,13 @@ const SelfServiceFormPage1 = props => {
       <br />
       <div>
         <label><b>Temporary Policy</b></label>
+          <p>Temporary policies will automatically be removed on the specified date.</p>
         <div>
           <div>
             <Field
                 name="is_temporary"
                 id="is_temporary"
-                label="This policy is temporary"
+                label="This policy change is temporary"
                 component={semanticCheckbox}
                 type="checkbox"
                 onChange={props.toggleCheckbox}/>

--- a/consoleme/templates/static/js/SelfServiceFormPage1.jsx
+++ b/consoleme/templates/static/js/SelfServiceFormPage1.jsx
@@ -1,6 +1,7 @@
 import {Field, reduxForm} from "redux-form";
 import React from "react";
-import {Dropdown, Form, Button, Icon} from 'semantic-ui-react';
+import {Dropdown, Form} from 'semantic-ui-react';
+import {DateInput} from 'semantic-ui-calendar-react';
 import SelfServiceFormAppSearch from "./SelfServiceFormAppSearch";
 
 const supportedServices = [
@@ -72,6 +73,28 @@ function DetermineArn(props) {
   )
 }
 
+const semanticCheckbox = ({input, label}) => (
+    <div className="ui checkbox" style={{paddingTop: "5px"}}>
+        <input type="checkbox" readOnly="" tabIndex="0" {...input}/>
+        <label style={{width: "auto"}}>{label}</label>
+    </div>
+);
+
+const semanticDatePicker = ({input, label}) => (
+    <div>
+        <Form.Field>
+            <label style={{width: "auto", paddingTop: "10px"}}>{label}</label>
+            <DateInput
+                clearable {...input}
+                dateFormat="YYYY-MM-DD"
+                name="Foo"
+                value={input.value}
+                onChange={(param, data) => input.onChange(data.value)}
+                placeholder={input.placeholder}
+            />
+        </Form.Field>
+    </div>
+)
 
 const SelfServiceFormPage1 = props => {
   const {handleSubmit, cancelRequest} = props;
@@ -79,11 +102,37 @@ const SelfServiceFormPage1 = props => {
   if (window.location.href.endsWith("self_service")) {
     cancelButtonDisplayed = "none";
   }
+
   return (
-    <Form onSubmit={handleSubmit}>
-        <DetermineArn arn={props.state.arn} />
+    <Form onSubmit={handleSubmit} className="ui form">
+        <DetermineArn arn={props.arn} />
       <div>
-        <Field name="choose" component={DropdownFormField} label="Service" validate={required}/>
+          <Field name="choose" component={DropdownFormField} label="Service" validate={required}/>
+      </div>
+      <br />
+      <div>
+        <label><b>Temporary Policy</b></label>
+        <div>
+          <div>
+            <Field
+                name="is_temporary"
+                id="is_temporary"
+                label="This policy is temporary"
+                component={semanticCheckbox}
+                type="checkbox"
+                onChange={props.toggleCheckbox}/>
+          </div>
+          { props.is_temporary ? <Field
+              name="expiration_date"
+              id="expiration_date"
+              label="Policy expiration date:"
+              component={semanticDatePicker}
+              value={props.expiration_date}
+              iconPosition="left"
+              onChange={props.handleDateChange}
+              validate={required} />
+              : null}
+        </div>
       </div>
       <div>
         <button type="cancel" className="ui negative button cancel" onClick={cancelRequest} style={{margin: "10px", display: cancelButtonDisplayed}}>

--- a/consoleme/templates/static/js/SelfServiceFormPage1.jsx
+++ b/consoleme/templates/static/js/SelfServiceFormPage1.jsx
@@ -74,26 +74,26 @@ function DetermineArn(props) {
 }
 
 const semanticCheckbox = ({input, label}) => (
-    <div className="ui checkbox">
-        <input type="checkbox" readOnly="" tabIndex="0" {...input}/>
-        <label style={{width: "auto"}}>{label}</label>
-    </div>
+  <div className="ui checkbox">
+    <input type="checkbox" readOnly="" tabIndex="0" {...input}/>
+    <label style={{width: "auto"}}>{label}</label>
+  </div>
 );
 
 const semanticDatePicker = ({input, label}) => (
-    <div>
-        <Form.Field>
-            <label style={{width: "auto", paddingTop: "10px"}}>{label}</label>
-            <DateInput
-                clearable {...input}
-                dateFormat="YYYY-MM-DD"
-                name="Foo"
-                value={input.value}
-                onChange={(param, data) => input.onChange(data.value)}
-                placeholder={input.placeholder}
-            />
-        </Form.Field>
-    </div>
+  <div>
+    <Form.Field>
+      <label style={{width: "auto", paddingTop: "10px"}}>{label}</label>
+      <DateInput
+        clearable {...input}
+        dateFormat="YYYY-MM-DD"
+        name="Foo"
+        value={input.value}
+        onChange={(param, data) => input.onChange(data.value)}
+        placeholder={input.placeholder}
+      />
+    </Form.Field>
+  </div>
 )
 
 const SelfServiceFormPage1 = props => {
@@ -107,7 +107,7 @@ const SelfServiceFormPage1 = props => {
     <Form onSubmit={handleSubmit} className="ui form">
         <DetermineArn arn={props.arn} />
       <div>
-          <Field name="choose" component={DropdownFormField} label="Service" validate={required}/>
+        <Field name="choose" component={DropdownFormField} label="Service" validate={required}/>
       </div>
       <br />
       <div>
@@ -116,23 +116,23 @@ const SelfServiceFormPage1 = props => {
         <div>
           <div>
             <Field
-                name="is_temporary"
-                id="is_temporary"
-                label="This policy change is temporary"
-                component={semanticCheckbox}
-                type="checkbox"
-                onChange={props.toggleCheckbox}/>
+              name="is_temporary"
+              id="is_temporary"
+              label="This policy change is temporary"
+              component={semanticCheckbox}
+              type="checkbox"
+              onChange={props.toggleCheckbox}/>
           </div>
           { props.is_temporary ? <Field
-              name="expiration_date"
-              id="expiration_date"
-              label="Policy expiration date:"
-              component={semanticDatePicker}
-              value={props.expiration_date}
-              iconPosition="left"
-              onChange={props.handleDateChange}
-              validate={required} />
-              : null}
+            name="expiration_date"
+            id="expiration_date"
+            label="Policy expiration date:"
+            component={semanticDatePicker}
+            value={props.expiration_date}
+            iconPosition="left"
+            onChange={props.handleDateChange}
+            validate={required} />
+            : null}
         </div>
       </div>
       <div>

--- a/consoleme/templates/static/js/SelfServiceFormPage3.jsx
+++ b/consoleme/templates/static/js/SelfServiceFormPage3.jsx
@@ -48,12 +48,20 @@ const Permissions = {
 
 let ALPHABET = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
 
-function generate_id() {
+function random_id() {
   let rtn = '';
   for (let i = 0; i < 8; i++) {
     rtn += ALPHABET.charAt(Math.floor(Math.random() * ALPHABET.length));
   }
-  return "ConsoleMe" + rtn;
+  return rtn
+}
+
+function generate_id() {
+  return "ConsoleMe" + random_id();
+}
+
+function generate_temp_id(expiration_date) {
+  return "temp_" + expiration_date + "_" + random_id();
 }
 
 function generatePolicy(choices, policy_sid, state) {
@@ -203,7 +211,12 @@ function WizardAceEditor(policy_value, choices) {
 
 let SelfServiceFormPage3 = props => {
   const {handleSubmit, pristine, previousPage, submitting, choices, state} = props;
-  const policy_sid = generate_id();
+  let policy_sid;
+  if (choices.is_temporary) {
+    policy_sid = generate_temp_id(choices.expiration_date);
+  } else {
+    policy_sid = generate_id();
+  }
   let policy_value = generatePolicy(choices, policy_sid, state);
   choices.policy_sid = policy_sid;
   choices.wizard_policy_editor = WizardAceEditor(policy_value, choices);

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "react-select": "^3.0.4",
+    "semantic-ui-calendar-react": "^0.15.3",
     "semantic-ui-react": "^0.84.0"
   },
   "description": "",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4895,6 +4895,11 @@ mkdirp@^0.5.0, mkdirp@^0.5.1:
   dependencies:
     minimist "0.0.8"
 
+moment@^2.22.2:
+  version "2.24.0"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
+  integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==
+
 move-concurrently@^1.0.1:
   version "1.0.1"
   resolved "https://artifacts.netflix.com/api/npm/npm-netflix/move-concurrently/-/move-concurrently-1.0.1.tgz#be2c005fda32e0b29af1f05d7c4b33214c701f92"
@@ -6187,6 +6192,16 @@ schema-utils@^1.0.0:
     ajv "^6.1.0"
     ajv-errors "^1.0.0"
     ajv-keywords "^3.1.0"
+
+semantic-ui-calendar-react@^0.15.3:
+  version "0.15.3"
+  resolved "https://registry.yarnpkg.com/semantic-ui-calendar-react/-/semantic-ui-calendar-react-0.15.3.tgz#eb25826076a2967d9bb04e0567824366f5eb6fe4"
+  integrity sha512-cXlg/dJf0z/dydnol1GCy9ssccXBAGYhmka9W2KNXqqW+B0mgPhu6ugWOjGD4i99e3dnNl1QVqYvQpQcpkcEIg==
+  dependencies:
+    keyboard-key "^1.0.2"
+    lodash "^4.17.15"
+    moment "^2.22.2"
+    prop-types "^15.6.2"
 
 semantic-ui-react@^0.78.2:
   version "0.78.3"


### PR DESCRIPTION
Add a checkbox and date picker to the self-service wizard to allow users to create temporary policies that will be automatically cleaned up.