### PR TITLE
Automatically load default plugins if unconfigured

### DIFF
--- a/consoleme/__main__.py
+++ b/consoleme/__main__.py
@@ -17,7 +17,7 @@ from consoleme.routes import make_app
 
 logging.basicConfig(level=logging.DEBUG, format=config.get("logging.format"))
 logging.getLogger("urllib3.connectionpool").setLevel(logging.CRITICAL)
-stats = get_plugin_by_name(config.get("plugins.metrics"))()
+stats = get_plugin_by_name(config.get("plugins.metrics", "default_metrics"))()
 log = config.get_logger()
 
 

--- a/consoleme/celery/celery_tasks.py
+++ b/consoleme/celery/celery_tasks.py
@@ -105,12 +105,18 @@ if config.get("celery.purge"):
 
 log = config.get_logger()
 red = async_to_sync(RedisHandler().redis)()
-aws = get_plugin_by_name(config.get("plugins.aws"))
-auth = get_plugin_by_name(config.get("plugins.auth"))()
-group_mapping = get_plugin_by_name(config.get("plugins.group_mapping"))()
-internal_celery_tasks = get_plugin_by_name(config.get("plugins.internal_celery_tasks"))
-stats = get_plugin_by_name(config.get("plugins.metrics"))()
-internal_policies = get_plugin_by_name(config.get("plugins.internal_policies"))()
+aws = get_plugin_by_name(config.get("plugins.aws", "default_aws"))
+auth = get_plugin_by_name(config.get("plugins.auth", "default_auth"))()
+group_mapping = get_plugin_by_name(
+    config.get("plugins.group_mapping", "default_group_mapping")
+)()
+internal_celery_tasks = get_plugin_by_name(
+    config.get("plugins.internal_celery_tasks", "default_celery_tasks")
+)
+stats = get_plugin_by_name(config.get("plugins.metrics", "default_metrics"))()
+internal_policies = get_plugin_by_name(
+    config.get("plugins.internal_policies", "default_policies")
+)()
 REDIS_IAM_COUNT = 1000
 
 

--- a/consoleme/exceptions/exceptions.py
+++ b/consoleme/exceptions/exceptions.py
@@ -5,7 +5,7 @@ from consoleme.config import config
 from consoleme.lib.plugins import get_plugin_by_name
 
 log = config.get_logger("consoleme")
-stats = get_plugin_by_name(config.get("plugins.metrics"))()
+stats = get_plugin_by_name(config.get("plugins.metrics", "default_metrics"))()
 
 
 class BaseException(Exception):

--- a/consoleme/handlers/base.py
+++ b/consoleme/handlers/base.py
@@ -34,9 +34,11 @@ from consoleme.lib.saml import authenticate_user_by_saml
 from consoleme.lib.tracing import ConsoleMeTracer
 
 log = config.get_logger()
-stats = get_plugin_by_name(config.get("plugins.metrics"))()
-auth = get_plugin_by_name(config.get("plugins.auth"))()
-group_mapping = get_plugin_by_name(config.get("plugins.group_mapping"))()
+stats = get_plugin_by_name(config.get("plugins.metrics", "default_metrics"))()
+auth = get_plugin_by_name(config.get("plugins.auth", "default_auth"))()
+group_mapping = get_plugin_by_name(
+    config.get("plugins.group_mapping", "default_group_mapping")
+)()
 
 
 class BaseJSONHandler(tornado.web.RequestHandler):

--- a/consoleme/handlers/v1/credentials.py
+++ b/consoleme/handlers/v1/credentials.py
@@ -12,13 +12,15 @@ from consoleme.lib.crypto import Crypto
 from consoleme.lib.duo import duo_mfa_user
 from consoleme.lib.plugins import get_plugin_by_name
 
-stats = get_plugin_by_name(config.get("plugins.metrics"))()
+stats = get_plugin_by_name(config.get("plugins.metrics", "default_metrics"))()
 log = config.get_logger()
 crypto = Crypto()
-aws = get_plugin_by_name(config.get("plugins.aws"))()
+aws = get_plugin_by_name(config.get("plugins.aws", "default_aws"))()
 internal_config = config.config_plugin
-auth = get_plugin_by_name(config.get("plugins.auth"))()
-group_mapping = get_plugin_by_name(config.get("plugins.group_mapping"))()
+auth = get_plugin_by_name(config.get("plugins.auth", "default_auth"))()
+group_mapping = get_plugin_by_name(
+    config.get("plugins.group_mapping", "default_group_mapping")
+)()
 
 
 class CredentialsSchema(Schema):

--- a/consoleme/handlers/v1/headers.py
+++ b/consoleme/handlers/v1/headers.py
@@ -4,7 +4,7 @@ from consoleme.config import config
 from consoleme.handlers.base import BaseHandler, BaseMtlsHandler
 from consoleme.lib.plugins import get_plugin_by_name
 
-stats = get_plugin_by_name(config.get("plugins.metrics"))()
+stats = get_plugin_by_name(config.get("plugins.metrics", "default_metrics"))()
 log = config.get_logger()
 
 

--- a/consoleme/handlers/v1/policies.py
+++ b/consoleme/handlers/v1/policies.py
@@ -12,9 +12,9 @@ from consoleme.lib.plugins import get_plugin_by_name
 from consoleme.lib.redis import redis_get, redis_hgetall
 
 log = config.get_logger()
-stats = get_plugin_by_name(config.get("plugins.metrics"))()
-aws = get_plugin_by_name(config.get("plugins.aws"))()
-auth = get_plugin_by_name(config.get("plugins.auth"))()
+stats = get_plugin_by_name(config.get("plugins.metrics", "default_metrics"))()
+aws = get_plugin_by_name(config.get("plugins.aws", "default_aws"))()
+auth = get_plugin_by_name(config.get("plugins.auth", "default_auth"))()
 
 
 class AutocompleteHandler(BaseAPIV1Handler):

--- a/consoleme/handlers/v1/roles.py
+++ b/consoleme/handlers/v1/roles.py
@@ -5,10 +5,10 @@ from consoleme.handlers.base import BaseMtlsHandler
 from consoleme.lib.crypto import Crypto
 from consoleme.lib.plugins import get_plugin_by_name
 
-stats = get_plugin_by_name(config.get("plugins.metrics"))()
+stats = get_plugin_by_name(config.get("plugins.metrics", "default_metrics"))()
 log = config.get_logger()
 crypto = Crypto()
-auth = get_plugin_by_name(config.get("plugins.auth"))()
+auth = get_plugin_by_name(config.get("plugins.auth", "default_auth"))()
 
 
 class GetRolesHandler(BaseMtlsHandler):

--- a/consoleme/handlers/v1/saml.py
+++ b/consoleme/handlers/v1/saml.py
@@ -13,10 +13,10 @@ from consoleme.lib.saml import init_saml_auth, prepare_tornado_request_for_saml
 if config.get("auth.get_user_by_saml"):
     from onelogin.saml2.utils import OneLogin_Saml2_Utils
 
-stats = get_plugin_by_name(config.get("plugins.metrics"))()
+stats = get_plugin_by_name(config.get("plugins.metrics", "default_metrics"))()
 log = config.get_logger()
 crypto = Crypto()
-auth = get_plugin_by_name(config.get("plugins.auth"))()
+auth = get_plugin_by_name(config.get("plugins.auth", "default_auth"))()
 
 
 class SamlHandler(BaseHandler):

--- a/consoleme/handlers/v2/dynamic_config.py
+++ b/consoleme/handlers/v2/dynamic_config.py
@@ -15,8 +15,8 @@ from consoleme.lib.plugins import get_plugin_by_name
 
 ddb = UserDynamoHandler()
 log = config.get_logger()
-stats = get_plugin_by_name(config.get("plugins.metrics"))()
-aws = get_plugin_by_name(config.get("plugins.aws"))()
+stats = get_plugin_by_name(config.get("plugins.metrics", "default_metrics"))()
+aws = get_plugin_by_name(config.get("plugins.aws", "default_aws"))()
 
 
 class DynamicConfigApiHandler(BaseHandler):

--- a/consoleme/handlers/v2/errors.py
+++ b/consoleme/handlers/v2/errors.py
@@ -2,7 +2,7 @@ from consoleme.config import config
 from consoleme.handlers.base import BaseAPIV2Handler
 from consoleme.lib.plugins import get_plugin_by_name
 
-stats = get_plugin_by_name(config.get("plugins.metrics"))()
+stats = get_plugin_by_name(config.get("plugins.metrics", "default_metrics"))()
 
 log = config.get_logger()
 

--- a/consoleme/handlers/v2/generate_changes.py
+++ b/consoleme/handlers/v2/generate_changes.py
@@ -11,7 +11,7 @@ from consoleme.lib.plugins import get_plugin_by_name
 from consoleme.models import ChangeGeneratorModelArray
 
 log = config.get_logger()
-stats = get_plugin_by_name(config.get("plugins.metrics"))()
+stats = get_plugin_by_name(config.get("plugins.metrics", "default_metrics"))()
 
 
 class GenerateChangesHandler(BaseAPIV2Handler):

--- a/consoleme/handlers/v2/generate_policy.py
+++ b/consoleme/handlers/v2/generate_policy.py
@@ -2,7 +2,7 @@ from consoleme.config import config
 from consoleme.handlers.base import BaseAPIV2Handler
 from consoleme.lib.plugins import get_plugin_by_name
 
-stats = get_plugin_by_name(config.get("plugins.metrics"))()
+stats = get_plugin_by_name(config.get("plugins.metrics", "default_metrics"))()
 log = config.get_logger()
 
 BASE_INLINE_POLICY = {"Statement": [{"Action": [], "Effect": "Allow", "Resource": []}]}

--- a/consoleme/handlers/v2/index.py
+++ b/consoleme/handlers/v2/index.py
@@ -7,9 +7,9 @@ from consoleme.lib.loader import WebpackLoader
 from consoleme.lib.plugins import get_plugin_by_name
 
 log = config.get_logger()
-aws = get_plugin_by_name(config.get("plugins.aws"))()
-auth = get_plugin_by_name(config.get("plugins.auth"))()
-stats = get_plugin_by_name(config.get("plugins.metrics"))()
+aws = get_plugin_by_name(config.get("plugins.aws", "default_aws"))()
+auth = get_plugin_by_name(config.get("plugins.auth", "default_auth"))()
+stats = get_plugin_by_name(config.get("plugins.metrics", "default_metrics"))()
 
 
 # TODO, move followings to util file

--- a/consoleme/handlers/v2/policies.py
+++ b/consoleme/handlers/v2/policies.py
@@ -10,7 +10,7 @@ from consoleme.lib.plugins import get_plugin_by_name
 from consoleme.lib.policies import get_url_for_resource
 from consoleme.lib.timeout import Timeout
 
-stats = get_plugin_by_name(config.get("plugins.metrics"))()
+stats = get_plugin_by_name(config.get("plugins.metrics", "default_metrics"))()
 log = config.get_logger()
 
 

--- a/consoleme/handlers/v2/requests.py
+++ b/consoleme/handlers/v2/requests.py
@@ -47,9 +47,9 @@ from consoleme.models import (
     RequestStatus,
 )
 
-stats = get_plugin_by_name(config.get("plugins.metrics"))()
+stats = get_plugin_by_name(config.get("plugins.metrics", "default_metrics"))()
 log = config.get_logger()
-aws = get_plugin_by_name(config.get("plugins.aws"))()
+aws = get_plugin_by_name(config.get("plugins.aws", "default_aws"))()
 
 
 class RequestHandler(BaseAPIV2Handler):

--- a/consoleme/handlers/v2/resources.py
+++ b/consoleme/handlers/v2/resources.py
@@ -12,11 +12,15 @@ from consoleme.lib.aws import fetch_resource_details
 from consoleme.lib.plugins import get_plugin_by_name
 
 log = config.get_logger()
-stats = get_plugin_by_name(config.get("plugins.metrics"))()
-aws = get_plugin_by_name(config.get("plugins.aws"))()
-group_mapping = get_plugin_by_name(config.get("plugins.group_mapping"))()
-auth = get_plugin_by_name(config.get("plugins.auth"))()
-internal_policies = get_plugin_by_name(config.get("plugins.internal_policies"))()
+stats = get_plugin_by_name(config.get("plugins.metrics", "default_metrics"))()
+aws = get_plugin_by_name(config.get("plugins.aws", "default_aws"))()
+group_mapping = get_plugin_by_name(
+    config.get("plugins.group_mapping", "default_group_mapping")
+)()
+auth = get_plugin_by_name(config.get("plugins.auth", "default_auth"))()
+internal_policies = get_plugin_by_name(
+    config.get("plugins.internal_policies", "default_policies")
+)()
 
 
 class ResourceDetailHandler(BaseHandler):

--- a/consoleme/handlers/v2/roles.py
+++ b/consoleme/handlers/v2/roles.py
@@ -16,13 +16,17 @@ from consoleme.lib.plugins import get_plugin_by_name
 from consoleme.lib.v2.roles import get_role_details
 from consoleme.models import CloneRoleRequestModel, RoleCreationRequestModel
 
-stats = get_plugin_by_name(config.get("plugins.metrics"))()
+stats = get_plugin_by_name(config.get("plugins.metrics", "default_metrics"))()
 log = config.get_logger()
 crypto = Crypto()
-auth = get_plugin_by_name(config.get("plugins.auth"))()
-aws = get_plugin_by_name(config.get("plugins.aws"))()
-group_mapping = get_plugin_by_name(config.get("plugins.group_mapping"))()
-internal_policies = get_plugin_by_name(config.get("plugins.internal_policies"))()
+auth = get_plugin_by_name(config.get("plugins.auth", "default_auth"))()
+aws = get_plugin_by_name(config.get("plugins.aws", "default_aws"))()
+group_mapping = get_plugin_by_name(
+    config.get("plugins.group_mapping", "default_group_mapping")
+)()
+internal_policies = get_plugin_by_name(
+    config.get("plugins.internal_policies", "default_policies")
+)()
 
 
 class RoleConsoleLoginHandler(BaseAPIV2Handler):

--- a/consoleme/handlers/v2/user_profile.py
+++ b/consoleme/handlers/v2/user_profile.py
@@ -9,7 +9,7 @@ from consoleme.lib.auth import (
 from consoleme.lib.generic import get_random_security_logo, is_in_group
 from consoleme.lib.plugins import get_plugin_by_name
 
-stats = get_plugin_by_name(config.get("plugins.metrics"))()
+stats = get_plugin_by_name(config.get("plugins.metrics", "default_metrics"))()
 log = config.get_logger()
 
 

--- a/consoleme/lib/account_indexers/__init__.py
+++ b/consoleme/lib/account_indexers/__init__.py
@@ -15,8 +15,8 @@ from consoleme.lib.plugins import get_plugin_by_name
 from consoleme.models import CloudAccountModelArray
 
 log = config.get_logger(__name__)
-auth = get_plugin_by_name(config.get("plugins.auth"))()
-stats = get_plugin_by_name(config.get("plugins.metrics"))()
+auth = get_plugin_by_name(config.get("plugins.auth", "default_auth"))()
+stats = get_plugin_by_name(config.get("plugins.metrics", "default_metrics"))()
 
 
 async def cache_cloud_accounts() -> CloudAccountModelArray:

--- a/consoleme/lib/account_indexers/swag.py
+++ b/consoleme/lib/account_indexers/swag.py
@@ -10,7 +10,7 @@ from consoleme.lib.plugins import get_plugin_by_name
 from consoleme.models import CloudAccountModel, CloudAccountModelArray
 
 log = config.get_logger()
-stats = get_plugin_by_name(config.get("plugins.metrics"))()
+stats = get_plugin_by_name(config.get("plugins.metrics", "default_metrics"))()
 
 
 async def retrieve_accounts_from_swag() -> CloudAccountModelArray:

--- a/consoleme/lib/auth.py
+++ b/consoleme/lib/auth.py
@@ -14,7 +14,7 @@ from consoleme.lib.generic import is_in_group
 from consoleme.lib.plugins import get_plugin_by_name
 
 crypto = Crypto()
-stats = get_plugin_by_name(config.get("plugins.metrics"))()
+stats = get_plugin_by_name(config.get("plugins.metrics", "default_metrics"))()
 log = config.get_logger()
 
 

--- a/consoleme/lib/aws.py
+++ b/consoleme/lib/aws.py
@@ -32,8 +32,8 @@ ALL_IAM_MANAGED_POLICIES: dict = {}
 ALL_IAM_MANAGED_POLICIES_LAST_UPDATE: int = 0
 
 log = config.get_logger(__name__)
-auth = get_plugin_by_name(config.get("plugins.auth"))()
-stats = get_plugin_by_name(config.get("plugins.metrics"))()
+auth = get_plugin_by_name(config.get("plugins.auth", "default_auth"))()
+stats = get_plugin_by_name(config.get("plugins.metrics", "default_metrics"))()
 
 
 @rate_limited()

--- a/consoleme/lib/aws_config/aws_config.py
+++ b/consoleme/lib/aws_config/aws_config.py
@@ -9,7 +9,7 @@ from consoleme.exceptions.exceptions import MissingConfigurationValue
 from consoleme.lib.plugins import get_plugin_by_name
 
 log = config.get_logger()
-stats = get_plugin_by_name(config.get("plugins.metrics"))()
+stats = get_plugin_by_name(config.get("plugins.metrics", "default_metrics"))()
 
 
 def query(

--- a/consoleme/lib/cache.py
+++ b/consoleme/lib/cache.py
@@ -15,7 +15,7 @@ from consoleme.lib.redis import RedisHandler
 from consoleme.lib.s3_helpers import get_object, put_object
 
 red = RedisHandler().redis_sync()
-stats = get_plugin_by_name(config.get("plugins.metrics"))()
+stats = get_plugin_by_name(config.get("plugins.metrics", "default_metrics"))()
 
 
 async def store_json_results_in_redis_and_s3(

--- a/consoleme/lib/change_request.py
+++ b/consoleme/lib/change_request.py
@@ -25,7 +25,9 @@ from consoleme.models import (
     Status,
 )
 
-group_mapping = get_plugin_by_name(config.get("plugins.group_mapping"))()
+group_mapping = get_plugin_by_name(
+    config.get("plugins.group_mapping", "default_group_mapping")
+)()
 ALL_ACCOUNTS = None
 
 

--- a/consoleme/lib/cloud_credential_authorization_mapping/internal_plugin.py
+++ b/consoleme/lib/cloud_credential_authorization_mapping/internal_plugin.py
@@ -14,7 +14,9 @@ class InternalPluginAuthorizationMappingGenerator(CredentialAuthzMappingGenerato
         self, authorization_mapping: Dict[user_or_group, RoleAuthorizations]
     ) -> Dict[user_or_group, RoleAuthorizations]:
         """This will list accounts that meet the account attribute search criteria."""
-        group_mapping = get_plugin_by_name(config.get("plugins.group_mapping"))()
+        group_mapping = get_plugin_by_name(
+            config.get("plugins.group_mapping", "default_group_mapping")
+        )()
 
         # Generate mapping from internal plugin
         authorization_mapping = (

--- a/consoleme/lib/crypto.py
+++ b/consoleme/lib/crypto.py
@@ -6,7 +6,7 @@ from consoleme.config import config
 from consoleme.lib.plugins import get_plugin_by_name
 
 log = config.get_logger("consoleme")
-stats = get_plugin_by_name(config.get("plugins.metrics"))()
+stats = get_plugin_by_name(config.get("plugins.metrics", "default_metrics"))()
 
 
 class Crypto:

--- a/consoleme/lib/duo.py
+++ b/consoleme/lib/duo.py
@@ -8,7 +8,7 @@ from botocore.exceptions import ClientError
 from consoleme.config import config
 from consoleme.lib.plugins import get_plugin_by_name
 
-stats = get_plugin_by_name(config.get("plugins.metrics"))()
+stats = get_plugin_by_name(config.get("plugins.metrics", "default_metrics"))()
 log = config.get_logger()
 
 

--- a/consoleme/lib/dynamo.py
+++ b/consoleme/lib/dynamo.py
@@ -43,7 +43,7 @@ POSSIBLE_STATUSES = config.get(
     ["pending", "approved", "rejected", "cancelled", "expired", "removed"],
 )
 
-stats = get_plugin_by_name(config.get("plugins.metrics"))()
+stats = get_plugin_by_name(config.get("plugins.metrics", "default_metrics"))()
 log = config.get_logger("consoleme")
 crypto = Crypto()
 red = RedisHandler().redis_sync()

--- a/consoleme/lib/google.py
+++ b/consoleme/lib/google.py
@@ -29,10 +29,10 @@ from consoleme.lib.dynamo import UserDynamoHandler
 from consoleme.lib.groups import does_group_require_bg_check
 from consoleme.lib.plugins import get_plugin_by_name
 
-stats = get_plugin_by_name(config.get("plugins.metrics"))()
+stats = get_plugin_by_name(config.get("plugins.metrics", "default_metrics"))()
 
 log = config.get_logger()
-auth = get_plugin_by_name(config.get("plugins.auth"))()
+auth = get_plugin_by_name(config.get("plugins.auth", "default_auth"))()
 
 
 async def add_user_to_group_task(

--- a/consoleme/lib/handler_utils.py
+++ b/consoleme/lib/handler_utils.py
@@ -6,8 +6,8 @@ from consoleme.config import config
 from consoleme.lib.account_indexers import get_account_id_to_name_mapping
 from consoleme.lib.plugins import get_plugin_by_name
 
-aws = get_plugin_by_name(config.get("plugins.aws"))()
-stats = get_plugin_by_name(config.get("plugins.metrics"))()
+aws = get_plugin_by_name(config.get("plugins.aws", "default_aws"))()
+stats = get_plugin_by_name(config.get("plugins.metrics", "default_metrics"))()
 log = config.get_logger()
 
 # ALL ACCOUNTS is a dictionary of account ID to a list of account names (including aliases)

--- a/consoleme/lib/policies.py
+++ b/consoleme/lib/policies.py
@@ -30,7 +30,7 @@ from consoleme.lib.ses import (
 from consoleme.models import ExtendedRequestModel, RequestStatus
 
 log = config.get_logger()
-stats = get_plugin_by_name(config.get("plugins.metrics"))()
+stats = get_plugin_by_name(config.get("plugins.metrics", "default_metrics"))()
 
 
 async def invalid_characters_in_policy(policy_value):
@@ -531,7 +531,7 @@ def get_actions_for_resource(resource_arn: str, statement: Dict) -> List[str]:
 
 
 async def get_formatted_policy_changes(account_id, arn, request):
-    aws = get_plugin_by_name(config.get("plugins.aws"))()
+    aws = get_plugin_by_name(config.get("plugins.aws", "default_aws"))()
     existing_role: dict = await aws.fetch_iam_role(account_id, arn, force_refresh=True)
     policy_changes: list = json.loads(request.get("policy_changes"))
     formatted_policy_changes = []
@@ -636,7 +636,7 @@ async def get_formatted_policy_changes(account_id, arn, request):
 
 
 async def should_auto_approve_policy(events, user, user_groups):
-    aws = get_plugin_by_name(config.get("plugins.aws"))()
+    aws = get_plugin_by_name(config.get("plugins.aws", "default_aws"))()
     result = await aws.should_auto_approve_policy(events, user, user_groups)
     return result
 
@@ -648,7 +648,7 @@ async def should_auto_approve_policy_v2(
     This uses your fancy internal logic to determine if a request should be auto-approved or not. The default plugin
     set included in ConsoleMe OSS will return False.
     """
-    aws = get_plugin_by_name(config.get("plugins.aws"))()
+    aws = get_plugin_by_name(config.get("plugins.aws", "default_aws"))()
     return await aws.should_auto_approve_policy_v2(extended_request, user, user_groups)
 
 

--- a/consoleme/lib/redis.py
+++ b/consoleme/lib/redis.py
@@ -13,7 +13,7 @@ from consoleme.lib.plugins import get_plugin_by_name
 
 region = config.region
 log = config.get_logger()
-stats = get_plugin_by_name(config.get("plugins.metrics"))()
+stats = get_plugin_by_name(config.get("plugins.metrics", "default_metrics"))()
 
 automatically_backup_to_s3 = config.get(
     "redis.automatically_backup_to_s3.enabled", False

--- a/consoleme/lib/requests.py
+++ b/consoleme/lib/requests.py
@@ -11,7 +11,7 @@ from consoleme.lib.cache import store_json_results_in_redis_and_s3
 from consoleme.lib.dynamo import UserDynamoHandler
 from consoleme.lib.plugins import get_plugin_by_name
 
-auth = get_plugin_by_name(config.get("plugins.auth"))()
+auth = get_plugin_by_name(config.get("plugins.auth", "default_auth"))()
 
 
 async def can_approve_reject_request(user, secondary_approvers, groups):

--- a/consoleme/lib/role_updater/handler.py
+++ b/consoleme/lib/role_updater/handler.py
@@ -11,7 +11,7 @@ from consoleme.lib.plugins import get_plugin_by_name
 from consoleme.lib.role_updater.schemas import RoleUpdaterRequest
 
 log = config.get_logger()
-stats = get_plugin_by_name(config.get("plugins.metrics"))()
+stats = get_plugin_by_name(config.get("plugins.metrics", "default_metrics"))()
 
 
 async def update_role(event):

--- a/consoleme/lib/s3_helpers.py
+++ b/consoleme/lib/s3_helpers.py
@@ -12,7 +12,7 @@ from consoleme.config import config
 from consoleme.lib.plugins import get_plugin_by_name
 
 log = config.get_logger("consoleme")
-stats = get_plugin_by_name(config.get("plugins.metrics"))()
+stats = get_plugin_by_name(config.get("plugins.metrics", "default_metrics"))()
 
 
 @rate_limited()

--- a/consoleme/lib/ses.py
+++ b/consoleme/lib/ses.py
@@ -10,7 +10,7 @@ from consoleme.lib.groups import get_group_url
 from consoleme.lib.plugins import get_plugin_by_name
 from consoleme.models import ExtendedRequestModel, RequestStatus
 
-stats = get_plugin_by_name(config.get("plugins.metrics"))()
+stats = get_plugin_by_name(config.get("plugins.metrics", "default_metrics"))()
 log = config.get_logger()
 
 

--- a/consoleme/lib/v2/requests.py
+++ b/consoleme/lib/v2/requests.py
@@ -74,8 +74,8 @@ from consoleme.models import (
 )
 
 log = config.get_logger()
-auth = get_plugin_by_name(config.get("plugins.auth"))()
-aws = get_plugin_by_name(config.get("plugins.aws"))()
+auth = get_plugin_by_name(config.get("plugins.auth", "default_auth"))()
+aws = get_plugin_by_name(config.get("plugins.aws", "default_aws"))()
 
 
 async def generate_request_from_change_model_array(

--- a/consoleme/lib/v2/roles.py
+++ b/consoleme/lib/v2/roles.py
@@ -21,12 +21,14 @@ from consoleme.models import (
     S3ErrorArray,
 )
 
-stats = get_plugin_by_name(config.get("plugins.metrics"))()
+stats = get_plugin_by_name(config.get("plugins.metrics", "default_metrics"))()
 log = config.get_logger()
 crypto = Crypto()
-auth = get_plugin_by_name(config.get("plugins.auth"))()
-aws = get_plugin_by_name(config.get("plugins.aws"))()
-internal_policies = get_plugin_by_name(config.get("plugins.internal_policies"))()
+auth = get_plugin_by_name(config.get("plugins.auth", "default_auth"))()
+aws = get_plugin_by_name(config.get("plugins.aws", "default_aws"))()
+internal_policies = get_plugin_by_name(
+    config.get("plugins.internal_policies", "default_policies")
+)()
 red = RedisHandler().redis_sync()
 
 

--- a/consoleme/routes.py
+++ b/consoleme/routes.py
@@ -63,7 +63,9 @@ from consoleme.handlers.v2.user_profile import UserProfileHandler
 from consoleme.lib.auth import mk_jwks_validator
 from consoleme.lib.plugins import get_plugin_by_name
 
-internal_routes = get_plugin_by_name(config.get("plugins.internal_routes"))()
+internal_routes = get_plugin_by_name(
+    config.get("plugins.internal_routes", "default_internal_routes")
+)()
 
 log = config.get_logger()
 

--- a/default_plugins/consoleme_default_plugins/plugins/auth/auth.py
+++ b/default_plugins/consoleme_default_plugins/plugins/auth/auth.py
@@ -14,7 +14,7 @@ from consoleme.lib.generic import str2bool
 from consoleme.lib.plugins import get_plugin_by_name
 
 log = config.get_logger("consoleme")
-stats = get_plugin_by_name(config.get("plugins.metrics"))()
+stats = get_plugin_by_name(config.get("plugins.metrics", "default_metrics"))()
 
 
 class Group(object):

--- a/default_plugins/consoleme_default_plugins/plugins/aws/aws.py
+++ b/default_plugins/consoleme_default_plugins/plugins/aws/aws.py
@@ -31,7 +31,7 @@ from consoleme.lib.dynamo import IAMRoleDynamoHandler
 from consoleme.lib.plugins import get_plugin_by_name
 from consoleme.lib.redis import RedisHandler
 
-stats = get_plugin_by_name(config.get("plugins.metrics"))()
+stats = get_plugin_by_name(config.get("plugins.metrics", "default_metrics"))()
 
 log = config.get_logger(__name__)
 

--- a/default_plugins/consoleme_default_plugins/plugins/group_mapping/group_mapping.py
+++ b/default_plugins/consoleme_default_plugins/plugins/group_mapping/group_mapping.py
@@ -17,8 +17,8 @@ from consoleme.lib.plugins import get_plugin_by_name
 from consoleme.lib.redis import RedisHandler
 
 log = config.get_logger("consoleme")
-aws = get_plugin_by_name(config.get("plugins.aws"))()
-stats = get_plugin_by_name(config.get("plugins.metrics"))()
+aws = get_plugin_by_name(config.get("plugins.aws", "default_aws"))()
+stats = get_plugin_by_name(config.get("plugins.metrics", "default_metrics"))()
 credential_authz_mapping = CredentialAuthorizationMapping()
 
 # TODO: Docstrings should provide examples of the data that needs to be returned

--- a/default_plugins/consoleme_default_plugins/plugins/internal_routes/handlers/internal_demo_route.py
+++ b/default_plugins/consoleme_default_plugins/plugins/internal_routes/handlers/internal_demo_route.py
@@ -2,7 +2,7 @@ from consoleme.config import config
 from consoleme.handlers.base import BaseHandler
 from consoleme.lib.plugins import get_plugin_by_name
 
-stats = get_plugin_by_name(config.get("plugins.metrics"))()
+stats = get_plugin_by_name(config.get("plugins.metrics", "default_metrics"))()
 log = config.get_logger()
 
 

--- a/example_config/example_config_base.yaml
+++ b/example_config/example_config_base.yaml
@@ -103,16 +103,18 @@ support_contact: consoleme-support@example.com
 support_chat_url: https://www.example.com/slack/channel
 documentation_page: https://github.com/Netflix/consoleme/
 
-plugins:
-  auth: default_auth
-  aws: default_aws
-  group_mapping: default_group_mapping
-  internal_celery_tasks: default_celery_tasks
-  internal_celery_tasks_functions: default_celery_tasks_functions
-  metrics: default_metrics
-  internal_config: config
-  internal_routes: default_internal_routes
-  internal_policies: default_policies
+# If you wish to override the entry-points to any of the default plugins with your own
+# plugin set that you `pip install`ed into ConsoleMe, you can modify this configuration to point to the applicable
+# entry point
+#plugins:
+#  auth: default_auth
+#  aws: default_aws
+#  group_mapping: default_group_mapping
+#  internal_celery_tasks: default_celery_tasks
+#  metrics: default_metrics
+#  internal_config: config
+#  internal_routes: default_internal_routes
+#  internal_policies: default_policies
 
 logging_levels:
   asyncio: WARNING

--- a/tests/lib/test_requests.py
+++ b/tests/lib/test_requests.py
@@ -9,7 +9,7 @@ from consoleme.exceptions.exceptions import NoMatchingRequest
 from consoleme.lib.plugins import get_plugin_by_name
 from tests.conftest import create_future
 
-auth = get_plugin_by_name(config.get("plugins.auth"))()
+auth = get_plugin_by_name(config.get("plugins.auth", "default_auth"))()
 
 Group = auth.Group
 


### PR DESCRIPTION
This PR removes the need to specify which plugin set you will be using. By default, the `default_plugins` will be used. Users can write their own custom plugins and modify their consoleme configuration if they wish to deviate from the default_plugins set.