### PR TITLE
addressed a bug when expanding a row

### DIFF
--- a/consoleme/templates/static/js/components/ConsoleMeDataTable.js
+++ b/consoleme/templates/static/js/components/ConsoleMeDataTable.js
@@ -130,9 +130,12 @@ class ConsoleMeDataTable extends Component {
         (activePage - 1) * tableConfig.rowsPerPage,
         activePage * tableConfig.rowsPerPage - 1,
       );
+
+      // get an offset if there is any expanded row and trying to expand row underneath
+      const offset = (expandedRow && expandedRow.index < idx) ? 1 : 0;
       const newExpandedRow = {
-        index: idx + 1,
-        data: expandNestedJson(filteredDataPaginated[idx]),
+        index: idx + 1 - offset,
+        data: expandNestedJson(filteredDataPaginated[idx - offset]),
       };
       this.setState({
         expandedRow: newExpandedRow,


### PR DESCRIPTION
There is an offset issue when we try to expand a row if any row is expanded and trying to expand the row underneath.