### PR TITLE
first attempt to fix logo sizing issue

### DIFF
--- a/ui/src/components/Sidebar.js
+++ b/ui/src/components/Sidebar.js
@@ -135,11 +135,11 @@ const ConsoleMeSidebar = () => {
           {consoleme_logo && (
             <a href={"/"} rel="noopener noreferrer" target="_blank">
               <Image
-                  style={{
-                    height: "250px",
-                    margin: "auto"
-                  }}
-                  src={consoleme_logo}
+                style={{
+                  height: "250px",
+                  margin: "auto",
+                }}
+                src={consoleme_logo}
               />
             </a>
           )}

--- a/ui/src/components/Sidebar.js
+++ b/ui/src/components/Sidebar.js
@@ -134,7 +134,13 @@ const ConsoleMeSidebar = () => {
         <Menu.Item>
           {consoleme_logo && (
             <a href={"/"} rel="noopener noreferrer" target="_blank">
-              <Image size="medium" src={consoleme_logo} />
+              <Image
+                  style={{
+                    height: "250px",
+                    margin: "auto"
+                  }}
+                  src={consoleme_logo}
+              />
             </a>
           )}
           <br />


### PR DESCRIPTION
We will need to strip all the CSS to separate files later but this is the first attempt to address the image size issue we are seeing on the sidebar. The problems are we didn't have a fixed size for logos and the images have different sizes.