### PR TITLE
add XSRF token in the page and use the token instead of the cookie

### DIFF
--- a/consoleme/handlers/v1/policies.py
+++ b/consoleme/handlers/v1/policies.py
@@ -498,10 +498,10 @@ class PolicyReviewSubmitHandler(BaseHandler):
                 raise MustBeFte("Only FTEs are authorized to view this page.")
 
         data: dict = tornado.escape.json_decode(self.request.body)
-
         arn: str = data.get("arn", "")
         account_id: str = data.get("account_id", "")
         justification: str = data.get("justification", "")
+
         if not justification:
             await write_json_error(
                 "Justification is required to submit a policy change request.", obj=self
@@ -951,11 +951,12 @@ class SelfServiceNewHandler(BaseHandler):
 
         await self.render(
             "self_service_new.html",
-            page_title="ConsoleMe - Self Service",
+            config=config,
             current_page="policies",
+            page_title="ConsoleMe - Self Service",
             user=self.user,
             user_groups=self.groups,
-            config=config,
+            xsrf=self.xsrf_token,
         )
 
 

--- a/consoleme/templates/self_service_new.html
+++ b/consoleme/templates/self_service_new.html
@@ -3,6 +3,10 @@
     <div id="new_policy_wizard" />
     <script src="/static/js/dist/selfService.js"></script>
     <script>
-        setTimeout(function(){ selfService.renderIAMSelfServiceWizard(); }, 1000);
+        // set xsrf global variable
+        const _xsrf = "{{ xsrf }}";
+        setTimeout(() => {
+            selfService.renderIAMSelfServiceWizard();
+        }, 1000);
     </script>
 </div>

--- a/consoleme/templates/static/js/components/SelfServiceStep3.js
+++ b/consoleme/templates/static/js/components/SelfServiceStep3.js
@@ -115,7 +115,7 @@ class SelfServiceStep3 extends Component {
             isLoading: true,
         }, async () => {
             const response = await sendRequestCommon(
-                JSON.stringify(request),
+                request,
                 '/policies/submit_for_review',
             );
 

--- a/consoleme/templates/static/js/helpers/utils.js
+++ b/consoleme/templates/static/js/helpers/utils.js
@@ -45,19 +45,19 @@ export async function getCookie(name) {
   return r ? r[1] : undefined
 }
 
-export async function sendRequestCommon(json, location = window.location.href) {
-    let xsrf = await getCookie('_xsrf');
-    const rawResponse = await fetch(location, {
+export async function sendRequestCommon(json, endpoint) {
+    // const xsrf_cookie = await getCookie('_xsrf');
+    const rawResponse = await fetch(endpoint, {
         method: 'post',
         headers: {
+            'Accept': 'application/json',
             'Content-type': 'application/json',
-            'X-Xsrftoken': xsrf,
+            'X-Xsrftoken': _xsrf,
         },
-        body: json
+        body: JSON.stringify(json),
     });
 
-    let res = await rawResponse;
-
+    const res = await rawResponse;
     let resJson;
     try {
         resJson = res.json();


### PR DESCRIPTION
I have added XSRF token when the new page is being rendered.
and used it to make a POST request to the submission page.

I stepped through the process using the debugger and it seems the xsrf token in the cookie and the token in the request header seems not matching.

I will need @jaydhulia for helping me debug this or better approach than this.