### PR TITLE
Add endpoint and models for templating

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -80,6 +80,30 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ExtendedRequestModel'
+  /template:
+    post:
+      summary: get templated changes
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              oneOf:
+                - $ref: '#/components/schemas/S3TemplateModel'
+              discriminator:
+                propertyName: template_type
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/InlinePolicyChangeModel'
+                  - $ref: '#/components/schemas/ManagedPolicyChangeModel'
+                  - $ref: '#/components/schemas/ResourcePolicyChangeModel'
+                discriminator:
+                  propertyName: change_type
   /resources:
     get:
       summary: get resources
@@ -333,6 +357,32 @@ components:
               type: string
             comments:
               $ref: '#/components/schemas/CommentModel'
+    TemplateModel: # I don't like this name. Help!
+      type: object
+      required:
+        - template_type
+        - resource
+      properties:
+        template_type:
+          type: string
+          enum:
+            - s3
+    S3TemplateModel: # These schemas could be defined in different files.
+      allOf:
+        - $ref: '#/components/schemas/TemplateModel'
+        - type: object
+          required:
+            - action_groups
+          properties:
+            action_groups:
+              type: array
+              items:
+                type: string
+                enum:
+                  - list
+                  - get
+                  - put
+                  - delete
     ChangeModel:
       type: object
       required:

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -93,7 +93,7 @@ paths:
                 anyOf:
                   - $ref: '#/components/schemas/S3ChangeGeneratorModel'
                 discriminator:
-                  propertyName: template_type
+                  propertyName: generator_type
       responses:
         '200':
           description: OK
@@ -364,10 +364,10 @@ components:
     ChangeGeneratorModel:
       type: object
       required:
-        - template_type
+        - generator_type
         - resource
       properties:
-        template_type:
+        generator_type:
           type: string
           enum:
             - s3

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -91,7 +91,10 @@ paths:
               type: array
               items:
                 anyOf:
+                  - $ref: '#/components/schemas/GenericChangeGeneratorModel'
                   - $ref: '#/components/schemas/S3ChangeGeneratorModel'
+                  - $ref: '#/components/schemas/SQSChangeGeneratorModel'
+                  - $ref: '#/components/schemas/SNSChangeGeneratorModel'
                 discriminator:
                   propertyName: generator_type
       responses:
@@ -370,8 +373,51 @@ components:
         generator_type:
           type: string
           enum:
+            - generic
             - s3
+            - sqs
+            - sns
+    GenericChangeGeneratorModel:
+      description: uses Policy Sentry to generate a policy based on access levels
+      allOf:
+        - $ref: '#/components/schemas/ChangeGeneratorModel'
+        - type: object
+          required:
+            - access_level
+          properties:
+            access_level:
+              type: array
+              items:
+                type: string
+                enum:
+                  - read
+                  - write
+                  - list
+                  - tagging
+                  - permissions-management
     S3ChangeGeneratorModel: # These schemas could be defined in different files.
+      allOf:
+        - $ref: '#/components/schemas/ChangeGeneratorModel'
+        - type: object
+          required:
+            - action_groups
+          properties:
+            bucket_name:
+              type: string
+              example: really.cool.bucket
+            bucket_prefix:
+              type: string
+              example: /awesome/prefix/*
+            action_groups:
+              type: array
+              items:
+                type: string
+                enum:
+                  - list
+                  - get
+                  - put
+                  - delete
+    SQSChangeGeneratorModel:
       allOf:
         - $ref: '#/components/schemas/ChangeGeneratorModel'
         - type: object
@@ -383,10 +429,28 @@ components:
               items:
                 type: string
                 enum:
-                  - list
-                  - get
-                  - put
-                  - delete
+                  - get_queue_attributes
+                  - set_queue_attributes
+                  - receive_messages
+                  - send_messages
+                  - delete_messages
+    SNSChangeGeneratorModel:
+      allOf:
+        - $ref: '#/components/schemas/ChangeGeneratorModel'
+        - type: object
+          required:
+            - action_groups
+          properties:
+            action_groups:
+              type: array
+              items:
+                type: string
+                enum:
+                  - get_topic_attributes
+                  - set_topic_attributes
+                  - publish
+                  - subscribe
+                  - unsubscribe
     ChangeModel:
       type: object
       required:

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -80,7 +80,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ExtendedRequestModel'
-  /template:
+  /generate_changes:
     post:
       summary: get templated changes
       requestBody:
@@ -88,22 +88,26 @@ paths:
         content:
           application/json:
             schema:
-              oneOf:
-                - $ref: '#/components/schemas/S3TemplateModel'
-              discriminator:
-                propertyName: template_type
+              type: array
+              items:
+                anyOf:
+                  - $ref: '#/components/schemas/S3ChangeGeneratorModel'
+                discriminator:
+                  propertyName: template_type
       responses:
         '200':
           description: OK
           content:
             application/json:
               schema:
-                oneOf:
-                  - $ref: '#/components/schemas/InlinePolicyChangeModel'
-                  - $ref: '#/components/schemas/ManagedPolicyChangeModel'
-                  - $ref: '#/components/schemas/ResourcePolicyChangeModel'
-                discriminator:
-                  propertyName: change_type
+                type: array
+                items:
+                  anyOf:
+                    - $ref: '#/components/schemas/InlinePolicyChangeModel'
+                    - $ref: '#/components/schemas/ManagedPolicyChangeModel'
+                    - $ref: '#/components/schemas/ResourcePolicyChangeModel'
+                  discriminator:
+                    propertyName: change_type
   /resources:
     get:
       summary: get resources
@@ -357,7 +361,7 @@ components:
               type: string
             comments:
               $ref: '#/components/schemas/CommentModel'
-    TemplateModel: # I don't like this name. Help!
+    ChangeGeneratorModel:
       type: object
       required:
         - template_type
@@ -367,9 +371,9 @@ components:
           type: string
           enum:
             - s3
-    S3TemplateModel: # These schemas could be defined in different files.
+    S3ChangeGeneratorModel: # These schemas could be defined in different files.
       allOf:
-        - $ref: '#/components/schemas/TemplateModel'
+        - $ref: '#/components/schemas/ChangeGeneratorModel'
         - type: object
           required:
             - action_groups


### PR DESCRIPTION
This is a first iteration of a helper endpoint to build a change set for a self-service request. Currently the concept is that we have a collection of supported "helpers" (right now they're called `Template` s, which I don't like). This schema allows for arbitrary types that can contain data needed to generate a `Change` model that is returned to the client to be used as part of a `Request`.