### PR TITLE
Downgrade python-json-logger

### DIFF
--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -40,7 +40,7 @@ markupsafe==1.1.1
     #   jinja2
 mkdocs-material-extensions==1.0.1
     # via mkdocs-material
-mkdocs-material==6.2.4
+mkdocs-material==6.2.5
     # via
     #   -r requirements-docs.in
     #   mkdocs-material-extensions

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -189,7 +189,7 @@ cryptography==3.3.1
     #   moto
     #   python-jose
     #   sshpubkeys
-datamodel-code-generator==0.6.20
+datamodel-code-generator==0.6.21
     # via
     #   -c requirements.txt
     #   -r requirements.txt
@@ -347,7 +347,7 @@ httplib2==0.18.1
     #   -r requirements.txt
     #   google-api-python-client
     #   google-auth-httplib2
-identify==1.5.12
+identify==1.5.13
     # via pre-commit
 idna==2.10
     # via
@@ -415,7 +415,7 @@ jsondiff==1.2.0
     # via moto
 jsonpatch==1.28
     # via cfn-lint
-jsonpickle==1.4.2
+jsonpickle==1.5.0
     # via aws-xray-sdk
 jsonpointer==2.0
     # via jsonpatch
@@ -645,7 +645,7 @@ pygments==2.7.4
     #   -r requirements.txt
     #   ipython
     #   readme-renderer
-pyjwt==2.0.0
+pyjwt==2.0.1
     # via
     #   -c requirements.txt
     #   -r requirements.txt
@@ -670,7 +670,7 @@ pysnooper==0.4.2
     #   datamodel-code-generator
 pytest-asyncio==0.14.0
     # via -r requirements-test.in
-pytest-cov==2.10.1
+pytest-cov==2.11.0
     # via -r requirements-test.in
 pytest-forked==1.3.0
     # via pytest-xdist
@@ -712,7 +712,7 @@ python-jose[cryptography]==3.2.0
     #   -r requirements.txt
     #   moto
     #   okta-jwt
-python-json-logger==2.0.1
+python-json-logger==0.1.11
     # via
     #   -c requirements.txt
     #   -r requirements.txt

--- a/requirements.in
+++ b/requirements.in
@@ -38,6 +38,7 @@ pydantic
 pyjwt
 pylint
 python-dateutil
+python-json-logger==0.1.11 # Needed until this is merged and new version created: https://github.com/madzak/python-json-logger/pull/113
 python3-saml
 pytz
 redis

--- a/requirements.txt
+++ b/requirements.txt
@@ -82,7 +82,7 @@ cloudaux==1.9.0
     # via -r requirements.in
 contextlib2==0.6.0.post1
     # via schema
-datamodel-code-generator==0.6.20
+datamodel-code-generator==0.6.21
     # via -r requirements.in
 decorator==4.4.2
     # via
@@ -276,7 +276,7 @@ pydantic[email]==1.7.3
     #   datamodel-code-generator
 pygments==2.7.4
     # via ipython
-pyjwt==2.0.0
+pyjwt==2.0.1
     # via -r requirements.in
 pylint==2.6.0
     # via -r requirements.in
@@ -294,8 +294,10 @@ python-dateutil==2.8.1
     #   pandas
 python-jose==3.2.0
     # via okta-jwt
-python-json-logger==2.0.1
-    # via logmatic-python
+python-json-logger==0.1.11
+    # via
+    #   -r requirements.in
+    #   logmatic-python
 python3-saml==1.10.0
     # via -r requirements.in
 pytz==2020.5


### PR DESCRIPTION
Downgrading python-json-logger due to an issue building Wheels for it. A PR was submitted to address the issue here: https://github.com/madzak/python-json-logger/pull/113

Also ran `make up-reqs` to pick up the latest packages where possible.