### PR TITLE
Add cross-account resource policy generation / application v1

### DIFF
--- a/consoleme/handlers/v1/policies.py
+++ b/consoleme/handlers/v1/policies.py
@@ -20,6 +20,7 @@ from consoleme.lib.aws import (
     fetch_resource_details,
     get_all_iam_managed_policies_for_account,
     get_resource_policies,
+    get_resource_policy,
 )
 from consoleme.lib.cache import retrieve_json_data_from_redis_or_s3
 from consoleme.lib.dynamo import UserDynamoHandler
@@ -660,7 +661,24 @@ class PolicyReviewHandler(BaseHandler):
         can_cancel: bool = False
         show_update_button: bool = False
         read_only = True
-        resource_policies: List = request.get("resource_policies", [])
+
+        can_apply_resource_policies = await can_manage_policy_requests(self.groups)
+        supported_resource_policies = ["s3", "sqs", "sns"]
+        resource_policies: List[Dict] = request.get("resource_policies", [])
+        for resource_policy in resource_policies:
+            resource_type: str = resource_policy.get("type", "")
+            resource_region: str = resource_policy.get("region", "")
+            resource_name: str = resource_policy.get("resource", "")
+            resource_account: str = resource_policy.get("account", "")
+            resource_policy["old_policy_document"] = await get_resource_policy(
+                resource_account, resource_type, resource_name, resource_region
+            )
+            # if account wasn't present, we don't support applying resource policies automatically
+            # (for backwards compatibility as we can't pull current resource policy and don't want to overwrite)
+            if not resource_account or resource_type not in supported_resource_policies:
+                resource_policy["supported"] = False
+            else:
+                resource_policy["supported"] = True
 
         if status == "pending":
             show_approve_reject_buttons = await can_manage_policy_requests(self.groups)
@@ -702,6 +720,7 @@ class PolicyReviewHandler(BaseHandler):
             escape_json=escape_json,
             policy_changes=formatted_policy_changes,
             resource_policies=resource_policies,
+            can_apply_resource_policies=can_apply_resource_policies,
         )
 
     async def post(self, request_id):

--- a/consoleme/handlers/v1/policies.py
+++ b/consoleme/handlers/v1/policies.py
@@ -681,7 +681,9 @@ class PolicyReviewHandler(BaseHandler):
         read_only = True
 
         can_apply_resource_policies = await can_manage_policy_requests(self.groups)
-        supported_resource_policies = ["s3", "sqs", "sns"]
+        supported_resource_policies = config.get(
+            "policies.supported_resource_types_for_policy_application", []
+        )
         resource_policies: List[Dict] = request.get("resource_policies", [])
         for resource_policy in resource_policies:
             resource_type: str = resource_policy.get("type", "")

--- a/consoleme/handlers/v1/policies.py
+++ b/consoleme/handlers/v1/policies.py
@@ -691,12 +691,21 @@ class PolicyReviewHandler(BaseHandler):
             resource_policy["old_policy_document"] = await get_resource_policy(
                 resource_account, resource_type, resource_name, resource_region
             )
+
             # if account wasn't present, we don't support applying resource policies automatically
             # (for backwards compatibility as we can't pull current resource policy and don't want to overwrite)
             if not resource_account or resource_type not in supported_resource_policies:
                 resource_policy["supported"] = False
             else:
                 resource_policy["supported"] = True
+                # only need to provide ARN if resource_type is IAM, which is not supported
+                resource_policy["url"] = await get_url_for_resource(
+                    arn="",
+                    resource_type=resource_type,
+                    account_id=resource_account,
+                    region=resource_region,
+                    resource_name=resource_name,
+                )
 
         if status == "pending":
             show_approve_reject_buttons = await can_manage_policy_requests(self.groups)

--- a/consoleme/lib/aws.py
+++ b/consoleme/lib/aws.py
@@ -215,7 +215,13 @@ async def get_resource_policies(
                 old_policy, principal_arn, arns, actions
             )
 
-            result = {"resource": resource_name, "policy_document": new_policy}
+            result = {
+                "resource": resource_name,
+                "account": resource_account,
+                "type": resource_type,
+                "region": resource_region,
+                "policy_document": new_policy,
+            }
             resource_policies.append(result)
 
     return resource_policies, cross_account_request

--- a/consoleme/lib/policies.py
+++ b/consoleme/lib/policies.py
@@ -364,7 +364,7 @@ async def update_resource_policy(
             log_data["error"] = e
             log.error(log_data, exc_info=True)
             result["status"] = "error"
-            result["error"] = log_data["error"]
+            result["error"] = str(e)
             return result
     if not changes:
         result = {"status": "error", "message": "No changes detected."}

--- a/consoleme/templates/policy_review.html
+++ b/consoleme/templates/policy_review.html
@@ -287,7 +287,13 @@
             <p>The InfraSec team may need to update the resource policy for the following resource(s). We've tried to give a head start by modifying the existing policy or building a new one. Note that these will <em>not</em> be applied when this request is approved and committed.</em></p>
             {% for idx, resource_policy in enumerate(resource_policies) %}
                 <div class="ui segment">
-                    <h3>Resource: {{ escape(resource_policy.get('resource')) }} </h3>
+                    <h3>Resource:
+                        {% if resource_policy.get('url', '') != '' %}
+                            <a href="{{ escape(resource_policy.get('url')) }}?refresh=true" target="_blank"> {{ escape(resource_policy.get('resource')) }} </a>
+                        {% else %}
+                            {{ escape(resource_policy.get('resource')) }}
+                        {% end %}
+                    </h3>
                     <div class="ui grid">
                         <div class="eight wide column">
                             <h4>Current Policy</h4>

--- a/consoleme/templates/policy_review.html
+++ b/consoleme/templates/policy_review.html
@@ -40,6 +40,7 @@
       };
       let langTools = ace.require("ace/ext/language_tools");
       langTools.addCompleter(permissionCompleter);
+      let resource_policy_diffs = [];
 </script>
 <link href="/static/css/ace-diff.min.css" rel="stylesheet">
 <div id="wrapper" class="container">
@@ -168,7 +169,10 @@
             {% end %}
             <tr>
                 <td>Cross-Account</td>
-                <td><span style="copendinglor: red;">{{ request.get("cross_account_request", False) }}</span>
+                <td>
+                    <strong style="color: {% if request.get("cross_account_request", False) %}red{% else %}green{% end %};">
+                        {{ request.get("cross_account_request", False) }}
+                    </strong>
                 </td>
             </tr>
         </tbody>
@@ -183,6 +187,9 @@
               </div>
               <ul class="list">
                 <li>If you've made a mistake or want to add additional permissions to your request, you can modify the request and click 'Save Edits'</li>
+                {% if request.get("cross_account_request", False) %}
+                   <li>For cross-account access to work properly, an administrator will need to apply the corresponding resource policies to the resources.</li>
+                {% end %}
               </ul>
             </div>
             {% end %}
@@ -279,18 +286,67 @@
             <h2>Resource Policy Changes</h2>
             <p>The InfraSec team may need to update the resource policy for the following resource(s). We've tried to give a head start by modifying the existing policy or building a new one. Note that these will <em>not</em> be applied when this request is approved and committed.</em></p>
             {% for idx, resource_policy in enumerate(resource_policies) %}
-                <h3>{{ resource_policy.get('resource') }}</h3>
-                <div id="resourcePolicy{{ idx }}" class="ui segment" style="height: 500px;">
-                    {{ json.dumps(resource_policy.get('policy_document'), indent=4, sort_keys=True, escape_forward_slashes=False) }}
+                <div class="ui segment">
+                    <h3>Resource: {{ escape(resource_policy.get('resource')) }} </h3>
+                    <div class="ui grid">
+                        <div class="eight wide column">
+                            <h4>Current Policy</h4>
+                            <p>This is a read-only view of the current policy in AWS.</p>
+                        </div>
+                        <div class="eight wide column">
+                            <h4>Proposed Policy</h4>
+                            <p>This is an editable view of the proposed policy. An approver can modify the proposed policy before approving and applying it.</p>
+                        </div>
+                    </div>
+                    <div class="ui segment" style="height: 500px;">
+                        <div class="resourcePolicy{{ idx }}"></div>
+                    </div>
+                    {% if resource_policy.get('supported') %}
+                        {% if can_apply_resource_policies %}
+                            <form class="ui form" onsubmit="return false;">
+                                {% module xsrf_form_html() %}
+                                 <div class="item">
+                                     <button class="positive ui button" onClick="policyEditor.applyResourcePolicy(resource_policy_diffs[`{{idx}}`].getEditors().right, '{{ escape(resource_policy.get('account')) }}', '{{ escape(resource_policy.get('type')) }}', '{{ escape(resource_policy.get('resource')) }}', '{{ escape(resource_policy.get('region', '')) }}');"
+                                        style="margin: 10px;">
+                                            Apply Resource Policy
+                                     </button>
+                                 </div>
+                            </form>
+                        {% end %}
+                    {% else %}
+                        <div class="ui error message">
+                          <div class="header">
+                            Warning
+                          </div>
+                          This resource type is currently not supported for automatic application of resource policies. A best effort proposed resource policy is shown above. Please review carefully before applying.
+                        </div>
+                    {% end %}
+                    <script>
+                          resource_policy_diffs[`{{idx}}`] = new AceDiff({
+                          element: '.resourcePolicy{{ idx }}',
+                          mode: "ace/mode/json",
+                          theme: "ace/theme/" + editor_theme,
+                          diffGranularity: "specific",
+                          left: {
+                            content: `{% raw escape_json(json.dumps(resource_policy.get("old_policy_document"), indent=4, sort_keys=True, escape_forward_slashes=False)) %}`,
+                            editable: false,
+                            copyLinkEnabled: false,
+                          },
+                          right: {
+                            content: `{% raw escape_json(json.dumps(resource_policy.get("policy_document"), indent=4, sort_keys=True, escape_forward_slashes=False)) %}`,
+                            copyLinkEnabled: false,
+                          {% if not can_apply_resource_policies %}
+                            editable: false
+                          {% end %}
+                          },
+                        })
+
+                        resource_policy_diffs[`{{idx}}`].editors.left.ace.setShowPrintMargin(false);
+                        resource_policy_diffs[`{{idx}}`].editors.right.ace.setShowPrintMargin(false);
+                        resource_policy_diffs[`{{idx}}`].editors.right.ace.setOptions({enableBasicAutocompletion: true});
+                        resource_policy_diffs[`{{idx}}`].editors.right.ace.setOptions({enableLiveAutocompletion: true});
+                    </script>
                 </div>
-                <script>
-                    var editor = ace.edit("resourcePolicy{{ idx }}");
-                    editor.setTheme("ace/theme/textmate");
-                    editor.session.setMode("ace/mode/json");
-                    editor.setOptions({
-                        editable: false,
-                    })
-                </script>
             {% end %}
         </div>
         {% end %}
@@ -340,3 +396,4 @@
 <style>
     body.swal2-shown:not(.swal2-no-backdrop):not(.swal2-toast-shown), html.swal2-shown:not(.swal2-no-backdrop):not(.swal2-toast-shown) { height: 100% !important; overflow-y: visible !important; }
 </style>
+<script src="/static/js/dist/policyEditor.js"></script>

--- a/consoleme/templates/static/js/policy_editor.jsx
+++ b/consoleme/templates/static/js/policy_editor.jsx
@@ -337,3 +337,39 @@ export async function deleteRole(account_id, role_name) {
     await handleResponse(resJson, "/policies", "Successfully deleted role! Redirecting to ConsoleMe's policies page", 5000);
   }
 }
+
+export async function applyResourcePolicy(editor_value, account_id, resource_type, resource_name, region, is_new=false) {
+  let lint_errors = editor_value.getSession().getAnnotations();
+  if (lint_errors.length > 0) {
+    Swal.fire(
+      'Lint Error',
+      JSON.stringify(lint_errors),
+      'error'
+    );
+    return false;
+  }
+  let url = "/policies/edit/" + account_id + "/" + resource_type + "/" + ((region === '') ? resource_name : region + "/" + resource_name)
+  let arr = [{'type': 'ResourcePolicy', 'name': 'Resource Policy', 'value': editor_value.getValue(), 'is_new': is_new}];
+  let json = JSON.stringify(arr);
+  let dimmer = $('.ui.dimmer');
+  dimmer.addClass('active');
+  let res = await sendRequestCommon(json, url);
+  dimmer.removeClass('active');
+  document.getElementById('error_div').classList.add('hidden');
+  document.getElementById('success_div').classList.add('hidden');
+  if (res.status !== "success") {
+    let element = document.getElementById('error_response');
+    document.getElementById('error_div').classList.remove('hidden');
+    if(res.hasOwnProperty("message")) {
+      element.textContent = res.message
+    } else {
+      element.textContent = JSON.stringify(res, null, '\t');
+    }
+    $('.ui.basic.modal').modal('show')
+  } else {
+    let element = document.getElementById('success_response');
+    element.textContent = "Successfully applied resource policy!";
+    document.getElementById('success_div').classList.remove('hidden')
+    $('.ui.basic.modal').modal('show');
+  }
+}


### PR DESCRIPTION
- Provide diff for current policy and proposed resource policy 
- Allow administrators to edit proposed resource policy with typeahead for permissions
- Allow administrators to apply resource policy directly from the page (for supported services)
- Provide links for supported services
- Pre-commit run