### PR TITLE
added EC2, RDS and Route53 components for Self Service Step2

### DIFF
--- a/consoleme/templates/static/js/components/SelfService.js
+++ b/consoleme/templates/static/js/components/SelfService.js
@@ -22,7 +22,6 @@ class SelfService extends Component {
         permissions: [],
         role: {
             roleArn: '',
-            roleFrom: 'app', // TODO, change to ENUM
         },
     };
 

--- a/consoleme/templates/static/js/components/SelfServiceComponent.js
+++ b/consoleme/templates/static/js/components/SelfServiceComponent.js
@@ -1,7 +1,10 @@
 import React, { Component } from 'react';
+import SelfServiceComponentCustom from "./SelfServiceComponentCustom";
+import SelfServiceComponentEC2 from "./SelfServiceComponentEC2";
+import SelfServiceComponentRDS from "./SelfServiceComponentRDS";
+import SelfServiceComponentRoute53 from "./SelfServiceComponentRoute53";
 import SelfServiceComponentS3 from './SelfServiceComponentS3';
-import SelfServiceComponentSQS from './SelfServiceComponentSQS';
-import SelfServiceComponentCustom from './SelfServiceComponentCustom';
+import SelfServiceComponentSQS from "./SelfServiceComponentSQS";
 
 // TODO, move this to config file.
 const DEFAULT_AWS_SERVICE = 's3';
@@ -10,9 +13,12 @@ const DEFAULT_AWS_SERVICE = 's3';
 class SelfServiceComponent extends Component {
     // TODO(heewonk), load available components via dynamic import using module name pattern.
     static components = {
+        custom: SelfServiceComponentCustom,
+        ec2: SelfServiceComponentEC2,
+        rds: SelfServiceComponentRDS,
+        route53: SelfServiceComponentRoute53,
         s3: SelfServiceComponentS3,
         sqs: SelfServiceComponentSQS,
-        custom: SelfServiceComponentCustom,
     };
 
     componentDidMount() {

--- a/consoleme/templates/static/js/components/SelfServiceComponentEC2.js
+++ b/consoleme/templates/static/js/components/SelfServiceComponentEC2.js
@@ -1,0 +1,58 @@
+import React, {Component} from 'react';
+import {
+    Form,
+    Header,
+} from 'semantic-ui-react';
+
+const actionOptions = [
+    { key: 'volmount', text: "Volume Mount", value: "volmount" },
+];
+
+
+class SelfServiceComponentEC2 extends Component {
+    static TYPE = 'ec2';
+    static NAME = 'EC2';
+
+    state = {
+    };
+
+    componentDidMount() {
+    }
+
+    handleActionChange(e, {value}) {
+        const {permission} = this.props;
+
+        this.props.updatePermission({
+            type: SelfServiceComponentEC2.TYPE,
+            actions: value,
+            value: permission.value,
+        });
+    }
+
+    render() {
+        const {permission} = this.props;
+        return (
+            <Form>
+                <Header as="h3">
+                    EC2
+                    <Header.Subheader>
+                        Please Select EC2 Permissions from the below dropdown.
+                    </Header.Subheader>
+                </Header>
+                <Form.Field>
+                    <label>Select Permissions</label>
+                    <Form.Dropdown
+                        placeholder=""
+                        multiple
+                        selection
+                        options={actionOptions}
+                        value={permission.actions || []}
+                        onChange={this.handleActionChange.bind(this)}
+                    />
+                </Form.Field>
+            </Form>
+        );
+    }
+}
+
+export default SelfServiceComponentEC2;

--- a/consoleme/templates/static/js/components/SelfServiceComponentRDS.js
+++ b/consoleme/templates/static/js/components/SelfServiceComponentRDS.js
@@ -1,0 +1,58 @@
+import React, {Component} from 'react';
+import {
+    Form,
+    Header,
+} from 'semantic-ui-react';
+
+const actionOptions = [
+    { key: 'passrole', text: "Passrole to rds-monitoring-role", value: "passrole" },
+];
+
+
+class SelfServiceComponentRDS extends Component {
+    static TYPE = 'rds';
+    static NAME = 'RDS';
+
+    state = {
+    };
+
+    componentDidMount() {
+    }
+
+    handleActionChange(e, {value}) {
+        const {permission} = this.props;
+
+        this.props.updatePermission({
+            type: SelfServiceComponentRDS.TYPE,
+            actions: value,
+            value: permission.value,
+        });
+    }
+
+    render() {
+        const {permission} = this.props;
+        return (
+            <Form>
+                <Header as="h3">
+                    EC2
+                    <Header.Subheader>
+                        Please Select RDS Permissions from the below dropdown.
+                    </Header.Subheader>
+                </Header>
+                <Form.Field>
+                    <label>Select Permissions</label>
+                    <Form.Dropdown
+                        placeholder=""
+                        multiple
+                        selection
+                        options={actionOptions}
+                        value={permission.actions || []}
+                        onChange={this.handleActionChange.bind(this)}
+                    />
+                </Form.Field>
+            </Form>
+        );
+    }
+}
+
+export default SelfServiceComponentRDS;

--- a/consoleme/templates/static/js/components/SelfServiceComponentRoute53.js
+++ b/consoleme/templates/static/js/components/SelfServiceComponentRoute53.js
@@ -1,0 +1,59 @@
+import React, {Component} from 'react';
+import {
+    Form,
+    Header,
+} from 'semantic-ui-react';
+
+const actionOptions = [
+    { key: 'list', text: "List Records", value: "list" },
+    { key: 'change', text: "Change Records", value: "change" },
+];
+
+
+class SelfServiceComponentRoute53 extends Component {
+    static TYPE = 'route53';
+    static NAME = 'Route53';
+
+    state = {
+    };
+
+    componentDidMount() {
+    }
+
+    handleActionChange(e, {value}) {
+        const {permission} = this.props;
+
+        this.props.updatePermission({
+            type: SelfServiceComponentRoute53.TYPE,
+            actions: value,
+            value: permission.value,
+        });
+    }
+
+    render() {
+        const {permission} = this.props;
+        return (
+            <Form>
+                <Header as="h3">
+                    EC2
+                    <Header.Subheader>
+                        Please Select Route53 Permissions from the below dropdown.
+                    </Header.Subheader>
+                </Header>
+                <Form.Field>
+                    <label>Select Permissions</label>
+                    <Form.Dropdown
+                        placeholder=""
+                        multiple
+                        selection
+                        options={actionOptions}
+                        value={permission.actions || []}
+                        onChange={this.handleActionChange.bind(this)}
+                    />
+                </Form.Field>
+            </Form>
+        );
+    }
+}
+
+export default SelfServiceComponentRoute53;

--- a/consoleme/templates/static/js/components/SelfServiceStep2.js
+++ b/consoleme/templates/static/js/components/SelfServiceStep2.js
@@ -46,7 +46,7 @@ class SelfServiceStep1 extends Component {
         const {permissions} = this.props;
 
         // skip adding a permission if any of followings are empty.
-        if (permission.value === '' || permission.actions.length < 1) {
+        if (permission.actions.length < 1) {
             return;
         }
 


### PR DESCRIPTION
I have implemented extra self service AWS service components for user inputs.

- SelfServiceComponentEC2 for EC2 volmount
- SelfServiceComponentRoute53 for Domain List, Add
- SelfServiceComponentRDS for Database passrole.

I was able to generalize how user inputs should be handled and work on a base class that easily implement simple Service Components.