### PR TITLE
Notate cross-account policy requests

### DIFF
--- a/consoleme/handlers/policies.py
+++ b/consoleme/handlers/policies.py
@@ -536,7 +536,7 @@ class PolicyReviewSubmitHandler(BaseHandler):
         try:
             resource_actions = await get_resources_from_events(events)
             resources = list(resource_actions.keys())
-            resource_policies, is_cross_account = await get_resource_policies(
+            resource_policies, cross_account_request = await get_resource_policies(
                 arn, resource_actions, account_id
             )
         except Exception as e:
@@ -546,7 +546,7 @@ class PolicyReviewSubmitHandler(BaseHandler):
             resource_actions = {}
             resources = []
             resource_policies = []
-            is_cross_account = False
+            cross_account_request = False
 
         log_data["resource_actions"] = resource_actions
         log_data["resource_policies"] = resource_policies
@@ -559,7 +559,7 @@ class PolicyReviewSubmitHandler(BaseHandler):
             events,
             resources,
             resource_policies,
-            cross_account=is_cross_account,
+            cross_account_request=cross_account_request,
         )
         if policy_status == "approved":
             try:
@@ -828,7 +828,7 @@ class PolicyReviewHandler(BaseHandler):
                 ]
             try:
                 resource_actions = await get_resources_from_events(policy_changes)
-                resource_policies, is_cross_account = await get_resource_policies(
+                resource_policies, cross_account_request = await get_resource_policies(
                     arn, resource_actions, account_id
                 )
             except Exception as e:
@@ -837,7 +837,7 @@ class PolicyReviewHandler(BaseHandler):
                 log.error(log_data, exc_info=True)
                 resource_actions = {}
                 resource_policies = []
-                is_cross_account = False
+                cross_account_request = False
 
             log_data["resource_actions"] = resource_actions
             log_data["resource_policies"] = resource_policies
@@ -846,7 +846,7 @@ class PolicyReviewHandler(BaseHandler):
             request["resource_policies"] = resource_policies
             request["policy_changes"] = json.dumps(policy_changes)
             request["reviewer_comments"] = reviewer_comments
-            request["cross_account_request"] = is_cross_account
+            request["cross_account_request"] = cross_account_request
 
         # Keep a record of the policy as it was at the time of the change, for historical record
         if updated_status == "approved":

--- a/consoleme/handlers/policies.py
+++ b/consoleme/handlers/policies.py
@@ -653,6 +653,8 @@ class PolicyReviewHandler(BaseHandler):
         can_cancel: bool = False
         show_update_button: bool = False
         read_only = True
+        resource_policies: List = request.get("resource_policies", [])
+        cross_account: bool = True if resource_policies else False
 
         if status == "pending":
             show_approve_reject_buttons = await can_manage_policy_requests(self.groups)
@@ -693,6 +695,8 @@ class PolicyReviewHandler(BaseHandler):
             role_uri=role_uri,
             escape_json=escape_json,
             policy_changes=formatted_policy_changes,
+            resource_policies=resource_policies,
+            cross_account=cross_account,
         )
 
     async def post(self, request_id):

--- a/consoleme/lib/aws.py
+++ b/consoleme/lib/aws.py
@@ -21,7 +21,7 @@ from policy_sentry.util.arns import (
     get_resource_from_arn,
     get_service_from_arn,
 )
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 from consoleme.config import config
 from consoleme.exceptions.exceptions import BackgroundCheckNotPassedException
@@ -192,12 +192,14 @@ async def get_resource_policy(account: str, resource_type: str, name: str, regio
 
 async def get_resource_policies(
     principal_arn: str, resource_actions: Dict[str, Dict[str, Any]], account: str
-) -> List[Dict]:
+) -> Tuple[List[Dict], bool]:
     resource_policies: List[Dict] = []
+    is_cross_account: bool = False
     for resource_name, resource_info in resource_actions.items():
         resource_account: str = resource_info.get("account", "")
         if resource_account and resource_account != account:
             # This is a cross-account request. Might need a resource policy.
+            is_cross_account = True
             resource_type: str = resource_info.get("type", "")
             resource_region: str = resource_info.get("region", "")
             old_policy = await get_resource_policy(
@@ -212,7 +214,7 @@ async def get_resource_policies(
             result = {"resource": resource_name, "policy_document": new_policy}
             resource_policies.append(result)
 
-    return resource_policies
+    return resource_policies, is_cross_account
 
 
 async def update_resource_policy(

--- a/consoleme/lib/aws.py
+++ b/consoleme/lib/aws.py
@@ -194,12 +194,12 @@ async def get_resource_policies(
     principal_arn: str, resource_actions: Dict[str, Dict[str, Any]], account: str
 ) -> Tuple[List[Dict], bool]:
     resource_policies: List[Dict] = []
-    is_cross_account: bool = False
+    cross_account_request: bool = False
     for resource_name, resource_info in resource_actions.items():
         resource_account: str = resource_info.get("account", "")
         if resource_account and resource_account != account:
             # This is a cross-account request. Might need a resource policy.
-            is_cross_account = True
+            cross_account_request = True
             resource_type: str = resource_info.get("type", "")
             resource_region: str = resource_info.get("region", "")
             old_policy = await get_resource_policy(
@@ -214,7 +214,7 @@ async def get_resource_policies(
             result = {"resource": resource_name, "policy_document": new_policy}
             resource_policies.append(result)
 
-    return resource_policies, is_cross_account
+    return resource_policies, cross_account_request
 
 
 async def update_resource_policy(

--- a/consoleme/lib/dynamo.py
+++ b/consoleme/lib/dynamo.py
@@ -352,6 +352,7 @@ class UserDynamoHandler(BaseDynamoHandler):
         request_time: int = None,
         request_uuid=None,
         policy_status="pending",
+        cross_account: bool = False,
     ):
         """
             Writes a policy request to the appropriate DynamoDB table
@@ -377,6 +378,7 @@ class UserDynamoHandler(BaseDynamoHandler):
             "policy_changes": json.dumps(policy_changes),
             "resources": resources,
             "resource_policies": resource_policies,
+            "cross_account_request": cross_account,
         }
 
         try:

--- a/consoleme/lib/dynamo.py
+++ b/consoleme/lib/dynamo.py
@@ -352,7 +352,7 @@ class UserDynamoHandler(BaseDynamoHandler):
         request_time: int = None,
         request_uuid=None,
         policy_status="pending",
-        cross_account: bool = False,
+        cross_account_request: bool = False,
     ):
         """
             Writes a policy request to the appropriate DynamoDB table
@@ -378,7 +378,7 @@ class UserDynamoHandler(BaseDynamoHandler):
             "policy_changes": json.dumps(policy_changes),
             "resources": resources,
             "resource_policies": resource_policies,
-            "cross_account_request": cross_account,
+            "cross_account_request": cross_account_request,
         }
 
         try:

--- a/consoleme/templates/policy_review.html
+++ b/consoleme/templates/policy_review.html
@@ -168,7 +168,7 @@
             {% end %}
             <tr>
                 <td>Cross-Account</td>
-                <td><span style="copendinglor: red;">{{ cross_account }}</span>
+                <td><span style="copendinglor: red;">{{ request.get("cross_account_request", False) }}</span>
                 </td>
             </tr>
         </tbody>

--- a/consoleme/templates/policy_review.html
+++ b/consoleme/templates/policy_review.html
@@ -166,6 +166,11 @@
                     <td><span style="copendinglor: red;">{% for resource in request.get("resources") %}{{ escape(resource) }} <br/> {% end %}</span>
                 </tr>
             {% end %}
+            <tr>
+                <td>Cross-Account</td>
+                <td><span style="copendinglor: red;">{{ cross_account }}</span>
+                </td>
+            </tr>
         </tbody>
     </table>
 
@@ -269,11 +274,11 @@
                 </form>
             </div>
         </div>
-        {% if request.get("resource_policies") %}
+        {% if resource_policies %}
         <div class="ui segment">
             <h2>Resource Policy Changes</h2>
-            <p>The InfraSec team may need to update the resource policy for the following resource(s). We've tried to give a head start by modifying the existing policy or creating a new one. Note that these will <em>not</em> be applied when this request is approved and committed.</em></p>
-            {% for idx, resource_policy in enumerate(request.get("resource_policies", [])) %}
+            <p>The InfraSec team may need to update the resource policy for the following resource(s). We've tried to give a head start by modifying the existing policy or building a new one. Note that these will <em>not</em> be applied when this request is approved and committed.</em></p>
+            {% for idx, resource_policy in enumerate(resource_policies) %}
                 <h3>{{ resource_policy.get('resource') }}</h3>
                 <div id="resourcePolicy{{ idx }}" class="ui segment" style="height: 500px;">
                     {{ json.dumps(resource_policy.get('policy_document'), indent=4, sort_keys=True, escape_forward_slashes=False) }}


### PR DESCRIPTION
This is pretty naive but might be sufficient. If a request has resource policies, it will be considered cross-account.