### PR TITLE
add endpoint for MTLS apps to delete roles

### DIFF
--- a/consoleme/handlers/base.py
+++ b/consoleme/handlers/base.py
@@ -437,12 +437,14 @@ class BaseHandler(SentryMixin, tornado.web.RequestHandler):
 
 class BaseAPIV1Handler(BaseHandler):
     """Default API Handler for api/v1/* routes."""
+
     def set_default_headers(self) -> None:
         self.set_header("Content-Type", "application/json")
 
 
 class BaseAPIV2Handler(BaseHandler):
     """Default API Handler for api/v2/* routes."""
+
     def set_default_headers(self) -> None:
         self.set_header("Content-Type", "application/json")
 
@@ -467,7 +469,7 @@ class BaseAPIV2Handler(BaseHandler):
             )
 
 
-class BaseMtlsHandler(BaseAPIV1Handler):
+class BaseMtlsHandler(BaseAPIV2Handler):
     def initialize(self, **kwargs):
         self.kwargs = kwargs
 

--- a/consoleme/handlers/v2/roles.py
+++ b/consoleme/handlers/v2/roles.py
@@ -168,9 +168,9 @@ class RoleDetailHandler(BaseAPIV2Handler):
 
 class RoleDetailAppHandler(BaseMtlsHandler):
 
-    """ Handler for /api/v2/metatron/roles/{accountNumber}/{roleName}
+    """ Handler for /api/v2/mtls/roles/{accountNumber}/{roleName}
 
-        Allows metatron apps to delete a role
+        Allows apps to delete a role
     """
 
     allowed_methods = ["DELETE"]
@@ -180,7 +180,7 @@ class RoleDetailAppHandler(BaseMtlsHandler):
 
     async def delete(self, account_id, role_name):
         """
-        DELETE /api/v2/metatron/roles/{account_id}/{role_name}
+        DELETE /api/v2/mtls/roles/{account_id}/{role_name}
         """
         log_data = {
             "function": f"{__name__}.{self.__class__.__name__}.{sys._getframe().f_code.co_name}",

--- a/consoleme/handlers/v2/roles.py
+++ b/consoleme/handlers/v2/roles.py
@@ -3,8 +3,8 @@ import sys
 import ujson as json
 
 from consoleme.config import config
-from consoleme.handlers.base import BaseAPIV2Handler
-from consoleme.lib.aws import can_delete_roles, delete_iam_role
+from consoleme.handlers.base import BaseAPIV2Handler, BaseMtlsHandler
+from consoleme.lib.aws import can_delete_roles, can_delete_roles_app, delete_iam_role
 from consoleme.lib.crypto import Crypto
 from consoleme.lib.plugins import get_plugin_by_name
 
@@ -149,6 +149,84 @@ class RoleDetailHandler(BaseAPIV2Handler):
                     "role": role_name,
                     "authorized": can_delete_role,
                     "ip": self.ip,
+                },
+            )
+            self.write_error(500, message="Error occurred deleting role: " + str(e))
+            return
+
+        # if here, role has been successfully deleted
+        arn = f"arn:aws:iam::{account_id}:role/{role_name}"
+        await aws.fetch_iam_role(account_id, arn, force_refresh=True)
+        response_json = {
+            "status": "success",
+            "message": "Successfully deleted role from account",
+            "role": role_name,
+            "account": account_id,
+        }
+        self.write(response_json)
+
+
+class RoleDetailAppHandler(BaseMtlsHandler):
+
+    """ Handler for /api/v2/metatron/roles/{accountNumber}/{roleName}
+
+        Allows metatron apps to delete a role
+    """
+
+    allowed_methods = ["DELETE"]
+
+    def check_xsrf_cookie(self):
+        pass
+
+    async def delete(self, account_id, role_name):
+        """
+        DELETE /api/v2/metatron/roles/{account_id}/{role_name}
+        """
+        log_data = {
+            "function": f"{__name__}.{self.__class__.__name__}.{sys._getframe().f_code.co_name}",
+            "user-agent": self.request.headers.get("User-Agent"),
+            "request_id": self.request_uuid,
+            "account": account_id,
+            "role": role_name,
+        }
+        requester_type = self.requester.get("type")
+        if requester_type != "application":
+            log_data[
+                "message"
+            ] = "Non-application trying to access application only endpoint"
+            log.error(log_data)
+            self.write_error(406, message="Endpoint not supported for non-applications")
+            return
+
+        app_name = self.requester.get("name")
+        can_delete_role = await can_delete_roles_app(app_name)
+        if not can_delete_role:
+            stats.count(
+                f"{log_data['function']}.unauthorized",
+                tags={
+                    "user": app_name,
+                    "account": account_id,
+                    "role": role_name,
+                    "authorized": can_delete_role,
+                },
+            )
+            log_data["message"] = "App is unauthorized to delete a role"
+            log.error(log_data)
+            self.write_error(403, message="App is unauthorized to delete a role")
+            return
+
+        try:
+            await delete_iam_role(account_id, role_name, app_name)
+        except Exception as e:
+            log_data["message"] = "Exception deleting role"
+            log.error(log_data, exc_info=True)
+            stats.count(
+                f"{log_data['function']}.exception",
+                tags={
+                    "user": app_name,
+                    "account": account_id,
+                    "role": role_name,
+                    "authorized": can_delete_role,
                 },
             )
             self.write_error(500, message="Error occurred deleting role: " + str(e))

--- a/consoleme/handlers/v2/roles.py
+++ b/consoleme/handlers/v2/roles.py
@@ -186,8 +186,8 @@ class RoleDetailAppHandler(BaseMtlsHandler):
             "function": f"{__name__}.{self.__class__.__name__}.{sys._getframe().f_code.co_name}",
             "user-agent": self.request.headers.get("User-Agent"),
             "request_id": self.request_uuid,
-            "account": account_id,
-            "role": role_name,
+            "account_id": account_id,
+            "role_name": role_name,
         }
         requester_type = self.requester.get("type")
         if requester_type != "application":
@@ -204,9 +204,9 @@ class RoleDetailAppHandler(BaseMtlsHandler):
             stats.count(
                 f"{log_data['function']}.unauthorized",
                 tags={
-                    "user": app_name,
-                    "account": account_id,
-                    "role": role_name,
+                    "app_name": app_name,
+                    "account_id": account_id,
+                    "role_name": role_name,
                     "authorized": can_delete_role,
                 },
             )
@@ -223,9 +223,9 @@ class RoleDetailAppHandler(BaseMtlsHandler):
             stats.count(
                 f"{log_data['function']}.exception",
                 tags={
-                    "user": app_name,
-                    "account": account_id,
-                    "role": role_name,
+                    "app_name": app_name,
+                    "account_id": account_id,
+                    "role_name": role_name,
                     "authorized": can_delete_role,
                 },
             )

--- a/consoleme/lib/aws.py
+++ b/consoleme/lib/aws.py
@@ -501,6 +501,12 @@ async def can_delete_roles(groups):
     return False
 
 
+async def can_delete_roles_app(app_name):
+    if app_name in config.get("groups.can_delete_roles_apps", []):
+        return True
+    return False
+
+
 def role_has_tag(role: Dict, key: str, value: Optional[str] = None) -> bool:
     """
     Checks a role dictionary and determine of the role has the specified tag. If `value` is passed,

--- a/consoleme/routes.py
+++ b/consoleme/routes.py
@@ -53,6 +53,7 @@ from consoleme.handlers.v2.index import IndexHandler as IndexHandlerV2  # noqa
 from consoleme.handlers.v2.requests import RequestDetailHandler, RequestsHandler
 from consoleme.handlers.v2.roles import (
     AccountRolesHandler,
+    RoleDetailAppHandler,
     RoleDetailHandler,
     RolesHandler,
 )
@@ -122,6 +123,7 @@ def make_app(jwt_validator=None):
         (r"/api/v2/roles/?", RolesHandler),
         (r"/api/v2/roles/(\d{12})", AccountRolesHandler),
         (r"/api/v2/roles/(\d{12})/(.*)", RoleDetailHandler),
+        (r"/api/v2/metatron/roles/(\d{12})/(.*)", RoleDetailAppHandler),
         (r"/config/?", DynamicConfigHandler),
         (r"/myheaders/?", HeaderHandler),
         (r"/policies/?", PolicyViewHandler),

--- a/consoleme/routes.py
+++ b/consoleme/routes.py
@@ -123,7 +123,7 @@ def make_app(jwt_validator=None):
         (r"/api/v2/roles/?", RolesHandler),
         (r"/api/v2/roles/(\d{12})", AccountRolesHandler),
         (r"/api/v2/roles/(\d{12})/(.*)", RoleDetailHandler),
-        (r"/api/v2/metatron/roles/(\d{12})/(.*)", RoleDetailAppHandler),
+        (r"/api/v2/mtls/roles/(\d{12})/(.*)", RoleDetailAppHandler),
         (r"/config/?", DynamicConfigHandler),
         (r"/myheaders/?", HeaderHandler),
         (r"/policies/?", PolicyViewHandler),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,16 +1,15 @@
+import asyncio
 import json
 import os
+import unittest
+from datetime import datetime, timedelta
 
-import asyncio
 import boto3
 import fakeredis
 import pytest
-import unittest
-from datetime import datetime, timedelta
-from mock import MagicMock
-from mock import patch, Mock
+from mock import MagicMock, Mock, patch
 from mockredis import mock_strict_redis_client
-from moto import mock_sts, mock_iam, mock_dynamodb2, mock_lambda
+from moto import mock_dynamodb2, mock_iam, mock_lambda, mock_sts
 from tornado.concurrent import Future
 
 from consoleme.lib.dynamo import BaseDynamoHandler
@@ -111,6 +110,18 @@ class MockBaseHandler:
         self.groups = ["group1", "group2"]
         self.contractor = False
         self.red = mock_strict_redis_client()
+
+
+class MockBaseMtlsHandler:
+    async def authorization_flow_user(self):
+        self.request_uuid = 1234
+        self.ip = "1.2.3.4"
+        self.requester = {"type": "user"}
+
+    async def authorization_flow_app(self):
+        self.request_uuid = 1234
+        self.ip = "1.2.3.4"
+        self.requester = {"type": "application", "name": "fakeapp"}
 
 
 class MockAuth:

--- a/tests/handlers/v2/test_roles.py
+++ b/tests/handlers/v2/test_roles.py
@@ -186,7 +186,7 @@ class TestRoleDetailAppHandler(AsyncHTTPTestCase):
             "message": "Endpoint not supported for non-applications",
         }
         response = self.fetch(
-            "/api/v2/metatron/roles/012345678901/fake_account_admin", method="DELETE",
+            "/api/v2/mtls/roles/012345678901/fake_account_admin", method="DELETE",
         )
         self.assertEqual(response.code, 406)
         self.assertDictEqual(json.loads(response.body), expected)
@@ -205,7 +205,7 @@ class TestRoleDetailAppHandler(AsyncHTTPTestCase):
         }
         mock_can_delete_roles.return_value = create_future(False)
         response = self.fetch(
-            "/api/v2/metatron/roles/012345678901/fake_account_admin", method="DELETE",
+            "/api/v2/mtls/roles/012345678901/fake_account_admin", method="DELETE",
         )
         self.assertEqual(response.code, 403)
         self.assertDictEqual(json.loads(response.body), expected)
@@ -224,7 +224,7 @@ class TestRoleDetailAppHandler(AsyncHTTPTestCase):
         }
 
         response = self.fetch(
-            f"/api/v2/metatron/roles/{account_id}/{role_name}", method="DELETE",
+            f"/api/v2/mtls/roles/{account_id}/{role_name}", method="DELETE",
         )
         self.assertEqual(response.code, 200)
         self.assertDictEqual(json.loads(response.body), expected)


### PR DESCRIPTION
- Added an endpoint for apps with metatron certs to be able to delete roles
- Added tests to test above endpoint
- Updated BaseMtlsHandler to inherit from BaseAPIV2 (for better error handling)
- Pre-commit