### PR TITLE
Add a link to AWS Config for a role if available

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM python:3.8
 MAINTAINER Curtis Castrapel
 COPY . /apps/consoleme
 WORKDIR /apps/consoleme
+ENV SETUPTOOLS_USE_DISTUTILS=stdlib
 RUN apt-get clean
 RUN apt-get update
 RUN apt-get install build-essential libxml2-dev libxmlsec1-dev libxmlsec1-openssl musl-dev libcurl4-nss-dev python3-dev -y

--- a/consoleme/handlers/v1/policies.py
+++ b/consoleme/handlers/v1/policies.py
@@ -33,6 +33,7 @@ from consoleme.lib.policies import (
     can_move_back_to_pending,
     can_update_requests,
     escape_json,
+    get_aws_config_history_url_for_resource,
     get_formatted_policy_changes,
     get_resources_from_events,
     get_url_for_resource,
@@ -274,6 +275,13 @@ class PolicyEditHandler(BaseHandler):
             )
             return
 
+        config_history_url = None
+        resource_id = role.get("resourceId")
+        if resource_id:
+            config_history_url = await get_aws_config_history_url_for_resource(
+                account_id, resource_id, "AWS::IAM::Role"
+            )
+
         cloudtrail_errors = await internal_policies.get_errors_by_role(
             arn, config.get("policies.number_cloudtrail_errors_to_display", 5)
         )
@@ -316,6 +324,7 @@ class PolicyEditHandler(BaseHandler):
             page_title="ConsoleMe - Policy Editor",
             current_page="policies",
             role=role,
+            config_history_url=config_history_url,
             account_id=account_id,
             account_name=account_name,
             cloudtrail_errors=cloudtrail_errors,

--- a/consoleme/lib/policies.py
+++ b/consoleme/lib/policies.py
@@ -1,6 +1,7 @@
 import re
 import sys
 import time
+import urllib
 from collections import defaultdict
 from typing import Dict, List
 
@@ -73,9 +74,11 @@ async def parse_policy_change_request(
         # Make sure the requester is only ever 64 chars with domain
         if len(requester) > 64:
             split_items: list = requester.split("@")
-            requester: str = split_items[0][
-                : (64 - (len(split_items[-1]) + 1))
-            ] + "@" + split_items[-1]
+            requester: str = (
+                split_items[0][: (64 - (len(split_items[-1]) + 1))]
+                + "@"
+                + split_items[-1]
+            )
 
         event: dict = {
             "arn": arn,
@@ -880,4 +883,15 @@ async def get_url_for_resource(arn, resource_type, account_id, region, resource_
             f"/role/{account_id}?redirect=" f"https://console.aws.amazon.com/wafv2/home"
         )
 
+    return url
+
+
+async def get_aws_config_history_url_for_resource(
+    account_id, resource_id, technology, region="us-east-1"
+):
+    encoded_redirect = urllib.parse.quote_plus(
+        f"https://{region}.console.aws.amazon.com/config/home?#/timeline/{technology}/{resource_id}/configuration"
+    )
+
+    url = f"/role/{account_id}?redirect={encoded_redirect}"
     return url

--- a/consoleme/templates/policy_editor.html
+++ b/consoleme/templates/policy_editor.html
@@ -165,7 +165,7 @@
         </div>
     </div>
     <h2 class="ui header"><a href="javascript:window.location.href=window.location.pathname + '?refresh=true'"><i
-            class="refresh icon"></i></a> Role {{ role.get("arn") }} ({{ account_name }}) {% if cloudtrail_error_uri %}Logs: [<a target="_blank" href="{{ cloudtrail_error_uri }}">Cloudtrail</a>] {% end %} {% if s3_non_error_query_url %}[<a target="_blank" href="{{ s3_non_error_query_url }}">S3</a>] {% end %}
+            class="refresh icon"></i></a> Role {{ role.get("arn") }} ({{ account_name }}) {% if cloudtrail_error_uri %}Logs: [<a target="_blank" href="{{ cloudtrail_error_uri }}">Cloudtrail</a>] {% end %} {% if s3_non_error_query_url %}[<a target="_blank" href="{{ s3_non_error_query_url }}">S3</a>] {% end %} {% if config_history_url %}[<a target="_blank" href="{{ config_history_url }}">Config History</a>] {% end %}
     </h2>
     <p>
         <button id="delete-role-button" onclick="policyEditor.deleteRole(  '{{ account_id }}', '{{ role.get("name") }}' )" class="ui red button"

--- a/docker-compose-credentials.yaml
+++ b/docker-compose-credentials.yaml
@@ -1,4 +1,4 @@
-version: '3'
+version: "3"
 # Never use this in a production environment.
 # Run with docker-compose -f docker-compose-saml.yaml up
 services:
@@ -14,6 +14,7 @@ services:
       - ~/.ssh:/root/.ssh
     environment:
       - CONFIG_LOCATION=/apps/consoleme/example_config/example_config_credential_auth.yaml
+      - SETUPTOOLS_USE_DISTUTILS=stdlib
     # Run commands to install Consoleme, run the service, and never exit in the event of failure (For dev debugging)
     command: >
       bash -c 'pip install argh watchdog; pip install -e /apps/consoleme/default_plugins;

--- a/docker-compose-oidc.yaml
+++ b/docker-compose-oidc.yaml
@@ -1,4 +1,4 @@
-version: '3'
+version: "3"
 # Never use this in a production environment.
 # Run with docker-compose -f docker-compose-saml.yaml up
 services:
@@ -14,6 +14,7 @@ services:
       - ~/.ssh:/root/.ssh:cached
     environment:
       - CONFIG_LOCATION=/apps/consoleme/example_config/example_config_oidc.yaml
+      - SETUPTOOLS_USE_DISTUTILS=stdlib
     # Run commands to install Consoleme, run the service, and never exit in the event of failure (For dev debugging)
     command: >
       bash -c 'pip install argh watchdog; pip install -e /apps/consoleme/default_plugins;

--- a/docker-compose-saml.yaml
+++ b/docker-compose-saml.yaml
@@ -1,4 +1,4 @@
-version: '3'
+version: "3"
 # Never use this in a production environment.
 # Run with docker-compose -f docker-compose-saml.yaml up
 services:
@@ -14,6 +14,7 @@ services:
       - ~/.ssh:/root/.ssh:cached
     environment:
       - CONFIG_LOCATION=/apps/consoleme/example_config/example_config_saml.yaml
+      - SETUPTOOLS_USE_DISTUTILS=stdlib
     # Run commands to install Consoleme, run the service, and never exit in the event of failure (For dev debugging)
     command: >
       bash -c 'pip install argh watchdog; pip install -e /apps/consoleme/default_plugins;

--- a/docker-compose-test.yaml
+++ b/docker-compose-test.yaml
@@ -1,4 +1,4 @@
-version: '3'
+version: "3"
 # Never use this in a production environment.
 # Run with docker-compose -f docker-compose-test.yaml up
 services:
@@ -6,6 +6,7 @@ services:
     build: .
     environment:
       - CONFIG_LOCATION=/apps/consoleme/example_config/example_config_test.yaml
+      - SETUPTOOLS_USE_DISTUTILS=stdlib
     volumes:
       - .:/apps/consoleme:delegated
       - ~/.aws:/root/.aws:cached

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,4 +1,4 @@
-version: '3'
+version: "3"
 # Never use this in a production environment.
 services:
   consoleme:
@@ -11,8 +11,10 @@ services:
       - .:/apps/consoleme:delegated
       - ~/.aws:/root/.aws:cached
       - ~/.ssh:/root/.ssh:cached
+      - ~/.config/consoleme:/etc/consoleme/
     environment:
       - CONFIG_LOCATION=/apps/consoleme/example_config/example_config_docker_development.yaml
+      - SETUPTOOLS_USE_DISTUTILS=stdlib
     # Run commands to install Consoleme, run the service, and never exit in the event of failure (For dev debugging)
     command: >
       bash -c '/apps/consoleme/node_modules/.bin/webpack --progress --watch &
@@ -25,4 +27,3 @@ services:
     links:
       - consoleme-redis
       - consoleme-dynamodb
-


### PR DESCRIPTION
- [X] Sync ResourceIds (AKA RoleIds) in cache_roles_for_account celery task
- [X] Sync ResourceId (AKA RoleId) when manually refreshing a role's configuration
- [X] Generate double-encoded redirect uri for AWS Config Role timeline
- [X] Add a link to AWS Config Timeline in the IAM Role policy editor
- [X] Add fix for https://github.com/pypa/setuptools/issues/2350 (use SETUPTOOLS_USE_DISTUTILS=stdlib)