### PR TITLE
bug fix for role selection when the role is no longer exist

### DIFF
--- a/consoleme/templates/static/js/components/SelfServiceStep1.js
+++ b/consoleme/templates/static/js/components/SelfServiceStep1.js
@@ -40,6 +40,7 @@ class SelfServiceStep1 extends Component {
                             this.props.handleRoleUpdate(null);
                             this.setState({
                                 isLoading: false,
+                                isRoleLoading: false,
                                 messages: [response.message],
                             });
                         } else {
@@ -112,14 +113,24 @@ class SelfServiceStep1 extends Component {
                 roleName = roleName.split('/').splice(-1, 1)[0];
                 fetch(`/api/v2/roles/${accountId}/${roleName}`).then((resp) => {
                     resp.text().then((resp) => {
-                        const role = JSON.parse(resp);
-                        this.props.handleRoleUpdate(role);
-                        this.setState({
-                            isLoading: false,
-                            isRoleLoading: false,
-                            messages: [],
-                            value: role.arn,
-                        });
+                        const response = JSON.parse(resp);
+                        if (response.status === 404) {
+                            this.props.handleRoleUpdate(null);
+                            this.setState({
+                                isLoading: false,
+                                isRoleLoading: false,
+                                messages: [response.message],
+                            });
+                        } else {
+                            const role = response;
+                            this.props.handleRoleUpdate(role);
+                            this.setState({
+                                isLoading: false,
+                                isRoleLoading: false,
+                                messages: [],
+                                value: role.arn,
+                            });
+                        }
                     });
                 });
             }


### PR DESCRIPTION
When there is a role showing up on typeahead cache but not actually exist it will break the role selection in Self Service Step1.
This is the fix for addressing such case.