### PR TITLE
Use lodash instead of loadash ; Upgrade node in Dockerfile

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -14,7 +14,7 @@ jobs:
           python-version: 3.8
       - name: Install dependencies
         run: |
-          curl -sL https://deb.nodesource.com/setup_10.x | sudo bash
+          curl -sL https://deb.nodesource.com/setup_14.x | sudo bash
           curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
           echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
           sudo apt-get update

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /apps/consoleme
 ENV NODE_OPTIONS="--max-old-space-size=20000"
 ENV SETUPTOOLS_USE_DISTUTILS=stdlib
 # Install dependencies
-RUN curl -sL https://deb.nodesource.com/setup_10.x | bash
+RUN curl -sL https://deb.nodesource.com/setup_14.x | bash
 RUN apt-get clean
 RUN apt-get update
 RUN apt-get install build-essential libxml2-dev libxmlsec1-dev libxmlsec1-openssl musl-dev libcurl4-nss-dev python3-dev nodejs -y

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Cloud administrators can [**create/clone IAM roles**](https://hawkins.gitbook.io
 
 Users can access most of your cloud resources in the AWS Console with a [**single click**](https://hawkins.gitbook.io/consoleme/feature-videos/policy-management/multi-account-policies-management).
 Cloud administrators can configure ConsoleMe to authenticate users through [**ALB Authentication**](https://hawkins.gitbook.io/consoleme/configuration/authentication-and-authorization/alb-auth), [**OIDC/OAuth2**](https://hawkins.gitbook.io/consoleme/configuration/authentication-and-authorization/oidc-oauth2-okta), or [**SAML**](https://hawkins.gitbook.io/consoleme/configuration/authentication-and-authorization/saml-auth0).
+
 … And more. Check out our [docs](https://hawkins.gitbook.io/consoleme/) to get started.
 
 ## Project resources

--- a/ui/package.json
+++ b/ui/package.json
@@ -9,7 +9,7 @@
     "axios": "^0.21.1",
     "brace": "^0.11.1",
     "js-cookie": "^2.2.1",
-    "loadash": "^1.0.0",
+    "lodash": "^4.17.20",
     "monaco-editor": "0.21.3",
     "monaco-editor-webpack-plugin": "^2.1.0",
     "qs": "^6.9.6",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ui",
   "version": "0.1.0",
-  "private": true,
+  "private": false,
   "dependencies": {
     "@testing-library/jest-dom": "^5.11.9",
     "@testing-library/react": "^11.2.3",
@@ -66,6 +66,6 @@
     "prettier": "^2.2.1"
   },
   "author": "infrasec",
-  "license": "UNLICENSED",
+  "license": "Apache-2.0",
   "proxy": "http://localhost:8081"
 }


### PR DESCRIPTION
Loadash shouldn't be used. It's a reserved name pointing to lodash, but we see a warning recommending lodash usage instead: https://www.npmjs.com/package/loadash

Upgrade Node in dockerfile to latest 14.x LTS