### PR TITLE
Switching admin policy changes to policy requests (for better auditing)

### DIFF
--- a/consoleme/handlers/v1/policies.py
+++ b/consoleme/handlers/v1/policies.py
@@ -347,6 +347,13 @@ class PolicyEditHandler(BaseHandler):
         if not can_save_delete:
             raise Unauthorized("You are not authorized to edit policies.")
 
+        if config.get("policies.log_admin_requests", False):
+            await write_json_error(
+                "Admin requests must be made as policy requests", obj=self
+            )
+            await self.finish()
+            return
+
         arn = f"arn:aws:iam::{account_id}:role/{role_name}"
 
         stats.count("PolicyEditHandler.post", tags={"user": self.user, "arn": arn})

--- a/consoleme/templates/policy_editor.html
+++ b/consoleme/templates/policy_editor.html
@@ -289,14 +289,14 @@
                 <div class="ui center floated">
                     <button class="ui primary button" type="save"
                             {% if read_only or not can_save_delete %}style="display: none;"{% end %}
-                            onClick="policyEditor.editPolicy('InlinePolicy', $('#newpolicy_name').val(), neweditor, is_new=true);"
+                            onClick="policyEditor.submitPolicyForReview('InlinePolicy', $('#newpolicy_name').val(), neweditor, '{{ role.get("arn") }}', '{{ account_id }}', is_new=true, admin_auto_approve=true);"
                             style="margin: 10px;">Save new policy
                     </button>
                 </div>
 
                 <div class="ui center floated">
                     <button class="ui primary button" type="save" {% if read_only %}style="display: none;"{% end %}
-                            onClick="policyEditor.submitPolicyForReview('InlinePolicy', $('#newpolicy_name').val(), neweditor, '{{ role.get("arn") }}', '{{ account_id }}', is_new=true);"
+                            onClick="policyEditor.submitPolicyForReview('InlinePolicy', $('#newpolicy_name').val(), neweditor, '{{ role.get("arn") }}', '{{ account_id }}', is_new=true, admin_auto_approve=false);"
                             style="margin: 10px;">submit new policy for review
                     </button>
                 </div>
@@ -372,13 +372,13 @@
             <div class="ui center floated">
                 <button class="ui primary button" type="save"
                         {% if read_only or not can_save_delete %}style="display: none;"{% end %}
-                        onClick="policyEditor.editPolicy('InlinePolicy', '{{ policy.get("PolicyName") }}', {{ editor }});"
+                        onClick="policyEditor.submitPolicyForReview('InlinePolicy', '{{ policy.get("PolicyName") }}', {{ editor }}, '{{ role.get("arn") }}', '{{ account_id }}', is_new=false, admin_auto_approve=true);"
                         style="margin: 10px;">Save {{ policy.get("PolicyName") }}
                 </button>
             </div>
             <div class="ui center floated">
                 <button class="ui primary button" type="save" {% if read_only %}style="display: none;"{% end %}
-                        onClick="policyEditor.submitPolicyForReview('InlinePolicy', '{{ policy.get("PolicyName") }}', {{ editor }}, '{{ role.get("arn") }}', '{{ account_id }}');"
+                        onClick="policyEditor.submitPolicyForReview('InlinePolicy', '{{ policy.get("PolicyName") }}', {{ editor }}, '{{ role.get("arn") }}', '{{ account_id }}', is_new=false, admin_auto_approve=false);"
                         style="margin: 10px;">Submit {{ policy.get("PolicyName") }} for review
                 </button>
             </div>
@@ -445,13 +445,13 @@
         <div class="ui center floated">
             <button class="ui primary button" type="save"
                     {% if read_only or not can_save_delete %}style="display: none;"{% end %}
-                    onClick="policyEditor.editPolicy('AssumeRolePolicyDocument', 'AssumeRolePolicyDocument', ar_editor);"
+                    onClick="policyEditor.submitPolicyForReview('AssumeRolePolicyDocument', 'AssumeRolePolicyDocument', ar_editor, '{{ role.get("arn") }}', '{{ account_id }}', is_new=false, admin_auto_approve=true);"
                     style="margin: 10px;">Save Assume Role Policy
             </button>
         </div>
         <div class="ui center floated">
             <button class="ui primary button" type="save" {% if read_only %}style="display: none;"{% end %}
-                    onClick="policyEditor.submitPolicyForReview('AssumeRolePolicyDocument', 'AssumeRolePolicyDocument', ar_editor, '{{ role.get("arn") }}', '{{ account_id }}');"
+                    onClick="policyEditor.submitPolicyForReview('AssumeRolePolicyDocument', 'AssumeRolePolicyDocument', ar_editor, '{{ role.get("arn") }}', '{{ account_id }}', is_new=false, admin_auto_approve=false);"
                     style="margin: 10px;">Submit Assume Role Policy for review
             </button>
         </div>

--- a/consoleme/templates/policy_editor.html
+++ b/consoleme/templates/policy_editor.html
@@ -289,7 +289,9 @@
                 <div class="ui center floated">
                     <button class="ui primary button" type="save"
                             {% if read_only or not can_save_delete %}style="display: none;"{% end %}
-                            onClick="policyEditor.submitPolicyForReview('InlinePolicy', $('#newpolicy_name').val(), neweditor, '{{ role.get("arn") }}', '{{ account_id }}', is_new=true, admin_auto_approve=true);"
+                            {% if config.get("policies.log_admin_requests", False) %}onClick="policyEditor.submitPolicyForReview('InlinePolicy', $('#newpolicy_name').val(), neweditor, '{{ role.get("arn") }}', '{{ account_id }}', is_new=true, admin_auto_approve=true);"
+                            {% else %}onClick="policyEditor.editPolicy('InlinePolicy', $('#newpolicy_name').val(), neweditor, is_new=true);"
+                            {% end %}
                             style="margin: 10px;">Save new policy
                     </button>
                 </div>
@@ -372,7 +374,9 @@
             <div class="ui center floated">
                 <button class="ui primary button" type="save"
                         {% if read_only or not can_save_delete %}style="display: none;"{% end %}
-                        onClick="policyEditor.submitPolicyForReview('InlinePolicy', '{{ policy.get("PolicyName") }}', {{ editor }}, '{{ role.get("arn") }}', '{{ account_id }}', is_new=false, admin_auto_approve=true);"
+                        {% if config.get("policies.log_admin_requests", False) %}onClick="policyEditor.submitPolicyForReview('InlinePolicy', '{{ policy.get("PolicyName") }}', {{ editor }}, '{{ role.get("arn") }}', '{{ account_id }}', is_new=false, admin_auto_approve=true);"
+                        {% else %}onClick="policyEditor.editPolicy('InlinePolicy', '{{ policy.get("PolicyName") }}', {{ editor }});"
+                        {% end %}
                         style="margin: 10px;">Save {{ policy.get("PolicyName") }}
                 </button>
             </div>
@@ -445,7 +449,9 @@
         <div class="ui center floated">
             <button class="ui primary button" type="save"
                     {% if read_only or not can_save_delete %}style="display: none;"{% end %}
-                    onClick="policyEditor.submitPolicyForReview('AssumeRolePolicyDocument', 'AssumeRolePolicyDocument', ar_editor, '{{ role.get("arn") }}', '{{ account_id }}', is_new=false, admin_auto_approve=true);"
+                    {% if config.get("policies.log_admin_requests", False) %}onClick="policyEditor.submitPolicyForReview('AssumeRolePolicyDocument', 'AssumeRolePolicyDocument', ar_editor, '{{ role.get("arn") }}', '{{ account_id }}', is_new=false, admin_auto_approve=true);"
+                    {% else %}onClick="policyEditor.editPolicy('AssumeRolePolicyDocument', 'AssumeRolePolicyDocument', ar_editor);"
+                    {% end %}
                     style="margin: 10px;">Save Assume Role Policy
             </button>
         </div>

--- a/consoleme/templates/static/js/common.js
+++ b/consoleme/templates/static/js/common.js
@@ -37,21 +37,31 @@ function formatRoleName(role, accounts) {
   }
 }
 
-async function handleResponse(res, redirect_uri = null, message = "Success! Refreshing cache and reloading the page.", delay = 0) {
+async function handleResponse(res, redirect_uri = null, message = "Success! Refreshing cache and reloading the page.", delay = 0, htmlMessage = "") {
   document.getElementById('error_div').classList.add('hidden');
   document.getElementById('success_div').classList.add('hidden');
+  console.log(res)
   if (res.status !== "success") {
     let element = document.getElementById('error_response');
     document.getElementById('error_div').classList.remove('hidden');
     if(res.hasOwnProperty("message")) {
-      element.textContent = res.message
+      // since sometimes we return error message string and sometimes error message JSON object
+      if(typeof res.message === "string") {
+        element.textContent = res.message
+      } else {
+        element.textContent = JSON.stringify(res.message, null, '\t');
+      }
     } else {
       element.textContent = JSON.stringify(res, null, '\t');
     }
     $('.ui.basic.modal').modal('show')
   } else {
     let element = document.getElementById('success_response');
-    element.textContent = message;
+    if(htmlMessage === "") {
+      element.textContent = message;
+    } else {
+      element.innerHTML = htmlMessage;
+    }
     document.getElementById('success_div').classList.remove('hidden')
     $('.ui.basic.modal').modal('show');
     setTimeout(() => {

--- a/consoleme/templates/static/js/common.js
+++ b/consoleme/templates/static/js/common.js
@@ -40,7 +40,6 @@ function formatRoleName(role, accounts) {
 async function handleResponse(res, redirect_uri = null, message = "Success! Refreshing cache and reloading the page.", delay = 0, htmlMessage = "") {
   document.getElementById('error_div').classList.add('hidden');
   document.getElementById('success_div').classList.add('hidden');
-  console.log(res)
   if (res.status !== "success") {
     let element = document.getElementById('error_response');
     document.getElementById('error_div').classList.remove('hidden');


### PR DESCRIPTION
The following changes that admins have access to will be created into self-approved policy requests:
- Save an existing inline policy
- Create a new inline policy and save it
- Save Assume Role Policy
On success, a popup will display for 5 seconds where users can click on a link to be directed to their request on a new page.
On error, a popup will display the exact error from the backend.