### PR TITLE
fixing spelling of cloudtrail and link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ and report Celery metrics. We have tasks that perform the following:
 
 - Cache IAM roles, SQS queues, SNS topics, and S3 buckets to Redis/DDB
 - Report Celery Last Success Metrics (Used for alerting on failed tasks)
-- Cache Cloudtrail Errors by ARN (This requires an internal celery task to aggregate Cloutrail errors from your
+- Cache Cloudtrail Errors by ARN (This requires an internal celery task to aggregate Cloudtrail errors from your
   preferred source)
 
 Netflix's internal celery tasks handle a variety of additional requirements that you may
@@ -45,7 +45,7 @@ BEFORE RUNNING THE COMMAND BELOW: We highly recommend that you put valid AWS cre
 using the default profile.
 
 The role you use should have the permissions outlined under the
-[ConsoleMeInstanceProfile configuration](####ConsoleMeInstanceProfile configuration) section. These credentials will be shared with the container, and when you start
+[ConsoleMeInstanceProfile configuration](#consolemepnstanceprofile-configuration) section. These credentials will be shared with the container, and when you start
 the containers, it will attempt to populate your redis cache with live resources from your account. Please
 
 ```bash


### PR DESCRIPTION
fixing spelling of cloudtrail and link in README.md