### PR TITLE
Detect cross-account self-service requests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ bootstrap:
 dynamo:
 	@echo "--> Configuring Dynamo (Make sure local dynamo is enabled on port 8000)"
 	. env/bin/activate || source activate consoleme;\
-	python scripts/initialize_dynamodb_dev.py
+	python scripts/initialize_dynamodb_oss.py
 
 .PHONY: redis
 redis:

--- a/consoleme/handlers/policies.py
+++ b/consoleme/handlers/policies.py
@@ -530,7 +530,7 @@ class PolicyReviewSubmitHandler(BaseHandler):
         buckets = await redis_hgetall("S3_BUCKETS")
         resource_actions = await get_resources_from_events(events)
         resources = list(resource_actions.keys())
-        resource_policies = await get_resource_policies(resource_actions, account_id)
+        resource_policies = await get_resource_policies(arn, resource_actions, account_id)
         dynamo = UserDynamoHandler(self.user)
         request = await dynamo.write_policy_request(
             self.user, justification, arn, policy_name, events, resources

--- a/consoleme/handlers/policies.py
+++ b/consoleme/handlers/policies.py
@@ -530,7 +530,7 @@ class PolicyReviewSubmitHandler(BaseHandler):
         buckets = await redis_hgetall("S3_BUCKETS")
         resource_actions = await get_resources_from_events(events)
         resources = resource_actions.keys()
-        resource_policies = await get_resource_policies(resources, account_id)
+        resource_policies = await get_resource_policies(resource_actions, account_id)
         dynamo = UserDynamoHandler(self.user)
         request = await dynamo.write_policy_request(
             self.user, justification, arn, policy_name, events, resources

--- a/consoleme/handlers/policies.py
+++ b/consoleme/handlers/policies.py
@@ -529,7 +529,7 @@ class PolicyReviewSubmitHandler(BaseHandler):
             policy_status = "approved"
         buckets = await redis_hgetall("S3_BUCKETS")
         resource_actions = await get_resources_from_events(events)
-        resources = resource_actions.keys()
+        resources = list(resource_actions.keys())
         resource_policies = await get_resource_policies(resource_actions, account_id)
         dynamo = UserDynamoHandler(self.user)
         request = await dynamo.write_policy_request(
@@ -1002,6 +1002,7 @@ async def handle_resource_type_ahead_request(cls):
             if search_string.lower() in account.lower():
                 results.append({"title": account})
     elif resource_type == "app":
+        results = {}
         all_role_arns = []
         all_role_arns_j = await redis_hgetall(
             (config.get("aws.iamroles_redis_key", "IAM_ROLE_CACHE"))
@@ -1021,7 +1022,7 @@ async def handle_resource_type_ahead_request(cls):
         seen: Dict = {}
         seen_roles = {}
         for app_name, roles in app_to_role_map.items():
-            if len(results) > 9:
+            if len(results.keys()) > 9:
                 break
             if search_string.lower() in app_name.lower():
                 results[app_name] = {"name": app_name, "results": []}
@@ -1039,7 +1040,7 @@ async def handle_resource_type_ahead_request(cls):
                         {"title": role, "description": account}
                     )
         for role in all_role_arns:
-            if len(results) > 9:
+            if len(results.keys()) > 9:
                 break
             if search_string.lower() in role.lower():
                 if seen_roles.get(role):

--- a/consoleme/handlers/policies.py
+++ b/consoleme/handlers/policies.py
@@ -528,7 +528,8 @@ class PolicyReviewSubmitHandler(BaseHandler):
         if should_auto_approve_request is not False:
             policy_status = "approved"
         buckets = await redis_hgetall("S3_BUCKETS")
-        resources = await get_resources_from_events(events)
+        resource_actions = await get_resources_from_events(events)
+        resources = resource_actions.keys()
         resource_policies = await get_resource_policies(resources, account_id)
         dynamo = UserDynamoHandler(self.user)
         request = await dynamo.write_policy_request(

--- a/consoleme/lib/aws.py
+++ b/consoleme/lib/aws.py
@@ -169,7 +169,6 @@ async def get_resource_accounts(arns: List[str]) -> Dict:
 
         resource_type: str = get_service_from_arn(arn)
         resource_name: str = get_resource_from_arn(arn)
-        # TODO: Does this need to support other resource types that don't have an account in the ARN?
         if resource_type == 's3':
             for k, v in s3_buckets.items():
                 if resource_name in v:

--- a/consoleme/lib/aws.py
+++ b/consoleme/lib/aws.py
@@ -180,9 +180,9 @@ async def get_resource_accounts(arns: List[str]) -> Dict:
     return results
 
 
-async def get_resource_policies(arns: List[str], account: str) -> Dict:
+async def get_resource_policies(resource_actions: Dict[str, List[str]], account: str) -> Dict:
     resource_policies: Dict = {}
-    resource_owners = await get_resource_accounts(arns)
+    resource_owners = await get_resource_accounts(resource_actions.keys())
     for arn, resource_account in resource_owners.items():
         if resource_account != account:
             # This is a cross-account request. Might need a resource policy.

--- a/consoleme/lib/policies.py
+++ b/consoleme/lib/policies.py
@@ -450,17 +450,17 @@ async def get_resources_from_events(policy_changes: List[Dict]) -> Dict[str, Lis
                 policy_document = policy['policy_document']
                 for statement in policy_document.get('Statement', []):
                     for resource in statement.get('Resource', []):
-                        actions = get_actions_for_resources(resource, policy_document)
+                        actions = get_actions_for_resources(resource, statement)
                         resource_actions[resource].extend(actions)
-    return resource_actions
+    return dict(resource_actions)
 
 
-def get_actions_for_resources(resource: str, policy_document: Dict) -> List[str]:
+def get_actions_for_resources(resource: str, statement: Dict) -> List[str]:
     results: List[str] = []
     # Get service from resource
     resource_service = get_service_from_arn(resource)
     # Get relevant actions from policy doc
-    for action in policy_document['Action']:
+    for action in statement['Action']:
         if get_service_from_action(action) == resource_service:
             results.append(action)
     

--- a/consoleme/lib/policies.py
+++ b/consoleme/lib/policies.py
@@ -2,6 +2,7 @@ import base64
 import re
 import sys
 import time
+from collections import defaultdict
 from typing import Dict, List
 
 import boto3
@@ -10,6 +11,8 @@ from asgiref.sync import sync_to_async
 from botocore.exceptions import ClientError
 from cloudaux.aws.sts import boto3_cached_conn
 from deepdiff import DeepDiff
+from policy_sentry.util.actions import get_service_from_action
+from policy_sentry.util.arns import get_service_from_arn
 
 from consoleme.config import config
 from consoleme.exceptions.exceptions import InvalidRequestParameter
@@ -436,16 +439,32 @@ async def validate_policy_name(policy_name):
         )
 
 
-async def get_resources_from_events(policy_changes: List[Dict]) -> List[str]:
-    """Returns a list of resources affected by a list of policy changes."""
-    resource_arns: List[str] = []
+async def get_resources_from_events(policy_changes: List[Dict]) -> Dict[str, List[str]]:
+    """Returns a dict of resources affected by a list of policy changes along with
+    the actions that are relevant to them.
+    """
+    resource_actions: Dict[str, List[str]] = defaultdict(list)
     for event in policy_changes:
         for policy_type in ['inline_policies', 'managed_policies']:
             for policy in event[policy_type]:
                 policy_document = policy['policy_document']
                 for statement in policy_document.get('Statement', []):
-                    resource_arns.extend(statement.get('Resource', []))
-    return list(set(resource_arns))
+                    for resource in statement.get('Resource', []):
+                        actions = get_actions_for_resources(resource, policy_document)
+                        resource_actions[resource].extend(actions)
+    return resource_actions
+
+
+def get_actions_for_resources(resource: str, policy_document: Dict) -> List[str]:
+    results: List[str] = []
+    # Get service from resource
+    resource_service = get_service_from_arn(resource)
+    # Get relevant actions from policy doc
+    for action in policy_document['Action']:
+        if get_service_from_action(action) == resource_service:
+            results.append(action)
+    
+    return list(set(results))
 
 
 async def get_formatted_policy_changes(account_id, arn, request):

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -12,21 +12,21 @@ aws-sam-translator==1.20.1  # via cfn-lint
 aws-xray-sdk==2.4.3       # via moto
 bandit==1.6.2             # via -r requirements-test.in (line 3)
 black==19.10b0            # via -r requirements-test.in (line 4)
-bleach==3.1.1             # via -c requirements.txt (line 16), readme-renderer
-boto3==1.12.4             # via -c requirements.txt (line 17), aws-sam-translator, moto
-boto==2.49.0              # via -c requirements.txt (line 18), moto
-botocore==1.15.4          # via -c requirements.txt (line 19), aws-xray-sdk, boto3, moto, s3transfer
-certifi==2019.11.28       # via -c requirements.txt (line 23), requests
+bleach==3.1.1             # via -c requirements.txt (line 17), readme-renderer
+boto3==1.12.4             # via -c requirements.txt (line 18), aws-sam-translator, moto
+boto==2.49.0              # via -c requirements.txt (line 19), moto
+botocore==1.15.4          # via -c requirements.txt (line 20), aws-xray-sdk, boto3, moto, s3transfer
+certifi==2019.11.28       # via -c requirements.txt (line 25), requests
 cffi==1.14.0              # via cryptography
 cfgv==3.0.0               # via pre-commit
 cfn-lint==0.28.1          # via moto
-chardet==3.0.4            # via -c requirements.txt (line 24), requests
-click==7.0                # via -c requirements.txt (line 25), black
+chardet==3.0.4            # via -c requirements.txt (line 26), requests
+click==7.0                # via -c requirements.txt (line 27), black
 coverage==5.0.3           # via -r requirements-test.in (line 5), pytest-cov
 cryptography==2.8         # via moto, sshpubkeys
 distlib==0.3.0            # via virtualenv
 docker==4.2.0             # via moto
-docutils==0.15.2          # via -c requirements.txt (line 30), botocore, readme-renderer
+docutils==0.15.2          # via -c requirements.txt (line 33), botocore, readme-renderer
 ecdsa==0.15               # via python-jose, sshpubkeys
 entrypoints==0.3          # via flake8
 execnet==1.7.1            # via pytest-xdist
@@ -39,17 +39,17 @@ future==0.18.2            # via aws-xray-sdk
 gitdb2==3.0.2             # via gitpython
 gitpython==3.0.8          # via bandit
 identify==1.4.11          # via pre-commit
-idna==2.8                 # via -c requirements.txt (line 46), moto, requests
-importlib-metadata==1.5.0  # via -c requirements.txt (line 47), jsonschema, pluggy, pre-commit, pytest, tox, virtualenv
-jinja2==2.11.1            # via moto
-jmespath==0.9.4           # via -c requirements.txt (line 54), boto3, botocore
+idna==2.8                 # via -c requirements.txt (line 50), moto, requests
+importlib-metadata==1.5.0  # via -c requirements.txt (line 51), jsonschema, pluggy, pre-commit, pytest, tox, virtualenv
+jinja2==2.11.1            # via -c requirements.txt (line 58), moto
+jmespath==0.9.4           # via -c requirements.txt (line 59), boto3, botocore
 jsondiff==1.1.2           # via moto
 jsonpatch==1.25           # via cfn-lint
 jsonpickle==1.3           # via aws-xray-sdk
 jsonpointer==2.0          # via jsonpatch
-jsonschema==3.2.0         # via -c requirements.txt (line 56), aws-sam-translator, cfn-lint
-markupsafe==1.1.1         # via jinja2
-mccabe==0.6.1             # via -c requirements.txt (line 62), flake8
+jsonschema==3.2.0         # via -c requirements.txt (line 61), aws-sam-translator, cfn-lint
+markupsafe==1.1.1         # via -c requirements.txt (line 66), jinja2
+mccabe==0.6.1             # via -c requirements.txt (line 68), flake8
 mock==3.0.5               # via -r requirements-test.in (line 10), moto
 mockredispy==2.9.3        # via -r requirements-test.in (line 11)
 more-itertools==8.2.0     # via pytest
@@ -63,54 +63,55 @@ pbr==5.4.4                # via stevedore
 pillow==7.0.0             # via -r requirements-test.in (line 14)
 pluggy==0.13.1            # via pytest, tox
 pre-commit==2.1.0         # via -r requirements-test.in (line 15)
-py==1.8.1                 # via -c requirements.txt (line 76), pytest, tox
-pyasn1==0.4.8             # via -c requirements.txt (line 78), python-jose, rsa
+py==1.8.1                 # via -c requirements.txt (line 83), pytest, tox
+pyasn1==0.4.8             # via -c requirements.txt (line 85), python-jose, rsa
 pycodestyle==2.5.0        # via flake8, flake8-import-order
 pycparser==2.19           # via cffi
 pydocstyle==5.0.2         # via flake8-docstrings
 pyflakes==2.1.1           # via flake8
-pygments==2.5.2           # via -c requirements.txt (line 80), readme-renderer
+pygments==2.5.2           # via -c requirements.txt (line 87), readme-renderer
 pyparsing==2.4.6          # via packaging
-pyrsistent==0.15.7        # via -c requirements.txt (line 83), jsonschema
+pyrsistent==0.15.7        # via -c requirements.txt (line 90), jsonschema
 pytest-asyncio==0.10.0    # via -r requirements-test.in (line 17)
 pytest-cov==2.8.1         # via -r requirements-test.in (line 18)
 pytest-forked==1.1.3      # via pytest-xdist
-pytest-timeout==1.3.4     # via -r requirements-test.in (line 19)
-pytest-tornado==0.8.0     # via -r requirements-test.in (line 20)
-pytest-xdist==1.31.0      # via -r requirements-test.in (line 21)
-pytest==5.3.5             # via -r requirements-test.in (line 16), pytest-asyncio, pytest-cov, pytest-forked, pytest-timeout, pytest-tornado, pytest-xdist
-python-dateutil==2.8.0    # via -c requirements.txt (line 84), botocore, moto
+pytest-mock==2.0.0        # via -r requirements-test.in (line 19)
+pytest-timeout==1.3.4     # via -r requirements-test.in (line 20)
+pytest-tornado==0.8.0     # via -r requirements-test.in (line 21)
+pytest-xdist==1.31.0      # via -r requirements-test.in (line 22)
+pytest==5.3.5             # via -r requirements-test.in (line 16), pytest-asyncio, pytest-cov, pytest-forked, pytest-mock, pytest-timeout, pytest-tornado, pytest-xdist
+python-dateutil==2.8.0    # via -c requirements.txt (line 91), botocore, moto
 python-jose==3.1.0        # via moto
-pytz==2019.3              # via -c requirements.txt (line 87), moto
-pyyaml==5.3               # via -c requirements.txt (line 88), bandit, cfn-lint, moto, pre-commit
-readme-renderer==24.0     # via -r requirements-test.in (line 22)
-redis==3.4.1              # via -c requirements.txt (line 90), fakeredis
+pytz==2019.3              # via -c requirements.txt (line 94), moto
+pyyaml==5.3               # via -c requirements.txt (line 95), bandit, cfn-lint, moto, pre-commit
+readme-renderer==24.0     # via -r requirements-test.in (line 23)
+redis==3.4.1              # via -c requirements.txt (line 97), fakeredis
 regex==2020.2.20          # via black
-requests==2.23.0          # via -c requirements.txt (line 91), docker, moto, responses
+requests==2.23.0          # via -c requirements.txt (line 98), docker, moto, responses
 responses==0.10.9         # via moto
-rsa==4.0                  # via -c requirements.txt (line 94), python-jose
-s3transfer==0.3.3         # via -c requirements.txt (line 95), boto3
-selenium==3.141.0         # via -r requirements-test.in (line 23)
-six==1.14.0               # via -c requirements.txt (line 97), aws-sam-translator, bandit, bleach, cfn-lint, cryptography, docker, ecdsa, fakeredis, jsonschema, mock, moto, packaging, pytest-xdist, python-dateutil, python-jose, readme-renderer, responses, stevedore, tox, virtualenv, websocket-client
+rsa==4.0                  # via -c requirements.txt (line 101), python-jose
+s3transfer==0.3.3         # via -c requirements.txt (line 102), boto3
+selenium==3.141.0         # via -r requirements-test.in (line 24)
+six==1.14.0               # via -c requirements.txt (line 105), aws-sam-translator, bandit, bleach, cfn-lint, cryptography, docker, ecdsa, fakeredis, jsonschema, mock, moto, packaging, pytest-xdist, python-dateutil, python-jose, readme-renderer, responses, stevedore, tox, virtualenv, websocket-client
 smmap2==2.0.5             # via gitdb2
 snowballstemmer==2.0.0    # via pydocstyle
 sortedcontainers==2.1.0   # via fakeredis
 sshpubkeys==3.1.0         # via moto
 stevedore==1.32.0         # via bandit
 toml==0.10.0              # via black, pre-commit, tox
-tornado==6.0.3            # via -c requirements.txt (line 99), -r requirements-test.in (line 24), pytest-tornado
-tox==3.14.5               # via -r requirements-test.in (line 25)
-typed-ast==1.4.1          # via -c requirements.txt (line 101), black, mypy
+tornado==6.0.3            # via -c requirements.txt (line 109), -r requirements-test.in (line 25), pytest-tornado
+tox==3.14.5               # via -r requirements-test.in (line 26)
+typed-ast==1.4.1          # via -c requirements.txt (line 111), black, mypy
 typing-extensions==3.7.4.1  # via mypy
-urllib3==1.25.8           # via -c requirements.txt (line 104), botocore, requests, selenium
+urllib3==1.25.8           # via -c requirements.txt (line 114), botocore, requests, selenium
 virtualenv==20.0.4        # via pre-commit, tox
-wcwidth==0.1.8            # via -c requirements.txt (line 108), pytest
-webencodings==0.5.1       # via -c requirements.txt (line 109), bleach
+wcwidth==0.1.8            # via -c requirements.txt (line 118), pytest
+webencodings==0.5.1       # via -c requirements.txt (line 119), bleach
 websocket-client==0.57.0  # via docker
 werkzeug==1.0.0           # via moto
-wrapt==1.11.2             # via -c requirements.txt (line 110), aws-xray-sdk
+wrapt==1.11.2             # via -c requirements.txt (line 120), aws-xray-sdk
 xmltodict==0.12.0         # via moto
-zipp==3.0.0               # via -c requirements.txt (line 112), importlib-metadata
+zipp==3.0.0               # via -c requirements.txt (line 122), importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements.in
+++ b/requirements.in
@@ -27,6 +27,7 @@ logmatic-python
 lxml
 pandas<1
 pkgconfig
+policy_sentry
 policyuniverse
 presto-python-client
 pycurl # For AsyncHTTPClient

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@
 #
 #    pip-compile --no-index --output-file=requirements.txt requirements.in
 #
-
 amqp==2.5.2               # via kombu
 apispec-webframeworks==0.5.2  # via -r requirements.in (line 2)
 apispec[yaml]==3.3.0      # via -r requirements.in (line 1), apispec-webframeworks
@@ -13,18 +12,21 @@ asgiref==3.2.3            # via -r requirements.in (line 3)
 astroid==2.3.3            # via pylint
 attrs==19.3.0             # via jsonschema
 backcall==0.1.0           # via ipython
+beautifulsoup4==4.8.2     # via bs4
 billiard==3.6.2.0         # via celery
 bleach==3.1.1             # via -r requirements.in (line 4)
 boto3==1.12.4             # via -r requirements.in (line 5), cloudaux
 boto==2.49.0              # via cloudaux
 botocore==1.15.4          # via boto3, cloudaux, s3transfer
+bs4==0.0.1                # via policy-sentry
 cachetools==4.0.0         # via google-auth
 cchardet==2.1.5           # via -r requirements.in (line 6)
 celery[redis]==4.4.0      # via -r requirements.in (line 7)
 certifi==2019.11.28       # via requests
 chardet==3.0.4            # via requests
-click==7.0                # via presto-python-client
+click==7.0                # via policy-sentry, presto-python-client
 cloudaux==1.8.1           # via -r requirements.in (line 8)
+contextlib2==0.5.5        # via schema
 decorator==4.4.1          # via ipython, retry, traitlets
 deepdiff[murmur]==4.2.0   # via -r requirements.in (line 9)
 defusedxml==0.6.0         # via -r requirements.in (line 10), cloudaux, python3-saml
@@ -43,6 +45,7 @@ google-resumable-media==0.5.0  # via google-cloud-storage
 googleapis-common-protos==1.51.0  # via google-api-core
 gunicorn==20.0.4          # via -r requirements.in (line 17)
 hiredis==1.0.1            # via -r requirements.in (line 18)
+html5lib==1.0.1           # via policy-sentry
 httplib2==0.17.0          # via google-api-python-client, google-auth-httplib2
 idna==2.8                 # via -r requirements.in (line 19), requests
 importlib-metadata==1.5.0  # via jsonschema, kombu
@@ -52,65 +55,68 @@ ipython==7.12.0           # via -r requirements.in (line 20)
 isodate==0.6.0            # via -r requirements.in (line 21), python3-saml
 isort==4.3.21             # via pylint
 jedi==0.16.0              # via ipython
+jinja2==2.11.1            # via policy-sentry
 jmespath==0.9.4           # via -r requirements.in (line 22), boto3, botocore
 joblib==0.14.1            # via cloudaux
 jsonschema==3.2.0         # via -r requirements.in (line 23)
 kombu==4.6.7              # via -r requirements.in (line 24), celery
 lazy-object-proxy==1.4.3  # via astroid
 logmatic-python==0.1.7    # via -r requirements.in (line 26)
-lxml==4.5.0               # via -r requirements.in (line 27), xmlsec
+lxml==4.5.0               # via -r requirements.in (line 27), policy-sentry, xmlsec
+markupsafe==1.1.1         # via jinja2
 marshmallow==2.20.5       # via -r requirements.in (line 25)
 mccabe==0.6.1             # via pylint
 mmh3==2.5.1               # via deepdiff
 numpy==1.18.1             # via pandas
 ordered-set==3.1.1        # via deepdiff
-pandas==0.25.3            # via -r requirements.in (line 28)
+pandas==0.25.3            # via -r requirements.in (line 28), policy-sentry
 parso==0.6.1              # via jedi
 pexpect==4.8.0            # via ipython
 pickleshare==0.7.5        # via ipython
 pkgconfig==1.5.1          # via -r requirements.in (line 29), xmlsec
-policyuniverse==1.3.2.1   # via -r requirements.in (line 30)
-presto-python-client==0.7.0  # via -r requirements.in (line 31)
+policy-sentry==0.7.1      # via -r requirements.in (line 30)
+policyuniverse==1.3.2.1   # via -r requirements.in (line 31), policy-sentry
+presto-python-client==0.7.0  # via -r requirements.in (line 32)
 prompt-toolkit==3.0.3     # via ipython
 protobuf==3.11.3          # via google-api-core, googleapis-common-protos
 ptyprocess==0.6.0         # via pexpect
 py==1.8.1                 # via retry
 pyasn1-modules==0.2.8     # via google-auth
 pyasn1==0.4.8             # via pyasn1-modules, rsa
-pycurl==7.43.0.5          # via -r requirements.in (line 32)
+pycurl==7.43.0.5          # via -r requirements.in (line 33)
 pygments==2.5.2           # via ipython
-pyjwt==1.7.1              # via -r requirements.in (line 33)
-pylint==2.4.4             # via -r requirements.in (line 34)
+pyjwt==1.7.1              # via -r requirements.in (line 34)
+pylint==2.4.4             # via -r requirements.in (line 35)
 pyrsistent==0.15.7        # via jsonschema
-python-dateutil==2.8.0    # via -r requirements.in (line 35), botocore, elasticsearch-dsl, pandas
+python-dateutil==2.8.0    # via -r requirements.in (line 36), botocore, elasticsearch-dsl, pandas
 python-json-logger==0.1.11  # via logmatic-python
-python3-saml==1.9.0       # via -r requirements.in (line 36)
-pytz==2019.3              # via -r requirements.in (line 37), celery, google-api-core, pandas
-pyyaml==5.3               # via apispec
-raven==6.10.0             # via -r requirements.in (line 38)
-redis==3.4.1              # via -r requirements.in (line 39), celery
-requests==2.23.0          # via -r requirements.in (line 40), google-api-core, presto-python-client
-retry==0.9.2              # via -r requirements.in (line 41)
-retrying==1.3.3           # via -r requirements.in (line 42)
+python3-saml==1.9.0       # via -r requirements.in (line 37)
+pytz==2019.3              # via -r requirements.in (line 38), celery, google-api-core, pandas
+pyyaml==5.3               # via apispec, policy-sentry
+raven==6.10.0             # via -r requirements.in (line 39)
+redis==3.4.1              # via -r requirements.in (line 40), celery
+requests==2.23.0          # via -r requirements.in (line 41), google-api-core, policy-sentry, presto-python-client
+retry==0.9.2              # via -r requirements.in (line 42)
+retrying==1.3.3           # via -r requirements.in (line 43)
 rsa==4.0                  # via google-auth
 s3transfer==0.3.3         # via boto3
-simplejson==3.17.0        # via -r requirements.in (line 43)
-six==1.14.0               # via -r requirements.in (line 44), astroid, bleach, cloudaux, elasticsearch-dsl, google-api-core, google-api-python-client, google-auth, google-resumable-media, isodate, jsonschema, presto-python-client, protobuf, pyrsistent, python-dateutil, retrying, tenacity, traitlets
-tenacity==6.0.0           # via -r requirements.in (line 45)
-tornado==6.0.3            # via -r requirements.in (line 46)
+schema==0.7.1             # via policy-sentry
+simplejson==3.17.0        # via -r requirements.in (line 44)
+six==1.14.0               # via -r requirements.in (line 45), astroid, bleach, cloudaux, elasticsearch-dsl, google-api-core, google-api-python-client, google-auth, google-resumable-media, html5lib, isodate, jsonschema, presto-python-client, protobuf, pyrsistent, python-dateutil, retrying, tenacity, traitlets
+soupsieve==1.9.5          # via beautifulsoup4
+sqlalchemy==1.3.13        # via policy-sentry
+tenacity==6.0.0           # via -r requirements.in (line 46)
+tornado==6.0.3            # via -r requirements.in (line 47)
 traitlets==4.3.3          # via ipython
 typed-ast==1.4.1          # via astroid
-ujson==1.35               # via -r requirements.in (line 47)
+ujson==1.35               # via -r requirements.in (line 48)
 uritemplate==3.0.1        # via google-api-python-client
 urllib3==1.25.8           # via botocore, elasticsearch, requests
-uvloop==0.14.0            # via -r requirements.in (line 48)
-validate-email==1.3       # via -r requirements.in (line 49)
+uvloop==0.14.0            # via -r requirements.in (line 49)
+validate-email==1.3       # via -r requirements.in (line 50)
 vine==1.3.0               # via amqp, celery
 wcwidth==0.1.8            # via prompt-toolkit
-webencodings==0.5.1       # via bleach
+webencodings==0.5.1       # via bleach, html5lib
 wrapt==1.11.2             # via astroid
-xmlsec==1.3.3             # via -r requirements.in (line 50), python3-saml
+xmlsec==1.3.3             # via -r requirements.in (line 51), python3-saml
 zipp==3.0.0               # via importlib-metadata
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools


### PR DESCRIPTION
This PR adds the groundwork for handling cross-account self service requests. For each resource in a policy request, we check the "owner" of the resource. If the owner is different than the requesting account, we have a chance to generate a resource policy for that resource.

Currently based on #30, will rebase once that's merged.