### PR TITLE
Always set XSRF cookie when preparing a request

### DIFF
--- a/consoleme/handlers/base.py
+++ b/consoleme/handlers/base.py
@@ -136,6 +136,8 @@ class BaseHandler(SentryMixin, tornado.web.RequestHandler):
         )
 
     async def prepare(self) -> None:
+        if config.get("tornado.xsrf", True):
+            self.set_cookie(config.get("xsrf_cookie_name", "_xsrf"), self.xsrf_token)
         self.responses = []
         self.request_uuid = str(uuid.uuid4())
         stats.timer("base_handler.incoming_request")

--- a/consoleme/handlers/base.py
+++ b/consoleme/handlers/base.py
@@ -137,7 +137,12 @@ class BaseHandler(SentryMixin, tornado.web.RequestHandler):
 
     async def prepare(self) -> None:
         if config.get("tornado.xsrf", True):
-            self.set_cookie(config.get("xsrf_cookie_name", "_xsrf"), self.xsrf_token)
+            cookie_kwargs = config.get("tornado.xsrf_cookie_kwargs", {})
+            self.set_cookie(
+                config.get("xsrf_cookie_name", "_xsrf"),
+                self.xsrf_token,
+                **cookie_kwargs,
+            )
         self.responses = []
         self.request_uuid = str(uuid.uuid4())
         stats.timer("base_handler.incoming_request")


### PR DESCRIPTION
Now when you load self_service page directly, we generate an _xsrf cookie for you. This will now happen for all pages by default.

![image](https://user-images.githubusercontent.com/7538233/77962336-45cad800-7290-11ea-9282-8daee20847f6.png)
