### PR TITLE
Set active page to 1 when using server side filtering in datatable

### DIFF
--- a/ui/src/components/blocks/ConsoleMeDataTable.js
+++ b/ui/src/components/blocks/ConsoleMeDataTable.js
@@ -431,6 +431,7 @@ class ConsoleMeDataTable extends Component {
       expandedRow: null,
       filteredData,
       loading: false,
+      activePage: 1,
     });
   }
 


### PR DESCRIPTION
This fixes #248 