### PR TITLE
Fix broken link in quick-start/docker.md

### DIFF
--- a/docs/gitbook/quick-start/docker.md
+++ b/docs/gitbook/quick-start/docker.md
@@ -46,7 +46,7 @@ After this is done, visit `http://localhost:8081`. You may notice the page is ra
 docker container logs -f consoleme_consoleme-celery_1
 ```
 
-By default, you're running ConsoleMe as an administrator, using the local [Docker development configuration](https://github.com/Netflix/consoleme/tree/cd6e5cd6fba4c8d5cf0b9474f58e6c34055d56c6/docs/gitbook/quick-start/example_config/example_config_docker_development.yaml)**.** This configuration does not implement authn/authz and is not intended to be used in a production environment.
+By default, you're running ConsoleMe as an administrator, using the local [Docker development configuration](https://github.com/Netflix/consoleme/blob/6914fdffb5ff6b42fb3b8338723b7fd95dce0ae6/example_config/example_config_docker_development.yaml)**.** This configuration does not implement authn/authz and is not intended to be used in a production environment.
 
 If successful, ConsoleMe should have been able to cache all of your resources. But you'll notice that you're unable to access any IAM roles with the default configuration. This is because we cannot generate an authorization mapping
 

--- a/docs/gitbook/quick-start/docker.md
+++ b/docs/gitbook/quick-start/docker.md
@@ -46,7 +46,7 @@ After this is done, visit `http://localhost:8081`. You may notice the page is ra
 docker container logs -f consoleme_consoleme-celery_1
 ```
 
-By default, you're running ConsoleMe as an administrator, using the local [Docker development configuration](https://github.com/Netflix/consoleme/blob/6914fdffb5ff6b42fb3b8338723b7fd95dce0ae6/example_config/example_config_docker_development.yaml)**.** This configuration does not implement authn/authz and is not intended to be used in a production environment.
+By default, you're running ConsoleMe as an administrator, using the local [Docker development configuration](https://github.com/Netflix/consoleme/blob/master/example_config/example_config_docker_development.yaml)**.** This configuration does not implement authn/authz and is not intended to be used in a production environment.
 
 If successful, ConsoleMe should have been able to cache all of your resources. But you'll notice that you're unable to access any IAM roles with the default configuration. This is because we cannot generate an authorization mapping
 


### PR DESCRIPTION
Currently, https://hawkins.gitbook.io/consoleme/quick-start/docker link here is broken. This PR fixes the broken link.