### PR TITLE
Simplify initial setup process; Attempt to retrieve current account

### DIFF
--- a/.run/Consoleme OSS - Local Celery Beat and Worker.run.xml
+++ b/.run/Consoleme OSS - Local Celery Beat and Worker.run.xml
@@ -1,6 +1,5 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Consoleme OSS - Local Celery Beat and Worker" type="PythonConfigurationType" factoryName="Python">
-    <module name="consoleme-deploy" />
     <option name="INTERPRETER_OPTIONS" value="" />
     <option name="PARENT_ENVS" value="true" />
     <envs>
@@ -8,11 +7,12 @@
       <env name="PYTHONASYNCIODEBUG" value="1" />
       <env name="CONSOLEME_CONFIG_ENTRYPOINT" value="default_config" />
     </envs>
-    <option name="SDK_HOME" value="" />
-    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/consoleme" />
-    <option name="IS_MODULE_SDK" value="true" />
+    <option name="SDK_HOME" value="$PROJECT_DIR$/env/bin/python" />
+    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/" />
+    <option name="IS_MODULE_SDK" value="false" />
     <option name="ADD_CONTENT_ROOTS" value="true" />
     <option name="ADD_SOURCE_ROOTS" value="true" />
+    <module name="" />
     <EXTENSION ID="PythonCoverageRunConfigurationExtension" runner="coverage.py" />
     <EXTENSION ID="net.ashald.envfile">
       <option name="IS_ENABLED" value="false" />

--- a/.run/OSS Unit Tests.run.xml
+++ b/.run/OSS Unit Tests.run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="OSS Unit Tests" type="tests" factoryName="py.test">
-    <module name="consoleme-deploy" />
+    <module name="consoleme" />
     <option name="INTERPRETER_OPTIONS" value="" />
     <option name="PARENT_ENVS" value="true" />
     <envs>
@@ -8,7 +8,7 @@
       <env name="ASYNC_TEST_TIMEOUT" value="60000" />
     </envs>
     <option name="SDK_HOME" value="$PROJECT_DIR$/env/bin/python" />
-    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/consoleme" />
+    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/" />
     <option name="IS_MODULE_SDK" value="false" />
     <option name="ADD_CONTENT_ROOTS" value="true" />
     <option name="ADD_SOURCE_ROOTS" value="true" />
@@ -25,7 +25,7 @@
     </EXTENSION>
     <option name="_new_keywords" value="&quot;&quot;" />
     <option name="_new_parameters" value="&quot;&quot;" />
-    <option name="_new_additionalArguments" value="&quot;-k test_populate_old_policies&quot;" />
+    <option name="_new_additionalArguments" value="&quot;&quot;" />
     <option name="_new_target" value="&quot;$PROJECT_DIR$/consoleme/tests&quot;" />
     <option name="_new_targetType" value="&quot;PATH&quot;" />
     <method v="2" />

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,8 @@ env_install: env/bin/activate
 .PHONY: install
 install: clean
 	make env_install
+	yarn
+	node_modules/webpack/bin/webpack.js --progress
 	make bootstrap
 
 .PHONY: bootstrap
@@ -49,7 +51,6 @@ dynamo:
 
 .PHONY: redis
 redis:
-	@echo "--> Configuring Redis"
 	@echo "--> Configuring Redis"
 	python scripts/initialize_redis_oss.py
 

--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ be interested in implementing. These include:
 ## Quick Start
 
 Docker-Compose is the quickest way to get ConsoleMe up and running locally for testing purposes.
-For development, we highly recommend setting up ConsoleMe locally with the instructions below this Quick Start. 
-The Dockerfile is a great point of reference for the installation process. 
+For development, we highly recommend setting up ConsoleMe locally with the instructions below this Quick Start.
+The Dockerfile is a great point of reference for the installation process.
 If you are going to deploy ConsoleMe in a production environment,
 we recommend deploying it to an isolated, locked-down AWS account.
 
@@ -84,6 +84,14 @@ A local set of Redis and DynamoDB (local) instances need to be set up. These are
 docker-compose -f docker-compose-dependencies.yaml up
 ```
 
+#### Get access to administrative credentials on your account
+
+For an initial setup, we advise making an IAM user with sufficient privileges to allow ConsoleMe to sync your IAM roles,
+S3 buckets, SQS queues, SNS topics, and AWS Config data. Sections below outline the required permissions. See
+[this page](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html) for configuring your user
+credentials. Note: After you have ConsoleMe set up, you should no longer need IAM user credentials. Please set a
+reminder to delete these when you're done with them.
+
 #### Make a virtual environment and run the installation script
 
 In repo root run `make install`. You may also want to install the default plugins if you have not developed internal plugins: `pip install -e default_plugins`
@@ -95,16 +103,14 @@ python3 -m venv env
 # Activate virtualenv
 . env/bin/activate
 
-# Install dependencies
-pip install -r requirements.txt -r requirements-test.txt -e default_plugins -e .
-
-# Install frontend dependencies and build the frontend
-yarn
-node_modules/webpack/bin/webpack.js --progress
-
-# Run the `make install` script, which will create the appropriate DynamoDB tables locally and probably make a futile
-# effort to cache data in Redis. Caching will only work after you've configured ConsoleMe for your environment.
 make install
+# The `make install` step runs the following commands, and attempts to create local dynamo tables:
+#
+# pip install -r requirements.txt -r requirements-test.txt -e default_plugins -e .
+# yarn
+# node_modules/webpack/bin/webpack.js --progress
+# python scripts/initialize_dynamodb_oss.py
+# python scripts/initialize_redis_oss.py
 ```
 
 > You will need to have AWS credentials for the installation to work (they need to be valid credentials for any
@@ -114,7 +120,7 @@ make install
 
 ```bash
 # Run ConsoleMe
-CONFIG_LOCATION=example_config/example_config_development.yaml python consoleme/__main__.py
+python consoleme/__main__.py
 ```
 
 > ConsoleMe requires Python 3.7+. If your virtualenv was installed under Python2.x

--- a/consoleme/celery/celery_tasks.py
+++ b/consoleme/celery/celery_tasks.py
@@ -968,7 +968,7 @@ def cache_sqs_queues_for_account(account_id: str) -> Dict[str, Union[str, int]]:
         client = boto3_cached_conn(
             "sqs",
             account_number=account_id,
-            assume_role=config.get("policies.role_name", "ConsoleMe"),
+            assume_role=config.get("policies.role_name"),
             region=region,
             read_only=True,
         )

--- a/consoleme/lib/account_indexers/__init__.py
+++ b/consoleme/lib/account_indexers/__init__.py
@@ -4,6 +4,7 @@ from consoleme.config import config
 from consoleme.lib.account_indexers.aws_organizations import (
     retrieve_accounts_from_aws_organizations,
 )
+from consoleme.lib.account_indexers.current_account import retrieve_current_account
 from consoleme.lib.account_indexers.local_config import retrieve_accounts_from_config
 from consoleme.lib.account_indexers.swag import retrieve_accounts_from_swag
 from consoleme.lib.cache import (
@@ -32,6 +33,9 @@ async def cache_cloud_accounts() -> CloudAccountModelArray:
         account_mapping = await retrieve_accounts_from_swag()
     elif config.get("cache_cloud_accounts.from_config", True):
         account_mapping = await retrieve_accounts_from_config()
+
+    if not account_mapping or not account_mapping.accounts:
+        account_mapping = await retrieve_current_account()
 
     account_id_to_name = {}
 

--- a/consoleme/lib/account_indexers/current_account.py
+++ b/consoleme/lib/account_indexers/current_account.py
@@ -1,0 +1,27 @@
+import boto3
+
+from consoleme.models import CloudAccountModel, CloudAccountModelArray
+
+
+async def retrieve_current_account() -> CloudAccountModelArray:
+    client = boto3.client("sts")
+    identity = client.get_caller_identity()
+    account_aliases = boto3.client("iam").list_account_aliases()["AccountAliases"]
+    account_id = None
+    if identity and identity.get("Account"):
+        account_id = identity.get("Account")
+    account_name = account_id
+
+    if account_aliases:
+        account_name = account_aliases[0]
+
+    cloud_account = [
+        CloudAccountModel(
+            id=account_id,
+            name=account_name,
+            status="active",
+            sync_enabled=True,
+            type="aws",
+        )
+    ]
+    return CloudAccountModelArray(accounts=cloud_account)

--- a/consoleme/lib/aws_config/aws_config.py
+++ b/consoleme/lib/aws_config/aws_config.py
@@ -43,7 +43,10 @@ def query(
     else:  # Don't use Config aggregator and instead query all the regions on an account
         session = boto3.Session()
         available_regions = session.get_available_regions("config")
-        excluded_regions = config.get("api_protect.exclude_regions", [])
+        excluded_regions = config.get(
+            "api_protect.exclude_regions",
+            ["af-south-1", "ap-east-1", "eu-south-1", "me-south-1"],
+        )
         regions = [x for x in available_regions if x not in excluded_regions]
         for region in regions:
             config_client = boto3_cached_conn(

--- a/default_plugins/consoleme_default_plugins/plugins/config/config.py
+++ b/default_plugins/consoleme_default_plugins/plugins/config/config.py
@@ -1,4 +1,5 @@
 import os
+from typing import List
 
 
 class Config:
@@ -6,8 +7,21 @@ class Config:
     def get_config_location():
         if os.environ.get("CONFIG_LOCATION"):
             return os.environ.get("CONFIG_LOCATION")
-        path = "example_config/example_config_test.yaml"
-        return path
+        config_locations: List[str] = [
+            f"{os.curdir}/consoleme.yaml",
+            os.path.expanduser("~/.config/consoleme/config.yaml"),
+            "/etc/consoleme/config/config.yaml",
+            "example_config/example_config_development.yaml",
+        ]
+        for loc in config_locations:
+            if os.path.exists(loc):
+                return loc
+        raise Exception(
+            "Unable to find ConsoleMe's configuration. It either doesn't exist, or "
+            "ConsoleMe doesn't have permission to access it. Please set the CONFIG_LOCATION environment variable "
+            "to the path of the configuration. Otherwise, ConsoleMe will automatically search for the configuration "
+            f"in these locations: {', '.join(config_locations)}"
+        )
 
     @staticmethod
     def internal_functions(cfg=None):

--- a/example_config/example_config_development.yaml
+++ b/example_config/example_config_development.yaml
@@ -1,6 +1,9 @@
 extends:
   - example_config_header_auth.yaml
 
+environment: dev
+development: true
+
 # A development configuration can specify a specific user to impersonate locally.
 _development_user_override: consoleme_admin@example.com
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,6 +21,8 @@ from moto import (
 )
 from tornado.concurrent import Future
 
+# This must be set before loading ConsoleMe's configuration
+os.environ["CONFIG_LOCATION"] = "example_config/example_config_test.yaml"  # noqa: E402
 from consoleme.config import config
 
 MOCK_ROLE = {


### PR DESCRIPTION
- [X] Simplified PyCharm run configurations to not expect submodule configuration
- [X] `make install` now installs node dependencies (yarn) and generates Frontend files with Webpack
- [X] README advises getting administrative credentials when initially configuring ConsoleMe
- [X] Simplified setup process in README 
- [X] Created a default configuration file lookup, defaulting to example_config_development.yaml
- [X] Added logic to retrieve AWS account information for the credentials currently in use, if available. During the `make install` process, we will add this account to our account mapping and will attempt to use these credentials to sync resources from the account.
- [] Document configuration file lookup order
- [] Add consoleme.yaml to gitignore