### PR TITLE
Support ec oidc algs

### DIFF
--- a/consoleme/lib/auth.py
+++ b/consoleme/lib/auth.py
@@ -269,7 +269,7 @@ def mk_jwt_validator(
             )
         except jwt.InvalidSignatureError:
             raise AuthenticationError("Invalid Token Signature")
-        except jwt.ExpiredSignature:
+        except jwt.ExpiredSignatureError:
             raise AuthenticationError("Token Expired")
         except jwt.InvalidAudienceError:
             raise AuthenticationError("Invalid Token Audience")

--- a/consoleme/lib/jwt.py
+++ b/consoleme/lib/jwt.py
@@ -37,7 +37,7 @@ async def validate_and_return_jwt_token(auth_cookie):
     if not jwt_secret:
         raise Exception(f"{config.get('jwt_secret')} configuration value is not set.")
     try:
-        decoded_jwt = jwt.decode(auth_cookie, jwt_secret, algorithm="HS256")
+        decoded_jwt = jwt.decode(auth_cookie, jwt_secret, algorithms="HS256")
         email = decoded_jwt.get(config.get("jwt.attributes.email", "email"))
         groups = decoded_jwt.get(config.get("jwt.attributes.groups", "groups"), [])
         exp = decoded_jwt.get("exp")

--- a/consoleme/lib/oidc.py
+++ b/consoleme/lib/oidc.py
@@ -6,7 +6,7 @@ import jwt
 import pytz
 import tornado.httpclient
 import ujson as json
-from jwt.algorithms import RSAAlgorithm
+from jwt.algorithms import ECAlgorithm, RSAAlgorithm
 from jwt.exceptions import DecodeError
 from tornado import httputil
 
@@ -64,10 +64,18 @@ async def populate_oidc_config():
         },
     )
     oidc_config["jwks_data"] = json.loads(res.body)
-    oidc_config["jwt_keys"] = {
-        k["kid"]: RSAAlgorithm.from_jwk(json.dumps(k))
-        for k in oidc_config["jwks_data"]["keys"]
-    }
+    oidc_config["jwt_keys"] = {}
+    for k in oidc_config["jwks_data"]["keys"]:
+        key_type = k["kty"]
+        key_id = k["kid"]
+        if key_type == "RSA":
+            oidc_config["jwt_keys"][key_id] = RSAAlgorithm.from_jwk(json.dumps(k))
+        elif key_type == "EC":
+            oidc_config["jwt_keys"][key_id] = ECAlgorithm.from_jwk(json.dumps(k))
+    # oidc_config["jwt_keys"] = {
+    #     k["kid"]: RSAAlgorithm.from_jwk(json.dumps(k))
+    #     for k in oidc_config["jwks_data"]["keys"]
+    # }
 
     return oidc_config
 
@@ -165,7 +173,7 @@ async def authenticate_user_by_oidc(request):
                 "get_user_by_oidc_settings.access_token_response_key", "access_token"
             )
         )
-        jwt_verify = config.get("get_user_by_oidc_settings.jwt_verify")
+        jwt_verify = config.get("get_user_by_oidc_settings.jwt_verify", True)
         if jwt_verify:
             header = jwt.get_unverified_header(id_token)
             key_id = header["kid"]
@@ -180,7 +188,7 @@ async def authenticate_user_by_oidc(request):
                 id_token,
                 pub_key,
                 audience=oidc_config["client_id"],
-                algorithm=algorithm,
+                algorithms=algorithm,
             )
 
             email = decoded_id_token.get(
@@ -204,9 +212,9 @@ async def authenticate_user_by_oidc(request):
                     audience=config.get(
                         "get_user_by_oidc_settings.access_token_audience"
                     ),
-                    algorithm=algorithm,
+                    algorithms=algorithm,
                 )
-            except DecodeError as e:
+            except (DecodeError, KeyError) as e:
                 # This exception occurs when the access token is not JWT-parsable. It is expected with some IdPs.
                 log.debug(
                     {

--- a/consoleme/lib/oidc.py
+++ b/consoleme/lib/oidc.py
@@ -72,11 +72,6 @@ async def populate_oidc_config():
             oidc_config["jwt_keys"][key_id] = RSAAlgorithm.from_jwk(json.dumps(k))
         elif key_type == "EC":
             oidc_config["jwt_keys"][key_id] = ECAlgorithm.from_jwk(json.dumps(k))
-    # oidc_config["jwt_keys"] = {
-    #     k["kid"]: RSAAlgorithm.from_jwk(json.dumps(k))
-    #     for k in oidc_config["jwks_data"]["keys"]
-    # }
-
     return oidc_config
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -43,7 +43,7 @@ elasticsearch-dsl==7.2.1  # via -r requirements.in
 elasticsearch==7.9.1      # via -r requirements.in, elasticsearch-dsl
 email-validator==1.1.1    # via pydantic
 flagpole==1.1.1           # via cloudaux
-furl==2.1.0
+furl==2.1.0               # via -r requirements.in
 genson==1.2.1             # via datamodel-code-generator
 gitdb==4.0.5              # via gitpython
 gitpython==3.1.8          # via -r requirements.in
@@ -74,7 +74,7 @@ jsonschema==3.2.0         # via -r requirements.in, openapi-spec-validator
 kombu==4.6.11             # via -r requirements.in, celery
 lazy-object-proxy==1.4.3  # via astroid
 logmatic-python==0.1.7    # via -r requirements.in
-lxml==4.5.2               # via -r requirements.in, xmlsec
+lxml==4.6.2               # via -r requirements.in, xmlsec
 markupsafe==1.1.1         # via jinja2
 marshmallow==3.7.1        # via -r requirements.in
 mccabe==0.6.1             # via pylint
@@ -84,6 +84,7 @@ numpy==1.19.2             # via pandas
 okta-jwt==1.3.5           # via -r requirements.in
 openapi-spec-validator==0.2.8  # via datamodel-code-generator
 ordered-set==4.0.2        # via deepdiff
+orderedmultidict==1.0.1   # via furl
 packaging==20.4           # via bleach
 pandas==0.25.3            # via -r requirements.in
 parso==0.7.1              # via jedi
@@ -105,7 +106,7 @@ pycparser==2.20           # via cffi
 pycurl==7.43.0.6          # via -r requirements.in
 pydantic[email]==1.5.1    # via -r requirements.in, datamodel-code-generator
 pygments==2.6.1           # via ipython
-pyjwt==1.7.1              # via -r requirements.in
+pyjwt==2.0.0              # via -r requirements.in
 pylint==2.6.0             # via -r requirements.in
 pyparsing==2.4.7          # via packaging
 pyrsistent==0.17.2        # via jsonschema
@@ -129,7 +130,7 @@ schema==0.7.3             # via policy-sentry
 semver==2.10.2            # via prance
 sentry-sdk==0.16.1        # via -r requirements.in
 simplejson==3.17.2        # via -r requirements.in
-six==1.15.0               # via -r requirements.in, astroid, bleach, cloudaux, ecdsa, elasticsearch-dsl, google-api-core, google-api-python-client, google-auth, google-auth-httplib2, google-resumable-media, isodate, jsonschema, okta-jwt, openapi-spec-validator, packaging, prance, presto-python-client, protobuf, python-dateutil, python-jose, retrying, tenacity
+six==1.15.0               # via -r requirements.in, astroid, bleach, cloudaux, ecdsa, elasticsearch-dsl, furl, google-api-core, google-api-python-client, google-auth, google-auth-httplib2, google-resumable-media, isodate, jsonschema, okta-jwt, openapi-spec-validator, orderedmultidict, packaging, prance, presto-python-client, protobuf, python-dateutil, python-jose, retrying, tenacity
 smmap==3.0.4              # via gitdb
 soupsieve==2.0.1          # via beautifulsoup4
 tenacity==6.2.0           # via -r requirements.in


### PR DESCRIPTION
This change adds supports for decoding elliptic curve keys from JSON Web Keys. These are commonly used to sign oidc/oauth2 metadata.

- [X] Update pyjwt which supports decoding EC keys from JWKs
- [X] Add support to decode EC keys from JWKs
- [X] Force JWT verification by default when authenticating users by OIDC
- [X] Update lxml to resolve vulnerability described here: https://github.com/advisories/GHSA-pgww-xf46-h92r