### PR TITLE
Use new credential authorization mapping logic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,13 +45,12 @@ bootstrap:
 .PHONY: dynamo
 dynamo:
 	@echo "--> Configuring Dynamo (Make sure local dynamo is enabled on port 8000)"
-	. env/bin/activate || source activate consoleme;\
 	python scripts/initialize_dynamodb_oss.py
 
 .PHONY: redis
 redis:
 	@echo "--> Configuring Redis"
-	. env/bin/activate || source activate consoleme;\
+	@echo "--> Configuring Redis"
 	python scripts/initialize_redis_oss.py
 
 .PHONY: test
@@ -64,7 +63,6 @@ bandit: clean
 
 .PHONY: testhtml
 testhtml: clean
-	. env/bin/activate || source activate consoleme;\
 	CONSOLEME_CONFIG_ENTRYPOINT=default_config $(pytest) $(html_report) && open htmlcov/index.html
 
 .PHONY: clean
@@ -81,7 +79,6 @@ clean:
 
 .PHONY: lint
 lint:
-	. env/bin/activate || source activate consoleme;\
 	$(flake8) $(project) setup.py test
 
 .PHONY: test-lint
@@ -164,7 +161,6 @@ endif
 
 .PHONY: default_plugins
 default_plugins:
-	. env/bin/activate || source activate consoleme;\
 	pip install -e default_plugins
 
 

--- a/example_config/example_config_base.yaml
+++ b/example_config/example_config_base.yaml
@@ -7,14 +7,30 @@ auth_cookie_name: consoleme_auth
 application_admin: consoleme_admins@example.com
 application_name: consoleme
 
-# We support account aliases, which is why the mapping of account names below is a list
-account_ids_to_name:
-  "123456789012":
-    - default_account
+# ConsoleMe needs to know about your AWS accounts. ConsoleMe can retrieve a list of your accounts from the following
+# sources:
+# 1) Config (See the account_ids_to_name key below)
+# 2) AWS Organizations (See the cache_accounts_from_aws_organizations key below)
+# 3) Swag ( https://github.com/Netflix-Skunkworks/swag-api) (See the retrieve_accounts_from_swag key below)
+
+#account_ids_to_name:
+#  "123456789012":
+#    - default_account
 #  "123456789013":
 #    - prod
 #  "123456789014":
 #    - test
+
+#cache_accounts_from_aws_organizations:
+#  # This is the account ID of your AWS organizations master
+#  organizations_master_account_id: "123456789012"
+#  # This is the name of the role that consoleme will attempt to assume on your Organizations master account to retrieve
+#  # account information. Ensure that ConsoleMe can assume this role, and that this role has the permission:
+#  # organizations:listaccounts
+#  organizations_master_role_to_assume: "ConsoleMe"
+
+#retrieve_accounts_from_swag:
+#  base_url: 'https://your_swag_url/'
 
 auth:
   get_groups_by_header: true

--- a/example_config/example_config_test.yaml
+++ b/example_config/example_config_test.yaml
@@ -7,6 +7,10 @@ environment: test
 
 url: http://127.0.0.1:8081
 
+account_ids_to_name:
+  "123456789012":
+    - default_account
+
 celery:
   test_account_ids:
     - "123456789012"

--- a/scripts/initialize_redis_oss.py
+++ b/scripts/initialize_redis_oss.py
@@ -1,21 +1,43 @@
+from asgiref.sync import async_to_sync
+
 from consoleme.celery import celery_tasks as celery
+from consoleme.lib.account_indexers import get_account_id_to_name_mapping
 from consoleme_default_plugins.plugins.celery_tasks import (
     celery_tasks as default_celery_tasks,
 )
 
-# Initialize Redis with an appropriate cache
-# Must have S3 permissions to access Template list.
-# You must also have Celery running. You can run this locally with the following command:
-# celery -A consoleme.celery.celery_tasks worker -l DEBUG -B -E --concurrency=8
+use_celery = False
 
-celery.cache_roles_across_accounts()
-celery.cache_s3_buckets_across_accounts()
-celery.cache_sns_topics_across_accounts()
-celery.cache_sqs_queues_across_accounts()
-celery.cache_policies_table_details()
-celery.cache_managed_policies_across_accounts()
-default_celery_tasks.cache_application_information()
-celery.cache_resources_from_aws_config_across_accounts()
-celery.cache_policies_table_details.apply_async(countdown=180)
-celery.cache_policy_requests()
-print("DONE")
+if use_celery:
+    # Initialize Redis locally. If use_celery is set to `True`, you must be running a celery beat and worker. You can
+    # run this locally with the following command:
+    # `celery -A consoleme.celery.celery_tasks worker -l DEBUG -B -E --concurrency=8`
+
+    celery.cache_roles_across_accounts()
+    celery.cache_s3_buckets_across_accounts()
+    celery.cache_sns_topics_across_accounts()
+    celery.cache_sqs_queues_across_accounts()
+    celery.cache_managed_policies_across_accounts()
+    default_celery_tasks.cache_application_information()
+    celery.cache_resources_from_aws_config_across_accounts()
+    celery.cache_policies_table_details.apply_async(countdown=180)
+    celery.cache_policy_requests()
+    celery.cache_credential_authorization_mapping(countdown=180)
+
+else:
+    celery.cache_cloud_account_mapping()
+    accounts_d = async_to_sync(get_account_id_to_name_mapping)()
+    default_celery_tasks.cache_application_information()
+
+    for account_id in accounts_d.keys():
+        celery.cache_roles_for_account(account_id)
+        celery.cache_s3_buckets_for_account(account_id)
+        celery.cache_sns_topics_for_account(account_id)
+        celery.cache_sqs_queues_for_account(account_id)
+        celery.cache_managed_policies_for_account(account_id)
+        celery.cache_resources_from_aws_config_for_account(account_id)
+    celery.cache_policies_table_details()
+    celery.cache_policy_requests()
+    celery.cache_credential_authorization_mapping()
+
+print("Done caching redis data")


### PR DESCRIPTION
- [X] - Simplify `make install` by not attempting to activate a virtualenv for every call (Expect the user to handle this)
- [X] - Make cloud_credential_authorization_mapping fail cleanly if it cannot retrieve a mapping from redis or s3
- [X] - Replace "get_eligible_roles.from_config" logic with credential_authz_mapping.determine_users_authorized_roles
- [X] - Add comments on the configuration options for generating an account_id -> account_name mapping
- [X] - Enhance initialize_redis_oss logic so that it won't require Celery on
