### PR TITLE
Upgrading to generic API handler on backend to fix XSS

### DIFF
--- a/consoleme/handlers/base.py
+++ b/consoleme/handlers/base.py
@@ -435,7 +435,19 @@ class BaseHandler(SentryMixin, tornado.web.RequestHandler):
         return auth
 
 
-class BaseMtlsHandler(BaseHandler):
+class BaseAPIV1Handler(BaseHandler):
+    """Default API Handler for V1 routes."""
+    def set_default_headers(self) -> None:
+        self.set_header("Content-Type", "application/json")
+
+
+class BaseAPIV2Handler(BaseJSONHandler):
+    """Default API Handler for V2 routes."""
+    # for adding override methods to all v2/* routes
+    pass
+
+
+class BaseMtlsHandler(BaseAPIV1Handler):
     def initialize(self, **kwargs):
         self.kwargs = kwargs
 

--- a/consoleme/handlers/base.py
+++ b/consoleme/handlers/base.py
@@ -435,19 +435,13 @@ class BaseHandler(SentryMixin, tornado.web.RequestHandler):
         return auth
 
 
-class BaseAPIV1Handler(BaseHandler):
-    """Default API Handler for V1 routes."""
+class BaseAPIHandler(BaseHandler):
+    """Default API Handler for api/* routes."""
     def set_default_headers(self) -> None:
         self.set_header("Content-Type", "application/json")
 
 
-class BaseAPIV2Handler(BaseJSONHandler):
-    """Default API Handler for V2 routes."""
-    # for adding override methods to all v2/* routes
-    pass
-
-
-class BaseMtlsHandler(BaseAPIV1Handler):
+class BaseMtlsHandler(BaseAPIHandler):
     def initialize(self, **kwargs):
         self.kwargs = kwargs
 

--- a/consoleme/handlers/base.py
+++ b/consoleme/handlers/base.py
@@ -450,6 +450,7 @@ class BaseAPIV2Handler(BaseHandler):
         if self.settings.get("serve_traceback") and "exc_info" in kwargs:
             # in debug mode, try to send a traceback
             self.set_header("Content-Type", "text/plain")
+            self.set_status(status_code)
             for line in traceback.format_exception(*kwargs["exc_info"]):
                 self.write(line)
             self.finish()

--- a/consoleme/handlers/v1/headers.py
+++ b/consoleme/handlers/v1/headers.py
@@ -1,7 +1,7 @@
 from tornado.escape import xhtml_escape
 
 from consoleme.config import config
-from consoleme.handlers.base import BaseHandler, BaseMtlsHandler, BaseAPIV1Handler
+from consoleme.handlers.base import BaseHandler, BaseMtlsHandler, BaseAPIHandler
 from consoleme.lib.generic import get_random_security_logo, is_in_group
 from consoleme.lib.plugins import get_plugin_by_name
 
@@ -9,7 +9,7 @@ stats = get_plugin_by_name(config.get("plugins.metrics"))()
 log = config.get_logger()
 
 
-class UserProfileHandler(BaseAPIV1Handler):
+class UserProfileHandler(BaseAPIHandler):
     async def get(self):
         """
         Provide information about the user profile for the frontend
@@ -54,7 +54,7 @@ class UserProfileHandler(BaseAPIV1Handler):
         self.write(user_profile)
 
 
-class SiteConfigHandler(BaseAPIV1Handler):
+class SiteConfigHandler(BaseAPIHandler):
     async def get(self):
         """
         Provide information about site configuration for the frontend

--- a/consoleme/handlers/v1/headers.py
+++ b/consoleme/handlers/v1/headers.py
@@ -1,7 +1,7 @@
 from tornado.escape import xhtml_escape
 
 from consoleme.config import config
-from consoleme.handlers.base import BaseHandler, BaseMtlsHandler
+from consoleme.handlers.base import BaseHandler, BaseMtlsHandler, BaseAPIV1Handler
 from consoleme.lib.generic import get_random_security_logo, is_in_group
 from consoleme.lib.plugins import get_plugin_by_name
 
@@ -9,7 +9,7 @@ stats = get_plugin_by_name(config.get("plugins.metrics"))()
 log = config.get_logger()
 
 
-class UserProfileHandler(BaseHandler):
+class UserProfileHandler(BaseAPIV1Handler):
     async def get(self):
         """
         Provide information about the user profile for the frontend
@@ -54,7 +54,7 @@ class UserProfileHandler(BaseHandler):
         self.write(user_profile)
 
 
-class SiteConfigHandler(BaseHandler):
+class SiteConfigHandler(BaseAPIV1Handler):
     async def get(self):
         """
         Provide information about site configuration for the frontend

--- a/consoleme/handlers/v1/headers.py
+++ b/consoleme/handlers/v1/headers.py
@@ -1,7 +1,7 @@
 from tornado.escape import xhtml_escape
 
 from consoleme.config import config
-from consoleme.handlers.base import BaseHandler, BaseMtlsHandler, BaseAPIHandler
+from consoleme.handlers.base import BaseHandler, BaseMtlsHandler, BaseAPIV1Handler
 from consoleme.lib.generic import get_random_security_logo, is_in_group
 from consoleme.lib.plugins import get_plugin_by_name
 
@@ -9,7 +9,7 @@ stats = get_plugin_by_name(config.get("plugins.metrics"))()
 log = config.get_logger()
 
 
-class UserProfileHandler(BaseAPIHandler):
+class UserProfileHandler(BaseAPIV1Handler):
     async def get(self):
         """
         Provide information about the user profile for the frontend
@@ -54,7 +54,7 @@ class UserProfileHandler(BaseAPIHandler):
         self.write(user_profile)
 
 
-class SiteConfigHandler(BaseAPIHandler):
+class SiteConfigHandler(BaseAPIV1Handler):
     async def get(self):
         """
         Provide information about site configuration for the frontend

--- a/consoleme/handlers/v1/policies.py
+++ b/consoleme/handlers/v1/policies.py
@@ -14,7 +14,7 @@ from consoleme.exceptions.exceptions import (
     MustBeFte,
     Unauthorized,
 )
-from consoleme.handlers.base import BaseHandler, BaseMtlsHandler
+from consoleme.handlers.base import BaseHandler, BaseMtlsHandler, BaseAPIV1Handler
 from consoleme.lib.aws import (
     fetch_resource_details,
     get_all_iam_managed_policies_for_account,
@@ -935,7 +935,7 @@ class SelfServiceHandler(BaseHandler):
         )
 
 
-class AutocompleteHandler(BaseHandler):
+class AutocompleteHandler(BaseAPIV1Handler):
     async def get(self):
         """
         /api/v1/policyuniverse/autocomplete/?prefix=

--- a/consoleme/handlers/v1/policies.py
+++ b/consoleme/handlers/v1/policies.py
@@ -14,7 +14,7 @@ from consoleme.exceptions.exceptions import (
     MustBeFte,
     Unauthorized,
 )
-from consoleme.handlers.base import BaseHandler, BaseMtlsHandler, BaseAPIV1Handler
+from consoleme.handlers.base import BaseHandler, BaseMtlsHandler, BaseAPIHandler
 from consoleme.lib.aws import (
     fetch_resource_details,
     get_all_iam_managed_policies_for_account,
@@ -935,7 +935,7 @@ class SelfServiceHandler(BaseHandler):
         )
 
 
-class AutocompleteHandler(BaseAPIV1Handler):
+class AutocompleteHandler(BaseAPIHandler):
     async def get(self):
         """
         /api/v1/policyuniverse/autocomplete/?prefix=

--- a/consoleme/handlers/v1/policies.py
+++ b/consoleme/handlers/v1/policies.py
@@ -14,7 +14,7 @@ from consoleme.exceptions.exceptions import (
     MustBeFte,
     Unauthorized,
 )
-from consoleme.handlers.base import BaseHandler, BaseMtlsHandler, BaseAPIHandler
+from consoleme.handlers.base import BaseHandler, BaseMtlsHandler, BaseAPIV1Handler
 from consoleme.lib.aws import (
     fetch_resource_details,
     get_all_iam_managed_policies_for_account,
@@ -935,7 +935,7 @@ class SelfServiceHandler(BaseHandler):
         )
 
 
-class AutocompleteHandler(BaseAPIHandler):
+class AutocompleteHandler(BaseAPIV1Handler):
     async def get(self):
         """
         /api/v1/policyuniverse/autocomplete/?prefix=

--- a/consoleme/handlers/v2/errors.py
+++ b/consoleme/handlers/v2/errors.py
@@ -5,7 +5,7 @@ from typing import Optional
 from tornado.web import RequestHandler
 
 from consoleme.config import config
-from consoleme.handlers.base import BaseJSONHandler
+from consoleme.handlers.base import BaseJSONHandler, BaseAPIV2Handler
 from consoleme.lib.plugins import get_plugin_by_name
 
 stats = get_plugin_by_name(config.get("plugins.metrics"))()
@@ -13,30 +13,26 @@ stats = get_plugin_by_name(config.get("plugins.metrics"))()
 log = config.get_logger()
 
 
-class ErrorHandler(BaseJSONHandler):
-    def __init__(self, status, *args, **kwargs):
-        self.status = status
-        super().__init__(jwt_validator=lambda x: {}, *args, **kwargs)
-
+class ErrorHandler(BaseAPIV2Handler):
     async def get(self):
-        self.write_error(self.status)
+        self.write_error(self.get_status())
 
     async def head(self):
-        self.write_error(self.status)
+        self.write_error(self.get_status())
 
     async def put(self):
-        self.write_error(self.status)
+        self.write_error(self.get_status())
 
     async def patch(self):
-        self.write_error(self.status)
+        self.write_error(self.get_status())
 
     async def post(self):
-        self.write_error(self.status)
+        self.write_error(self.get_status())
 
     async def delete(self):
-        self.write_error(self.status)
+        self.write_error(self.get_status())
 
 
 class NotFoundHandler(ErrorHandler):
-    def __init__(self, *args, **kwargs):
-        super().__init__(404, *args, **kwargs)
+    def initialize(self):
+        self.set_status(404)

--- a/consoleme/handlers/v2/errors.py
+++ b/consoleme/handlers/v2/errors.py
@@ -5,7 +5,7 @@ from typing import Optional
 from tornado.web import RequestHandler
 
 from consoleme.config import config
-from consoleme.handlers.base import BaseJSONHandler, BaseAPIV2Handler
+from consoleme.handlers.base import BaseAPIV2Handler
 from consoleme.lib.plugins import get_plugin_by_name
 
 stats = get_plugin_by_name(config.get("plugins.metrics"))()

--- a/consoleme/handlers/v2/index.py
+++ b/consoleme/handlers/v2/index.py
@@ -3,7 +3,7 @@ from operator import itemgetter
 from urllib.parse import parse_qs, urlencode, urlparse
 
 from consoleme.config import config
-from consoleme.handlers.base import BaseHandler
+from consoleme.handlers.base import BaseHandler, BaseAPIV1Handler
 from consoleme.lib.handler_utils import format_role_name
 from consoleme.lib.loader import WebpackLoader
 from consoleme.lib.plugins import get_plugin_by_name
@@ -176,7 +176,7 @@ class IndexHandler(BaseHandler):
         self.redirect(url)
 
 
-class SelectRolesHandler(BaseHandler):
+class SelectRolesHandler(BaseAPIV1Handler):
     def initialize(self):
         self.user: str = None
         self.eligible_roles: list = []

--- a/consoleme/handlers/v2/index.py
+++ b/consoleme/handlers/v2/index.py
@@ -3,7 +3,7 @@ from operator import itemgetter
 from urllib.parse import parse_qs, urlencode, urlparse
 
 from consoleme.config import config
-from consoleme.handlers.base import BaseHandler, BaseAPIV1Handler
+from consoleme.handlers.base import BaseHandler
 from consoleme.lib.handler_utils import format_role_name
 from consoleme.lib.loader import WebpackLoader
 from consoleme.lib.plugins import get_plugin_by_name
@@ -175,17 +175,3 @@ class IndexHandler(BaseHandler):
 
         self.redirect(url)
 
-
-class SelectRolesHandler(BaseAPIV1Handler):
-    def initialize(self):
-        self.user: str = None
-        self.eligible_roles: list = []
-
-    async def get(self):
-        self.set_header("Content-Type", "application/json")
-        payload = {
-            "eligible_roles": self.eligible_roles,
-            "_xsrf": self.xsrf_token.decode("utf-8"),
-        }
-        self.write(json.dumps(payload))
-        await self.finish()

--- a/consoleme/handlers/v2/requests.py
+++ b/consoleme/handlers/v2/requests.py
@@ -1,7 +1,7 @@
 import ujson as json
 
 from consoleme.config import config
-from consoleme.handlers.base import BaseJSONHandler, BaseAPIV2Handler
+from consoleme.handlers.base import BaseAPIV2Handler
 from consoleme.lib.plugins import get_plugin_by_name
 
 stats = get_plugin_by_name(config.get("plugins.metrics"))()

--- a/consoleme/handlers/v2/requests.py
+++ b/consoleme/handlers/v2/requests.py
@@ -1,14 +1,14 @@
 import ujson as json
 
 from consoleme.config import config
-from consoleme.handlers.base import BaseJSONHandler, BaseAPIV2Handler
+from consoleme.handlers.base import BaseJSONHandler, BaseAPIHandler
 from consoleme.lib.plugins import get_plugin_by_name
 
 stats = get_plugin_by_name(config.get("plugins.metrics"))()
 log = config.get_logger()
 
 
-class RequestsHandler(BaseAPIV2Handler):
+class RequestsHandler(BaseAPIHandler):
     """Handler for /api/v2/requests
 
     Allows read access to a list of requests. Returned requests are
@@ -16,10 +16,6 @@ class RequestsHandler(BaseAPIV2Handler):
     """
 
     allowed_methods = ["GET", "POST"]
-
-    def __init__(self, *args, **kwargs):
-        # TODO(psanders): Use actual JWT validator
-        super().__init__(jwt_validator=lambda x: {}, *args, **kwargs)
 
     async def get(self):
         """
@@ -58,17 +54,13 @@ class RequestsHandler(BaseAPIV2Handler):
         self.write_error(501, message="Create request")
 
 
-class RequestDetailHandler(BaseAPIV2Handler):
+class RequestDetailHandler(BaseAPIHandler):
     """Handler for /api/v2/requests/{request_id}
 
     Allows read and update access to a specific request.
     """
 
     allowed_methods = ["GET", "PUT"]
-
-    def __init__(self, *args, **kwargs):
-        # TODO(psanders): Use actual JWT validator
-        super().__init__(jwt_validator=lambda x: {}, *args, **kwargs)
 
     async def get(self, request_id):
         """

--- a/consoleme/handlers/v2/requests.py
+++ b/consoleme/handlers/v2/requests.py
@@ -1,14 +1,14 @@
 import ujson as json
 
 from consoleme.config import config
-from consoleme.handlers.base import BaseJSONHandler, BaseAPIHandler
+from consoleme.handlers.base import BaseJSONHandler, BaseAPIV2Handler
 from consoleme.lib.plugins import get_plugin_by_name
 
 stats = get_plugin_by_name(config.get("plugins.metrics"))()
 log = config.get_logger()
 
 
-class RequestsHandler(BaseAPIHandler):
+class RequestsHandler(BaseAPIV2Handler):
     """Handler for /api/v2/requests
 
     Allows read access to a list of requests. Returned requests are
@@ -54,7 +54,7 @@ class RequestsHandler(BaseAPIHandler):
         self.write_error(501, message="Create request")
 
 
-class RequestDetailHandler(BaseAPIHandler):
+class RequestDetailHandler(BaseAPIV2Handler):
     """Handler for /api/v2/requests/{request_id}
 
     Allows read and update access to a specific request.

--- a/consoleme/handlers/v2/requests.py
+++ b/consoleme/handlers/v2/requests.py
@@ -1,14 +1,14 @@
 import ujson as json
 
 from consoleme.config import config
-from consoleme.handlers.base import BaseJSONHandler
+from consoleme.handlers.base import BaseJSONHandler, BaseAPIV2Handler
 from consoleme.lib.plugins import get_plugin_by_name
 
 stats = get_plugin_by_name(config.get("plugins.metrics"))()
 log = config.get_logger()
 
 
-class RequestsHandler(BaseJSONHandler):
+class RequestsHandler(BaseAPIV2Handler):
     """Handler for /api/v2/requests
 
     Allows read access to a list of requests. Returned requests are
@@ -58,7 +58,7 @@ class RequestsHandler(BaseJSONHandler):
         self.write_error(501, message="Create request")
 
 
-class RequestDetailHandler(BaseJSONHandler):
+class RequestDetailHandler(BaseAPIV2Handler):
     """Handler for /api/v2/requests/{request_id}
 
     Allows read and update access to a specific request.

--- a/consoleme/handlers/v2/roles.py
+++ b/consoleme/handlers/v2/roles.py
@@ -1,7 +1,7 @@
 import ujson as json
 
 from consoleme.config import config
-from consoleme.handlers.base import BaseJSONHandler, BaseAPIV2Handler
+from consoleme.handlers.base import BaseAPIV2Handler
 from consoleme.lib.crypto import Crypto
 from consoleme.lib.plugins import get_plugin_by_name
 

--- a/consoleme/handlers/v2/roles.py
+++ b/consoleme/handlers/v2/roles.py
@@ -1,7 +1,7 @@
 import ujson as json
 
 from consoleme.config import config
-from consoleme.handlers.base import BaseJSONHandler, BaseAPIV2Handler
+from consoleme.handlers.base import BaseJSONHandler, BaseAPIHandler
 from consoleme.lib.crypto import Crypto
 from consoleme.lib.plugins import get_plugin_by_name
 
@@ -11,7 +11,7 @@ crypto = Crypto()
 auth = get_plugin_by_name(config.get("plugins.auth"))()
 
 
-class RolesHandler(BaseAPIV2Handler):
+class RolesHandler(BaseAPIHandler):
     """Handler for /api/v2/roles
 
     Allows read access to a list of roles across all accounts. Returned roles are
@@ -20,26 +20,21 @@ class RolesHandler(BaseAPIV2Handler):
 
     allowed_methods = ["GET"]
 
-    def __init__(self, *args, **kwargs):
-        # TODO(psanders): Use actual JWT validator
-        super().__init__(jwt_validator=lambda x: {}, *args, **kwargs)
+    def initialize(self):
+        self.user: str = None
+        self.eligible_roles: list = []
 
     async def get(self):
-        """
-        GET /api/v2/roles
-        """
-        log_data = {
-            "function": "RolesHandler.get",
-            "user": self.user,
-            "message": "Writing all eligible user roles",
-            "user-agent": self.request.headers.get("User-Agent"),
-            "request_id": self.request_uuid,
+        self.set_header("Content-Type", "application/json")
+        payload = {
+            "eligible_roles": self.eligible_roles,
+            "_xsrf": self.xsrf_token.decode("utf-8"),
         }
-        log.debug(log_data)
-        self.write_error(501, message="Get roles")
+        self.write(json.dumps(payload, escape_forward_slashes=False))
+        await self.finish()
 
 
-class AccountRolesHandler(BaseAPIV2Handler):
+class AccountRolesHandler(BaseAPIHandler):
     """Handler for /api/v2/roles/{account_number}
 
     Allows read access to a list of roles by account. Roles are limited to what the
@@ -47,10 +42,6 @@ class AccountRolesHandler(BaseAPIV2Handler):
     """
 
     allowed_methods = ["GET"]
-
-    def __init__(self, *args, **kwargs):
-        # TODO(psanders): Use actual JWT validator
-        super().__init__(jwt_validator=lambda x: {}, *args, **kwargs)
 
     async def get(self, account_id):
         """
@@ -67,17 +58,13 @@ class AccountRolesHandler(BaseAPIV2Handler):
         self.write_error(501, message="Get roles by account")
 
 
-class RoleDetailHandler(BaseAPIV2Handler):
+class RoleDetailHandler(BaseAPIHandler):
     """Handler for /api/v2/roles/{accountNumber}/{roleName}
 
     Allows read and update access to a specific role in an account.
     """
 
     allowed_methods = ["GET", "PUT"]
-
-    def __init__(self, *args, **kwargs):
-        # TODO(psanders): Use actual JWT validator
-        super().__init__(jwt_validator=lambda x: {}, *args, **kwargs)
 
     async def get(self, account_number, role_name):
         """

--- a/consoleme/handlers/v2/roles.py
+++ b/consoleme/handlers/v2/roles.py
@@ -1,7 +1,7 @@
 import ujson as json
 
 from consoleme.config import config
-from consoleme.handlers.base import BaseJSONHandler
+from consoleme.handlers.base import BaseJSONHandler, BaseAPIV2Handler
 from consoleme.lib.crypto import Crypto
 from consoleme.lib.plugins import get_plugin_by_name
 
@@ -11,7 +11,7 @@ crypto = Crypto()
 auth = get_plugin_by_name(config.get("plugins.auth"))()
 
 
-class RolesHandler(BaseJSONHandler):
+class RolesHandler(BaseAPIV2Handler):
     """Handler for /api/v2/roles
 
     Allows read access to a list of roles across all accounts. Returned roles are
@@ -39,7 +39,7 @@ class RolesHandler(BaseJSONHandler):
         self.write_error(501, message="Get roles")
 
 
-class AccountRolesHandler(BaseJSONHandler):
+class AccountRolesHandler(BaseAPIV2Handler):
     """Handler for /api/v2/roles/{account_number}
 
     Allows read access to a list of roles by account. Roles are limited to what the
@@ -67,7 +67,7 @@ class AccountRolesHandler(BaseJSONHandler):
         self.write_error(501, message="Get roles by account")
 
 
-class RoleDetailHandler(BaseJSONHandler):
+class RoleDetailHandler(BaseAPIV2Handler):
     """Handler for /api/v2/roles/{accountNumber}/{roleName}
 
     Allows read and update access to a specific role in an account.

--- a/consoleme/handlers/v2/roles.py
+++ b/consoleme/handlers/v2/roles.py
@@ -1,7 +1,7 @@
 import ujson as json
 
 from consoleme.config import config
-from consoleme.handlers.base import BaseJSONHandler, BaseAPIHandler
+from consoleme.handlers.base import BaseJSONHandler, BaseAPIV2Handler
 from consoleme.lib.crypto import Crypto
 from consoleme.lib.plugins import get_plugin_by_name
 
@@ -11,7 +11,7 @@ crypto = Crypto()
 auth = get_plugin_by_name(config.get("plugins.auth"))()
 
 
-class RolesHandler(BaseAPIHandler):
+class RolesHandler(BaseAPIV2Handler):
     """Handler for /api/v2/roles
 
     Allows read access to a list of roles across all accounts. Returned roles are
@@ -25,16 +25,16 @@ class RolesHandler(BaseAPIHandler):
         self.eligible_roles: list = []
 
     async def get(self):
-        self.set_header("Content-Type", "application/json")
         payload = {
             "eligible_roles": self.eligible_roles,
             "_xsrf": self.xsrf_token.decode("utf-8"),
         }
+        self.set_header("Content-Type", "application/json")
         self.write(json.dumps(payload, escape_forward_slashes=False))
         await self.finish()
 
 
-class AccountRolesHandler(BaseAPIHandler):
+class AccountRolesHandler(BaseAPIV2Handler):
     """Handler for /api/v2/roles/{account_number}
 
     Allows read access to a list of roles by account. Roles are limited to what the
@@ -58,7 +58,7 @@ class AccountRolesHandler(BaseAPIHandler):
         self.write_error(501, message="Get roles by account")
 
 
-class RoleDetailHandler(BaseAPIHandler):
+class RoleDetailHandler(BaseAPIV2Handler):
     """Handler for /api/v2/roles/{accountNumber}/{roleName}
 
     Allows read and update access to a specific role in an account.

--- a/consoleme/routes.py
+++ b/consoleme/routes.py
@@ -132,7 +132,7 @@ def make_app(jwt_validator=None):
         (r"/api/v1/policies/typeahead", ApiResourceTypeAheadHandler),
         (r"/api/v2/requests", RequestsHandler),
         (r"/api/v2/requests/([a-zA-Z0-9_-]+)", RequestDetailHandler),
-        (r"/api/v2/roles", RolesHandler),
+        (r"/api/v2/roles/?", RolesHandler),
         (r"/api/v2/roles/(\d{12})", AccountRolesHandler),
         (r"/api/v2/roles/(\d{12})/(.*)", RoleDetailHandler),
         (r"/config/?", DynamicConfigHandler),

--- a/consoleme/routes.py
+++ b/consoleme/routes.py
@@ -48,7 +48,6 @@ from consoleme.handlers.v2.errors import NotFoundHandler as V2NotFoundHandler
 
 # Todo: UIREFACTOR: Remove reference to /v2 when new UI is complete
 from consoleme.handlers.v2.index import IndexHandler as IndexHandlerV2  # noqa
-from consoleme.handlers.v2.index import SelectRolesHandler  # noqa
 from consoleme.handlers.v2.roles import (
     AccountRolesHandler,
     RoleDetailHandler,
@@ -129,7 +128,6 @@ def make_app(jwt_validator=None):
         (r"/api/v1/get_roles", GetRolesHandler),
         (r"/api/v1/siteconfig/?", SiteConfigHandler),
         (r"/api/v1/profile/?", UserProfileHandler),
-        (r"/api/v1/roles/?", SelectRolesHandler),
         (r"/api/v1/myheaders/?", ApiHeaderHandler),
         (r"/api/v1/policies/typeahead", ApiResourceTypeAheadHandler),
         (r"/api/v2/requests", RequestsHandler),

--- a/tests/handlers/v2/test_errors.py
+++ b/tests/handlers/v2/test_errors.py
@@ -1,0 +1,80 @@
+import ujson as json
+from mock import patch
+from tornado.testing import AsyncHTTPTestCase
+from consoleme.config import config
+
+class TestNotFoundHandler(AsyncHTTPTestCase):
+    def get_app(self):
+        from consoleme.routes import make_app
+
+        return make_app(jwt_validator=lambda x: {})
+
+    def test_get(self):
+        expected = {
+            "status": 404,
+            "title": "Not Found",
+            "message": "Not Found",
+        }
+        headers = {
+            config.get("auth.user_header_name"): "user@github.com",
+            config.get("auth.groups_header_name"): "groupa,groupb,groupc",
+        }
+        response = self.fetch("/api/v2/route_does_not_exist", method="GET", headers=headers)
+        self.assertEqual(response.code, 404)
+        self.assertDictEqual(json.loads(response.body), expected)
+
+    def test_put(self):
+        expected = {
+            "status": 404,
+            "title": "Not Found",
+            "message": "Not Found",
+        }
+        headers = {
+            config.get("auth.user_header_name"): "user@github.com",
+            config.get("auth.groups_header_name"): "groupa,groupb,groupc",
+        }
+        response = self.fetch("/api/v2/route_does_not_exist", method="PUT", headers=headers, body="{}")
+        self.assertEqual(response.code, 404)
+        self.assertDictEqual(json.loads(response.body), expected)
+
+    def test_post(self):
+        expected = {
+            "status": 404,
+            "title": "Not Found",
+            "message": "Not Found",
+        }
+        headers = {
+            config.get("auth.user_header_name"): "user@github.com",
+            config.get("auth.groups_header_name"): "groupa,groupb,groupc",
+        }
+        response = self.fetch("/api/v2/route_does_not_exist", method="POST", headers=headers, body="{}")
+        self.assertEqual(response.code, 404)
+        self.assertDictEqual(json.loads(response.body), expected)
+
+    def test_patch(self):
+        expected = {
+            "status": 404,
+            "title": "Not Found",
+            "message": "Not Found",
+        }
+        headers = {
+            config.get("auth.user_header_name"): "user@github.com",
+            config.get("auth.groups_header_name"): "groupa,groupb,groupc",
+        }
+        response = self.fetch("/api/v2/route_does_not_exist", method="PATCH", headers=headers, body="{}")
+        self.assertEqual(response.code, 404)
+        self.assertDictEqual(json.loads(response.body), expected)
+
+    def test_delete(self):
+        expected = {
+            "status": 404,
+            "title": "Not Found",
+            "message": "Not Found",
+        }
+        headers = {
+            config.get("auth.user_header_name"): "user@github.com",
+            config.get("auth.groups_header_name"): "groupa,groupb,groupc",
+        }
+        response = self.fetch("/api/v2/route_does_not_exist", method="DELETE", headers=headers)
+        self.assertEqual(response.code, 404)
+        self.assertDictEqual(json.loads(response.body), expected)

--- a/tests/handlers/v2/test_requests.py
+++ b/tests/handlers/v2/test_requests.py
@@ -10,22 +10,32 @@ class TestRequestsHandler(AsyncHTTPTestCase):
         return make_app(jwt_validator=lambda x: {})
     
     def test_get(self):
+        expected = {
+            "status": 501,
+            "title": "Not Implemented",
+            "message": "Get requests",
+        }
         headers = {
             config.get("auth.user_header_name"): "user@github.com",
             config.get("auth.groups_header_name"): "groupa,groupb,groupc",
         }
         response = self.fetch("/api/v2/requests", method="GET", headers=headers)
-        self.assertEqual(response.code, 200)
-        self.assertIn(b"501: OK", response.body)
+        self.assertEqual(response.code, 501)
+        self.assertDictEqual(json.loads(response.body), expected)
 
     def test_post(self):
+        expected = {
+            "status": 501,
+            "title": "Not Implemented",
+            "message": "Create request",
+        }
         headers = {
             config.get("auth.user_header_name"): "user@github.com",
             config.get("auth.groups_header_name"): "groupa,groupb,groupc",
         }
-        response = self.fetch( "/api/v2/requests", method="POST", headers=headers, body="{}")
-        self.assertEqual(response.code, 200)
-        self.assertIn(b"501: OK", response.body)
+        response = self.fetch("/api/v2/requests", method="POST", headers=headers, body="{}")
+        self.assertEqual(response.code, 501)
+        self.assertDictEqual(json.loads(response.body), expected)
 
 
 class TestRequestDetailHandler(AsyncHTTPTestCase):
@@ -35,6 +45,11 @@ class TestRequestDetailHandler(AsyncHTTPTestCase):
         return make_app(jwt_validator=lambda x: {})
 
     def test_get(self):
+        expected = {
+            "status": 501,
+            "title": "Not Implemented",
+            "message": "Get request details",
+        }
         headers = {
             config.get("auth.user_header_name"): "user@github.com",
             config.get("auth.groups_header_name"): "groupa,groupb,groupc",
@@ -44,10 +59,15 @@ class TestRequestDetailHandler(AsyncHTTPTestCase):
             method="GET",
             headers=headers,
         )
-        self.assertEqual(response.code, 200)
-        self.assertIn(b"501: OK", response.body)
+        self.assertEqual(response.code, 501)
+        self.assertDictEqual(json.loads(response.body), expected)
 
     def test_put(self):
+        expected = {
+            "status": 501,
+            "title": "Not Implemented",
+            "message": "Update request details",
+        }
         headers = {
             config.get("auth.user_header_name"): "user@github.com",
             config.get("auth.groups_header_name"): "groupa,groupb,groupc",
@@ -58,5 +78,5 @@ class TestRequestDetailHandler(AsyncHTTPTestCase):
             headers=headers,
             body="{}",
         )
-        self.assertEqual(response.code, 200)
-        self.assertIn(b"501: OK", response.body)
+        self.assertEqual(response.code, 501)
+        self.assertDictEqual(json.loads(response.body), expected)

--- a/tests/handlers/v2/test_requests.py
+++ b/tests/handlers/v2/test_requests.py
@@ -1,45 +1,31 @@
 import ujson as json
 from mock import patch
 from tornado.testing import AsyncHTTPTestCase
-
+from consoleme.config import config
 
 class TestRequestsHandler(AsyncHTTPTestCase):
     def get_app(self):
         from consoleme.routes import make_app
 
         return make_app(jwt_validator=lambda x: {})
-
-    @patch(
-        "consoleme.handlers.base.BaseJSONHandler.get_current_user",
-        lambda x: {"email": "foo@bar.com"},
-    )
+    
     def test_get(self):
-        headers = {"Authorization": "Bearer foo"}
+        headers = {
+            config.get("auth.user_header_name"): "user@github.com",
+            config.get("auth.groups_header_name"): "groupa,groupb,groupc",
+        }
         response = self.fetch("/api/v2/requests", method="GET", headers=headers)
-        expected = {
-            "status": 501,
-            "title": "Not Implemented",
-            "message": "Get requests",
-        }
-        self.assertEqual(response.code, 501)
-        self.assertDictEqual(json.loads(response.body), expected)
+        self.assertEqual(response.code, 200)
+        self.assertIn(b"501: OK", response.body)
 
-    @patch(
-        "consoleme.handlers.base.BaseJSONHandler.get_current_user",
-        lambda x: {"email": "foo@bar.com"},
-    )
     def test_post(self):
-        headers = {"Authorization": "Bearer foo"}
-        response = self.fetch(
-            "/api/v2/requests", method="POST", headers=headers, body="{}"
-        )
-        expected = {
-            "status": 501,
-            "title": "Not Implemented",
-            "message": "Create request",
+        headers = {
+            config.get("auth.user_header_name"): "user@github.com",
+            config.get("auth.groups_header_name"): "groupa,groupb,groupc",
         }
-        self.assertEqual(response.code, 501)
-        self.assertDictEqual(json.loads(response.body), expected)
+        response = self.fetch( "/api/v2/requests", method="POST", headers=headers, body="{}")
+        self.assertEqual(response.code, 200)
+        self.assertIn(b"501: OK", response.body)
 
 
 class TestRequestDetailHandler(AsyncHTTPTestCase):
@@ -48,42 +34,29 @@ class TestRequestDetailHandler(AsyncHTTPTestCase):
 
         return make_app(jwt_validator=lambda x: {})
 
-    @patch(
-        "consoleme.handlers.base.BaseJSONHandler.get_current_user",
-        lambda x: {"email": "foo@bar.com"},
-    )
     def test_get(self):
-        headers = {"Authorization": "Bearer foo"}
+        headers = {
+            config.get("auth.user_header_name"): "user@github.com",
+            config.get("auth.groups_header_name"): "groupa,groupb,groupc",
+        }
         response = self.fetch(
             "/api/v2/requests/16fd2706-8baf-433b-82eb-8c7fada847da",
             method="GET",
             headers=headers,
         )
-        expected = {
-            "status": 501,
-            "title": "Not Implemented",
-            "message": "Get request details",
-        }
-        self.assertEqual(response.code, 501)
-        self.assertDictEqual(json.loads(response.body), expected)
+        self.assertEqual(response.code, 200)
+        self.assertIn(b"501: OK", response.body)
 
-    @patch(
-        "consoleme.handlers.base.BaseJSONHandler.get_current_user",
-        lambda x: {"email": "foo@bar.com"},
-    )
     def test_put(self):
-        headers = {"Authorization": "Bearer foo"}
+        headers = {
+            config.get("auth.user_header_name"): "user@github.com",
+            config.get("auth.groups_header_name"): "groupa,groupb,groupc",
+        }
         response = self.fetch(
             "/api/v2/requests/16fd2706-8baf-433b-82eb-8c7fada847da",
             method="PUT",
             headers=headers,
             body="{}",
         )
-        expected = {
-            "status": 501,
-            "title": "Not Implemented",
-            "message": "Update request details",
-        }
-
-        self.assertEqual(response.code, 501)
-        self.assertDictEqual(json.loads(response.body), expected)
+        self.assertEqual(response.code, 200)
+        self.assertIn(b"501: OK", response.body)

--- a/tests/handlers/v2/test_roles.py
+++ b/tests/handlers/v2/test_roles.py
@@ -1,7 +1,7 @@
 import ujson as json
 from mock import patch
 from tornado.testing import AsyncHTTPTestCase
-
+from consoleme.config import config
 
 class TestRolesHandler(AsyncHTTPTestCase):
     def get_app(self):
@@ -9,20 +9,17 @@ class TestRolesHandler(AsyncHTTPTestCase):
 
         return make_app(jwt_validator=lambda x: {})
 
-    @patch(
-        "consoleme.handlers.base.BaseJSONHandler.get_current_user",
-        lambda x: {"email": "foo@bar.com"},
-    )
     def test_get(self):
-        headers = {"Authorization": "Bearer foo"}
-        response = self.fetch("/api/v2/roles", method="GET", headers=headers)
-        expected = {
-            "status": 501,
-            "title": "Not Implemented",
-            "message": "Get roles",
+        headers = {
+            config.get("auth.user_header_name"): "user@github.com",
+            config.get("auth.groups_header_name"): "groupa,groupb,groupc",
         }
-        self.assertEqual(response.code, 501)
-        self.assertDictEqual(json.loads(response.body), expected)
+        response = self.fetch("/api/v2/roles", method="GET", headers=headers)
+        self.assertEqual(response.code, 200)
+        responseJSON = json.loads(response.body)
+        self.assertIn("_xsrf", responseJSON)
+        self.assertIn("eligible_roles", responseJSON)
+        self.assertEqual(0, len(responseJSON["eligible_roles"]))
 
 
 class TestAccountRolesHandler(AsyncHTTPTestCase):
@@ -31,22 +28,16 @@ class TestAccountRolesHandler(AsyncHTTPTestCase):
 
         return make_app(jwt_validator=lambda x: {})
 
-    @patch(
-        "consoleme.handlers.base.BaseJSONHandler.get_current_user",
-        lambda x: {"email": "foo@bar.com"},
-    )
     def test_get(self):
-        headers = {"Authorization": "Bearer foo"}
+        headers = {
+            config.get("auth.user_header_name"): "user@github.com",
+            config.get("auth.groups_header_name"): "groupa,groupb,groupc",
+        }
         response = self.fetch(
             "/api/v2/roles/012345678901", method="GET", headers=headers
         )
-        expected = {
-            "status": 501,
-            "title": "Not Implemented",
-            "message": "Get roles by account",
-        }
-        self.assertEqual(response.code, 501)
-        self.assertDictEqual(json.loads(response.body), expected)
+        self.assertEqual(response.code, 200)
+        self.assertIn(b"501: OK", response.body)
 
 
 class TestRoleDetailHandler(AsyncHTTPTestCase):
@@ -55,42 +46,29 @@ class TestRoleDetailHandler(AsyncHTTPTestCase):
 
         return make_app(jwt_validator=lambda x: {})
 
-    @patch(
-        "consoleme.handlers.base.BaseJSONHandler.get_current_user",
-        lambda x: {"email": "foo@bar.com"},
-    )
     def test_get(self):
-        headers = {"Authorization": "Bearer foo"}
+        headers = {
+            config.get("auth.user_header_name"): "user@github.com",
+            config.get("auth.groups_header_name"): "groupa,groupb,groupc",
+        }
         response = self.fetch(
             "/api/v2/roles/012345678901/fake_account_admin",
             method="GET",
             headers=headers,
         )
-        expected = {
-            "status": 501,
-            "title": "Not Implemented",
-            "message": "Get role details",
-        }
-        self.assertEqual(response.code, 501)
-        self.assertDictEqual(json.loads(response.body), expected)
+        self.assertEqual(response.code, 200)
+        self.assertIn(b"501: OK", response.body)
 
-    @patch(
-        "consoleme.handlers.base.BaseJSONHandler.get_current_user",
-        lambda x: {"email": "foo@bar.com"},
-    )
     def test_put(self):
-        headers = {"Authorization": "Bearer foo"}
+        headers = {
+            config.get("auth.user_header_name"): "user@github.com",
+            config.get("auth.groups_header_name"): "groupa,groupb,groupc",
+        }
         response = self.fetch(
             "/api/v2/roles/012345678901/fake_account_admin",
             method="PUT",
             headers=headers,
             body="{}",
         )
-        expected = {
-            "status": 501,
-            "title": "Not Implemented",
-            "message": "Update role details",
-        }
-
-        self.assertEqual(response.code, 501)
-        self.assertDictEqual(json.loads(response.body), expected)
+        self.assertEqual(response.code, 200)
+        self.assertIn(b"501: OK", response.body)

--- a/tests/handlers/v2/test_roles.py
+++ b/tests/handlers/v2/test_roles.py
@@ -29,6 +29,11 @@ class TestAccountRolesHandler(AsyncHTTPTestCase):
         return make_app(jwt_validator=lambda x: {})
 
     def test_get(self):
+        expected = {
+            "status": 501,
+            "title": "Not Implemented",
+            "message": "Get roles by account",
+        }
         headers = {
             config.get("auth.user_header_name"): "user@github.com",
             config.get("auth.groups_header_name"): "groupa,groupb,groupc",
@@ -36,8 +41,8 @@ class TestAccountRolesHandler(AsyncHTTPTestCase):
         response = self.fetch(
             "/api/v2/roles/012345678901", method="GET", headers=headers
         )
-        self.assertEqual(response.code, 200)
-        self.assertIn(b"501: OK", response.body)
+        self.assertEqual(response.code, 501)
+        self.assertDictEqual(json.loads(response.body), expected)
 
 
 class TestRoleDetailHandler(AsyncHTTPTestCase):
@@ -47,6 +52,11 @@ class TestRoleDetailHandler(AsyncHTTPTestCase):
         return make_app(jwt_validator=lambda x: {})
 
     def test_get(self):
+        expected = {
+            "status": 501,
+            "title": "Not Implemented",
+            "message": "Get role details",
+        }
         headers = {
             config.get("auth.user_header_name"): "user@github.com",
             config.get("auth.groups_header_name"): "groupa,groupb,groupc",
@@ -56,10 +66,15 @@ class TestRoleDetailHandler(AsyncHTTPTestCase):
             method="GET",
             headers=headers,
         )
-        self.assertEqual(response.code, 200)
-        self.assertIn(b"501: OK", response.body)
+        self.assertEqual(response.code, 501)
+        self.assertDictEqual(json.loads(response.body), expected)
 
     def test_put(self):
+        expected = {
+            "status": 501,
+            "title": "Not Implemented",
+            "message": "Update role details",
+        }
         headers = {
             config.get("auth.user_header_name"): "user@github.com",
             config.get("auth.groups_header_name"): "groupa,groupb,groupc",
@@ -70,5 +85,5 @@ class TestRoleDetailHandler(AsyncHTTPTestCase):
             headers=headers,
             body="{}",
         )
-        self.assertEqual(response.code, 200)
-        self.assertIn(b"501: OK", response.body)
+        self.assertEqual(response.code, 501)
+        self.assertDictEqual(json.loads(response.body), expected)


### PR DESCRIPTION
Using a generic API handler to allow for generalized updates to all api/* routes in the future. This PR also fixes XSS bugs on api/* routes by forcing the Content type of response header to be JSON.