### PR TITLE
Server-side generated login + redirect urls for most common AWS Config resource types

### DIFF
--- a/consoleme/handlers/v1/policies.py
+++ b/consoleme/handlers/v1/policies.py
@@ -1,8 +1,13 @@
 import re
 import sys
+from datetime import datetime, timedelta
+from typing import Dict, List, Optional
+from urllib.parse import quote_plus
+
 import tornado.escape
 import ujson as json
-import urllib.parse
+from policyuniverse.expander_minimizer import _expand_wildcard_action
+
 from consoleme.config import config
 from consoleme.exceptions.exceptions import (
     InvalidRequestParameter,
@@ -27,6 +32,7 @@ from consoleme.lib.policies import (
     escape_json,
     get_formatted_policy_changes,
     get_resources_from_events,
+    get_url_for_resource,
     parse_policy_change_request,
     should_auto_approve_policy,
     update_resource_policy,
@@ -34,10 +40,6 @@ from consoleme.lib.policies import (
 )
 from consoleme.lib.redis import redis_get, redis_hgetall
 from consoleme.lib.timeout import Timeout
-from datetime import datetime, timedelta
-from policyuniverse.expander_minimizer import _expand_wildcard_action
-from typing import Dict, List, Optional
-from urllib.parse import quote_plus
 
 log = config.get_logger()
 stats = get_plugin_by_name(config.get("plugins.metrics"))()
@@ -66,7 +68,7 @@ class PolicyViewHandler(BaseHandler):
 
         if config.get("policy_editor.disallow_contractors", True) and self.contractor:
             if self.user not in config.get(
-                    "groups.can_bypass_contractor_restrictions", []
+                "groups.can_bypass_contractor_restrictions", []
             ):
                 raise MustBeFte("Only FTEs are authorized to view this page.")
         stats.count("PolicyViewHandler.get", tags={"user": self.user})
@@ -127,7 +129,7 @@ class GetPoliciesHandler(BaseHandler):
             return
         if config.get("policy_editor.disallow_contractors", True) and self.contractor:
             if self.user not in config.get(
-                    "groups.can_bypass_contractor_restrictions", []
+                "groups.can_bypass_contractor_restrictions", []
             ):
                 raise MustBeFte("Only FTEs are authorized to view this page.")
         draw = int(self.request.arguments.get("draw")[0])
@@ -197,32 +199,12 @@ class GetPoliciesHandler(BaseHandler):
                 resource_name = resource_name.split("/")[1]
             region = arn.split(":")[3]
             if resource_type == "iam" and not arn.split(":")[5].startswith("role/"):
-                resource_type = "iam_other"
+                resource_type = "iam" + arn.split(":")[5].split("/")[0]
 
-            url = ""
-            if resource_type == "iam":
-                url = f"/policies/edit/{account_id}/iamrole/{resource_name}"
-            elif resource_type == "s3":
-                url = f"/policies/edit/{account_id}/s3/{resource_name}"
-            elif resource_type in ["sqs", "sns"]:
-                url = f"/policies/edit/{account_id}/{resource_type}/{region}/{resource_name}"
-            elif resource_type == "AWS::EC2::SecurityGroup":
-                url = f"/role/{account_id}?redirect=https://console.aws.amazon.com/ec2/v2/home?region={region}%23SecurityGroup:groupId={resource_name}"
-            elif resource_type == "AWS::EC2::RouteTable":
-                url = f"/role/{account_id}?redirect=https://console.aws.amazon.com/vpc/home?region={region}%23RouteTables:sort=routeTableId"
-            elif resource_type == "AWS::RDS::DBSnapshot":
-                resource_name = policy.get("arn").split(":")[6]
-                url = f"/role/{account_id}?redirect=https://console.aws.amazon.com/rds/home?region={region}%23db-snapshot:id={resource_name}"
-            elif resource_type == "AWS::CloudWatch::Alarm":
-                # CloudWatch alarms have a different resource_name format
-                resource_name = policy.get("arn").split(":")[6]
+            url = await get_url_for_resource(
+                arn, resource_type, account_id, region, resource_name
+            )
 
-                # :alarm/{urllib.parse.quote(resource_name)}?
-                # TODO: Not sure how to parse this properly
-                url = (
-                          f"/role/{account_id}?redirect=https://console.aws.amazon.com/cloudwatch/home"
-                          f"?region={region}%23alarmsV2"
-                )
             data.append(
                 [
                     account_id,
@@ -257,7 +239,7 @@ class PolicyEditHandler(BaseHandler):
             return
         if config.get("policy_editor.disallow_contractors", True) and self.contractor:
             if self.user not in config.get(
-                    "groups.can_bypass_contractor_restrictions", []
+                "groups.can_bypass_contractor_restrictions", []
             ):
                 raise MustBeFte("Only FTEs are authorized to view this page.")
         read_only = False
@@ -355,7 +337,7 @@ class PolicyEditHandler(BaseHandler):
 
         if config.get("policy_editor.disallow_contractors", True) and self.contractor:
             if self.user not in config.get(
-                    "groups.can_bypass_contractor_restrictions", []
+                "groups.can_bypass_contractor_restrictions", []
             ):
                 raise MustBeFte("Only FTEs are authorized to view this page.")
 
@@ -409,7 +391,7 @@ class ResourcePolicyEditHandler(BaseHandler):
             return
         if config.get("policy_editor.disallow_contractors", True) and self.contractor:
             if self.user not in config.get(
-                    "groups.can_bypass_contractor_restrictions", []
+                "groups.can_bypass_contractor_restrictions", []
             ):
                 raise MustBeFte("Only FTEs are authorized to view this page.")
         read_only = False
@@ -480,7 +462,7 @@ class ResourcePolicyEditHandler(BaseHandler):
 
         if config.get("policy_editor.disallow_contractors", True) and self.contractor:
             if self.user not in config.get(
-                    "groups.can_bypass_contractor_restrictions", []
+                "groups.can_bypass_contractor_restrictions", []
             ):
                 raise MustBeFte("Only FTEs are authorized to view this page.")
 
@@ -530,7 +512,7 @@ class PolicyReviewSubmitHandler(BaseHandler):
 
         if config.get("policy_editor.disallow_contractors", True) and self.contractor:
             if self.user not in config.get(
-                    "groups.can_bypass_contractor_restrictions", []
+                "groups.can_bypass_contractor_restrictions", []
             ):
                 raise MustBeFte("Only FTEs are authorized to view this page.")
 
@@ -654,7 +636,7 @@ class PolicyReviewHandler(BaseHandler):
 
         if config.get("policy_editor.disallow_contractors", True) and self.contractor:
             if self.user not in config.get(
-                    "groups.can_bypass_contractor_restrictions", []
+                "groups.can_bypass_contractor_restrictions", []
             ):
                 raise MustBeFte("Only FTEs are authorized to view this page.")
 
@@ -747,7 +729,7 @@ class PolicyReviewHandler(BaseHandler):
 
         if config.get("policy_editor.disallow_contractors", True) and self.contractor:
             if self.user not in config.get(
-                    "groups.can_bypass_contractor_restrictions", []
+                "groups.can_bypass_contractor_restrictions", []
             ):
                 raise MustBeFte("Only FTEs are authorized to view this page.")
 
@@ -907,7 +889,7 @@ class PolicyReviewHandler(BaseHandler):
             data_type = (
                 "AssumeRolePolicyDocument"
                 if policy_name
-                   in ["Assume Role Policy Document", "AssumeRolePolicyDocument"]
+                in ["Assume Role Policy Document", "AssumeRolePolicyDocument"]
                 else "InlinePolicy"
             )
             data_list = [
@@ -1010,16 +992,16 @@ class AutocompleteHandler(BaseAPIV1Handler):
 
         if config.get("policy_editor.disallow_contractors", True) and self.contractor:
             if self.user not in config.get(
-                    "groups.can_bypass_contractor_restrictions", []
+                "groups.can_bypass_contractor_restrictions", []
             ):
                 raise MustBeFte("Only FTEs are authorized to view this page.")
 
         only_filter_services = False
 
         if (
-                self.request.arguments.get("only_filter_services")
-                and self.request.arguments.get("only_filter_services")[0].decode("utf-8")
-                == "true"
+            self.request.arguments.get("only_filter_services")
+            and self.request.arguments.get("only_filter_services")[0].decode("utf-8")
+            == "true"
         ):
             only_filter_services = True
 
@@ -1225,7 +1207,7 @@ class ResourceTypeAheadHandler(BaseHandler):
     async def get(self):
         if config.get("policy_editor.disallow_contractors", True) and self.contractor:
             if self.user not in config.get(
-                    "groups.can_bypass_contractor_restrictions", []
+                "groups.can_bypass_contractor_restrictions", []
             ):
                 raise MustBeFte("Only FTEs are authorized to view this page.")
         results = await handle_resource_type_ahead_request(self)

--- a/consoleme/lib/policies.py
+++ b/consoleme/lib/policies.py
@@ -607,3 +607,65 @@ async def should_auto_approve_policy(events, user, user_groups):
     aws = get_plugin_by_name(config.get("plugins.aws"))()
     result = await aws.should_auto_approve_policy(events, user, user_groups)
     return result
+
+
+async def get_url_for_resource(arn, resource_type, account_id, region, resource_name):
+    url = ""
+    if resource_type == "iam":
+        url = f"/policies/edit/{account_id}/iamrole/{resource_name}"
+    elif resource_type == "s3":
+        url = f"/policies/edit/{account_id}/s3/{resource_name}"
+    elif resource_type in ["sqs", "sns"]:
+        url = f"/policies/edit/{account_id}/{resource_type}/{region}/{resource_name}"
+    elif resource_type == "AWS::CloudFormation::Stack":
+        url = f"/role/{account_id}?redirect=https://console.aws.amazon.com/cloudformation/home?region={region}#/stacks/"
+    elif resource_type == "AWS::CloudFront::Distribution":
+        url = f"/role/{account_id}?redirect=https://console.aws.amazon.com/cloudfront/home?%23distribution-settings:{resource_name}"
+    elif resource_type == "AWS::CloudTrail::Trail":
+        url = f"/role/{account_id}?redirect=https://console.aws.amazon.com/cloudtrail/home?region={region}%23/configuration"
+    elif resource_type == "AWS::CloudWatch::Alarm":
+        url = (
+            f"/role/{account_id}?redirect=https://console.aws.amazon.com/cloudwatch/home"
+            f"?region={region}%23alarmsV2:"
+        )
+    elif resource_type == "AWS::CodeBuild::Project":
+        url = (
+            f"/role/{account_id}?redirect=https://console.aws.amazon.com/codesuite/codebuild/"
+            f"{account_id}/projects/{resource_name}/history?region={region}"
+        )
+    elif resource_type == "AWS::CodePipeline::Pipeline":
+        url = (
+            f"/role/{account_id}?redirect="
+            "https://console.aws.amazon.com/codesuite/codepipeline/pipelines/"
+            f"{resource_name}/view?region={region}"
+        )
+    elif resource_type == "AWS::DynamoDB::Table":
+        url = (
+            f"/role/{account_id}?redirect="
+            f"https://console.aws.amazon.com/dynamodb/home?region={region}%23tables:selected={resource_name}"
+        )
+    elif resource_type == "AWS::EC2::VPC":
+        url = (
+            f"/role/{account_id}?redirect="
+            f"https://console.aws.amazon.com/vpc/home?region={region}%23vpcs:search={resource_name};sort=VpcId"
+        )
+    elif resource_type == "AWS::Lambda::Function":
+        resource_name = arn.split(":")[6]
+        url = (
+            f"/role/{account_id}?redirect="
+            f"https://console.aws.amazon.com/lambda/home?region={region}%23/functions/{resource_name}"
+        )
+    elif resource_type == "AWS::EC2::SecurityGroup":
+        url = f"/role/{account_id}?redirect=https://console.aws.amazon.com/ec2/v2/home?region={region}%23SecurityGroup:groupId={resource_name}"
+    elif resource_type == "AWS::EC2::RouteTable":
+        url = f"/role/{account_id}?redirect=https://console.aws.amazon.com/vpc/home?region={region}%23RouteTables:sort=routeTableId"
+    elif resource_type == "AWS::RDS::DBSnapshot":
+        resource_name = arn.split(":")[6]
+        url = f"/role/{account_id}?redirect=https://console.aws.amazon.com/rds/home?region={region}%23db-snapshot:id={resource_name}"
+    elif resource_type == "AWS::IAM::Policy":
+        url = f"/role/{account_id}?redirect=https://console.aws.amazon.com/iam/home?%23/policies/{arn}$serviceLevelSummary"
+    elif resource_type == "AWS::IAM::User":
+        url = f"/role/{account_id}?redirect=https://console.aws.amazon.com/iam/home?%23/users/{resource_name}"
+    elif resource_type == "AWS::IAM::Group":
+        url = f"/role/{account_id}?redirect=https://console.aws.amazon.com/iam/home?%23/groups/{resource_name}"
+    return url

--- a/consoleme/templates/static/js/policies.js
+++ b/consoleme/templates/static/js/policies.js
@@ -18,11 +18,15 @@ $(document).ready(function () {
       $('#loading').css('display', 'none');
     },
     "lengthMenu": [[10, 25, 50, 100, 1000], [10, 25, 50, 100, 1000]],
-    "order": [],
     "displayLength": 25,
     "processing": true,
     "serverSide": true,
-    "ajax": "/policies/get_policies",
+    "ajax": {
+      "url": "/policies/get_policies",
+      "data": function ( d ) {
+        return d;
+      }
+    },
     "search": {
       "regex": true
     },
@@ -38,27 +42,9 @@ $(document).ready(function () {
         "orderable": false,
         "render": function (data, type, row, meta) {
           if (type === 'display') {
-            let account_id = row[0];
-            let resource_name = data.split(":")[5];
-            let split_resource_name = resource_name.split("/");
-            let is_service_role = (split_resource_name[1] === "aws-service-role");
-            let iam_resource_name = split_resource_name.slice(1).join("/");
-            let resource_type = data.split(":")[2];
-            if (resource_type === "iam" && !data.split(":")[5].startsWith("role/")) {
-              resource_type = "iam_other"
-            }
-            let region = data.split(":")[3];
-            if (!is_service_role && resource_type === "iam") {
-              data = '<a target="_blank" href="/policies/edit/' + account_id + '/iamrole/' + iam_resource_name + '">' + data + '</a>';
-            }
-            else if (resource_type === "s3") {
-              data = '<a target="_blank" href="/policies/edit/' + account_id + '/s3/' + resource_name + '">' + data + '</a>';
-            }
-            else if (resource_type === "sqs") {
-              data = '<a target="_blank" href="/policies/edit/' + account_id + '/sqs/' + region + '/' + resource_name + '">' + data + '</a>';
-            }
-            else if (resource_type === "sns") {
-              data = '<a target="_blank" href="/policies/edit/' + account_id + '/sns/' + region + '/' + resource_name + '">' + data + '</a>';
+            let link = row[6];
+            if (link) {
+              data = '<a target="_blank" href=' + link + '>' + data + '</a>';
             }
           }
           return data;


### PR DESCRIPTION
- [X] Generate Policies Table URLS server-side now
- [X] Generate Console Login URLs for most common resource types that ConsoleMe doesn't natively support

