### PR TITLE
fix authentication cookie issue

### DIFF
--- a/ui/src/App.js
+++ b/ui/src/App.js
@@ -15,83 +15,91 @@ import ConsoleLogin from "./components/ConsoleLogin";
 import ConsoleMeChallengeValidator from "./components/challenge/ConsoleMeChallengeValidator";
 import CreateCloneFeature from "./components/roles/CreateCloneFeature";
 import NoMatch from "./components/NoMatch";
+import AuthenticateModal from "./components/AuthenticateModal";
 
 function App() {
   return (
     <BrowserRouter>
-      <AuthProvider>
-        <ConsoleMeHeader />
-        <ConsoleMeSidebar />
-        <Switch>
-          <ProtectedRoute
-            key="roles"
-            exact
-            path="/"
-            component={ConsoleMeSelectRoles}
-          />
-          <ProtectedRoute
-            key="selfservice"
-            exact
-            path="/selfservice"
-            component={ConsoleMeSelfService}
-          />
-          <ProtectedRoute
-            key="policies"
-            exact
-            path="/policies"
-            component={ConsoleMePolicyTable}
-          />
-          <ProtectedRoute
-            key="review"
-            exact
-            path="/policies/request/:requestID"
-            component={PolicyRequestReview}
-          />
-          <ProtectedRoute
-            key="requests"
-            exact
-            path="/requests"
-            component={ConsoleMeRequestTable}
-          />
-          <ProtectedRoute
-            key="iamrole_policy"
-            path="/policies/edit/:accountID/:serviceType/:region/:resourceName"
-            component={PolicyEditor}
-          />
-          <ProtectedRoute
-            key="resource_policy"
-            path="/policies/edit/:accountID/:serviceType/:resourceName"
-            component={PolicyEditor}
-          />
-          <ProtectedRoute
-            key="config"
-            exact
-            path="/config"
-            component={ConsoleMeDynamicConfig}
-          />
-          <ProtectedRoute
-            key="role_query"
-            exact
-            path="/role/:roleQuery+"
-            component={ConsoleLogin}
-          />
-          <ProtectedRoute
-            key="challenge_validator"
-            exact
-            path="/challenge_validator/:challengeToken"
-            component={ConsoleMeChallengeValidator}
-          />
-          <ProtectedRoute
-            key="create_role"
-            exact
-            path="/create_role"
-            component={CreateCloneFeature}
-          />
-          <Route component={NoMatch} />
-        </Switch>
-      </AuthProvider>
+      <ConsoleMeHeader />
+      <ConsoleMeSidebar />
+      <Switch>
+        <ProtectedRoute
+          key="roles"
+          exact
+          path="/"
+          component={ConsoleMeSelectRoles}
+        />
+        <ProtectedRoute
+          key="selfservice"
+          exact
+          path="/selfservice"
+          component={ConsoleMeSelfService}
+        />
+        <ProtectedRoute
+          key="policies"
+          exact
+          path="/policies"
+          component={ConsoleMePolicyTable}
+        />
+        <ProtectedRoute
+          key="review"
+          exact
+          path="/policies/request/:requestID"
+          component={PolicyRequestReview}
+        />
+        <ProtectedRoute
+          key="requests"
+          exact
+          path="/requests"
+          component={ConsoleMeRequestTable}
+        />
+        <ProtectedRoute
+          key="iamrole_policy"
+          path="/policies/edit/:accountID/:serviceType/:region/:resourceName"
+          component={PolicyEditor}
+        />
+        <ProtectedRoute
+          key="resource_policy"
+          path="/policies/edit/:accountID/:serviceType/:resourceName"
+          component={PolicyEditor}
+        />
+        <ProtectedRoute
+          key="config"
+          exact
+          path="/config"
+          component={ConsoleMeDynamicConfig}
+        />
+        <ProtectedRoute
+          key="role_query"
+          exact
+          path="/role/:roleQuery+"
+          component={ConsoleLogin}
+        />
+        <ProtectedRoute
+          key="challenge_validator"
+          exact
+          path="/challenge_validator/:challengeToken"
+          component={ConsoleMeChallengeValidator}
+        />
+        <ProtectedRoute
+          key="create_role"
+          exact
+          path="/create_role"
+          component={CreateCloneFeature}
+        />
+        <Route component={NoMatch} />
+      </Switch>
+      <AuthenticateModal />
     </BrowserRouter>
   );
 }
 
-export default App;
+const AuthWrapper = () => {
+  return (
+    <AuthProvider>
+      <App />
+    </AuthProvider>
+  );
+};
+
+export default AuthWrapper;

--- a/ui/src/auth/AuthProviderDefault.js
+++ b/ui/src/auth/AuthProviderDefault.js
@@ -1,7 +1,9 @@
 import React, { createContext, useContext, useReducer } from "react";
+import { getCookie } from "../helpers/utils";
 
 const initialAuthState = {
   user: null, // user profile data
+  isSessionExpired: false,
 };
 
 const AuthContext = createContext(initialAuthState);
@@ -21,6 +23,13 @@ const reducer = (state, action) => {
       return {
         ...state,
         user: null,
+      };
+    }
+    case "SESSION_EXPIRED": {
+      const { isSessionExpired } = action;
+      return {
+        ...state,
+        isSessionExpired,
       };
     }
     default: {
@@ -44,14 +53,9 @@ export const AuthProvider = ({ children }) => {
     if (auth.type === "redirect") {
       window.location.href = auth.redirect_url;
     }
+
     // User is now authenticated so retrieve user profile.
-    const xsrf = document.cookie.match("_xsrf=([^;]*)");
-    const user = await sendRequestTarget(
-      null,
-      "/api/v2/user_profile",
-      "get",
-      xsrf
-    );
+    const user = await sendRequestCommon(null, "/api/v2/user_profile", "get");
     dispatch({
       type: "LOGIN",
       user,
@@ -64,63 +68,188 @@ export const AuthProvider = ({ children }) => {
     });
   };
 
+  const setIsSessionExpired = (isSessionExpired) => {
+    dispatch({
+      type: "SESSION_EXPIRED",
+      isSessionExpired,
+    });
+  };
+
+  const sendRequestCommon = async (
+    json,
+    location = window.location.href,
+    method = "post"
+  ) => {
+    let body = null;
+
+    if (json) {
+      body = JSON.stringify(json);
+    }
+
+    if (state.isSessionExpired) {
+      return null;
+    }
+
+    const xsrf = getCookie("_xsrf");
+    return fetch(location, {
+      method: method,
+      headers: {
+        "Content-type": "application/json",
+        "X-Xsrftoken": xsrf,
+        "X-Requested-With": "XMLHttpRequest",
+        Accept: "application/json",
+      },
+      body: body,
+    })
+      .then((response) => {
+        if (
+          response.status === 403 &&
+          response.type === "redirect" &&
+          response.reason === "unauthenticated"
+        ) {
+          fetch("/auth?redirect_url=" + window.location.href, {
+            headers: {
+              "X-Requested-With": "XMLHttpRequest",
+              Accept: "application/json",
+            },
+          }).then((resp) => {
+            if (resp.type === "redirect") {
+              window.location.href = resp.redirect_url;
+            }
+          });
+        } else if (response.status === 401) {
+          setIsSessionExpired(true);
+        }
+
+        if (response.ok) {
+          return response.json();
+        } else {
+          throw new Error(response);
+        }
+      })
+      .then((data) => {
+        return data;
+      })
+      .catch((error) => {
+        console.error(`Exception Raised: ${error}`);
+        return null;
+      });
+  };
+
+  const sendRequestV2 = async (requestV2) => {
+    const response = await sendRequestCommon(requestV2, "/api/v2/request");
+
+    if (response) {
+      const { request_created, request_id, request_url, errors } = response;
+      if (request_created === true) {
+        if (requestV2.admin_auto_approve && errors === 0) {
+          return {
+            message: `Successfully created and applied request: [${request_id}](${request_url}).`,
+            request_created,
+            error: false,
+          };
+        } else if (errors === 0) {
+          return {
+            message: `Successfully created request: [${request_id}](${request_url}).`,
+            request_created,
+            error: false,
+          };
+        } else {
+          return {
+            // eslint-disable-next-line max-len
+            message: `This request was created and partially successful: : [${request_id}](${request_url}). But the server reported some errors with the request: ${JSON.stringify(
+              response
+            )}`,
+            request_created,
+            error: true,
+          };
+        }
+      }
+      return {
+        message: `Server reported an error with the request: ${JSON.stringify(
+          response
+        )}`,
+        request_created,
+        error: true,
+      };
+    } else {
+      return {
+        message: `"Failed to submit request: ${JSON.stringify(response)}`,
+        request_created: false,
+        error: true,
+      };
+    }
+  };
+
+  const sendProposedPolicyWithHooks = async (
+    command,
+    change,
+    newStatement,
+    requestID,
+    setIsLoading,
+    setButtonResponseMessage,
+    reloadDataFromBackend
+  ) => {
+    setIsLoading(true);
+    const request = {
+      modification_model: {
+        command,
+        change_id: change.id,
+      },
+    };
+    if (newStatement) {
+      request.modification_model.policy_document = JSON.parse(newStatement);
+    }
+    await sendRequestCommon(
+      request,
+      "/api/v2/requests/" + requestID,
+      "PUT"
+    ).then((response) => {
+      if (!response) {
+        return;
+      }
+      if (
+        response.status === 403 ||
+        response.status === 400 ||
+        response.status === 500
+      ) {
+        // Error occurred making the request
+        setIsLoading(false);
+        setButtonResponseMessage([
+          {
+            status: "error",
+            message: response.message,
+          },
+        ]);
+      } else {
+        // Successful request
+        setIsLoading(false);
+        setButtonResponseMessage(
+          response.action_results.reduce((resultsReduced, result) => {
+            if (result.visible === true) {
+              resultsReduced.push(result);
+            }
+            return resultsReduced;
+          }, [])
+        );
+        reloadDataFromBackend();
+      }
+    });
+  };
+
   return (
     <AuthContext.Provider
       value={{
         ...state,
         login,
         logout,
+        setIsSessionExpired,
+        sendRequestCommon,
+        sendRequestV2,
+        sendProposedPolicyWithHooks,
       }}
     >
       {children}
     </AuthContext.Provider>
   );
 };
-
-export async function sendRequestTarget(
-  json,
-  location = window.location.href,
-  method = "post",
-  xsrf
-) {
-  let body = null;
-  if (json) {
-    body = JSON.stringify(json);
-  }
-  const rawResponse = await fetch(location, {
-    method: method,
-    headers: {
-      "Content-type": "application/json",
-      "X-Xsrftoken": xsrf,
-      "X-Requested-With": "XMLHttpRequest",
-      Accept: "application/json",
-    },
-    body: body,
-  });
-  const response = await rawResponse;
-
-  let resJson;
-  try {
-    resJson = await response.json();
-    if (
-      response.status === 403 &&
-      resJson.type === "redirect" &&
-      resJson.reason === "unauthenticated"
-    ) {
-      const auth = await fetch("/auth?redirect_url=" + window.location.href, {
-        headers: {
-          "X-Requested-With": "XMLHttpRequest",
-          Accept: "application/json",
-        },
-      }).then((res) => res.json());
-      // redirect to IDP for authentication.
-      if (auth.type === "redirect") {
-        window.location.href = auth.redirect_url;
-      }
-    }
-  } catch (e) {
-    resJson = response;
-  }
-
-  return resJson;
-}

--- a/ui/src/auth/ProtectedRoute.js
+++ b/ui/src/auth/ProtectedRoute.js
@@ -4,7 +4,8 @@ import { Route, useRouteMatch } from "react-router-dom";
 import { Segment } from "semantic-ui-react";
 
 const ProtectedRoute = (props) => {
-  const { login, user } = useAuth();
+  const auth = useAuth();
+  const { login, user } = auth;
   const match = useRouteMatch(props);
   const { component: Component, ...rest } = props;
 
@@ -43,7 +44,7 @@ const ProtectedRoute = (props) => {
       <Route
         {...rest}
         render={(props) => {
-          return <Component {...props} {...rest} />;
+          return <Component {...props} {...rest} {...auth} />;
         }}
       />
     </Segment>

--- a/ui/src/components/AuthenticateModal.js
+++ b/ui/src/components/AuthenticateModal.js
@@ -1,0 +1,37 @@
+import React from "react";
+import { Button, Modal } from "semantic-ui-react";
+import { useAuth } from "../auth/AuthProviderDefault";
+
+const AuthenticateModal = () => {
+  const { isSessionExpired, setIsSessionExpired } = useAuth();
+
+  const reloadPage = () => {
+    window.location.reload(true);
+  };
+
+  return (
+    <Modal
+      onClose={() => setIsSessionExpired(false)}
+      onOpen={() => setIsSessionExpired(true)}
+      open={isSessionExpired}
+      closeOnDimmerClick={false}
+    >
+      <Modal.Header>Session Expired</Modal.Header>
+      <Modal.Content>
+        <Modal.Description>
+          You have been logged out. Please press the button to refresh you log
+          back.
+        </Modal.Description>
+      </Modal.Content>
+      <Modal.Actions>
+        <Button
+          content="Refresh and log me back in"
+          onClick={reloadPage}
+          negative
+        />
+      </Modal.Actions>
+    </Modal>
+  );
+};
+
+export default AuthenticateModal;

--- a/ui/src/components/AuthenticateModal.js
+++ b/ui/src/components/AuthenticateModal.js
@@ -19,16 +19,11 @@ const AuthenticateModal = () => {
       <Modal.Header>Session Expired</Modal.Header>
       <Modal.Content>
         <Modal.Description>
-          You have been logged out. Please press the button to refresh you log
-          back.
+          Your authenticated session has expired. Please re-authenticate.
         </Modal.Description>
       </Modal.Content>
       <Modal.Actions>
-        <Button
-          content="Refresh and log me back in"
-          onClick={reloadPage}
-          negative
-        />
+        <Button content="Re-Authenticate" onClick={reloadPage} negative />
       </Modal.Actions>
     </Modal>
   );

--- a/ui/src/components/ConsoleLogin.js
+++ b/ui/src/components/ConsoleLogin.js
@@ -1,7 +1,8 @@
 import React, { useCallback, useEffect, useState } from "react";
 import { useParams, useLocation } from "react-router-dom";
 import { Icon, Message } from "semantic-ui-react";
-import { delay, sendRequestCommon, setRecentRoles } from "../helpers/utils";
+import { delay, setRecentRoles } from "../helpers/utils";
+import { useAuth } from "../auth/AuthProviderDefault";
 
 const signOutUrl = "https://signin.aws.amazon.com/oauth?Action=logout";
 
@@ -9,6 +10,7 @@ const ConsoleLogin = () => {
   const { search } = useLocation();
   const { roleQuery } = useParams();
   const [errorMessage, setErrorMessage] = useState("");
+  const { sendRequestCommon } = useAuth();
 
   const onSignIn = useCallback(async () => {
     const roleData = await sendRequestCommon(
@@ -16,14 +18,20 @@ const ConsoleLogin = () => {
       "/api/v2/role_login/" + roleQuery + search,
       "get"
     );
+
+    if (!roleData) {
+      return;
+    }
+
     if (roleData.type === "redirect") {
       if (roleData.reason === "console_login") {
         setRecentRoles(roleData.role);
       }
       window.location.assign(roleData.redirect_url);
     }
+
     setErrorMessage(roleData.message);
-  }, [roleQuery, search]);
+  }, [roleQuery, search, sendRequestCommon]);
 
   useEffect(() => {
     (async () => {

--- a/ui/src/components/DynamicConfig.js
+++ b/ui/src/components/DynamicConfig.js
@@ -9,12 +9,13 @@ import {
   Message,
   Divider,
 } from "semantic-ui-react";
-import { sendRequestCommon } from "../helpers/utils";
+import { useAuth } from "../auth/AuthProviderDefault";
 
 function ConsoleMeDynamicConfig() {
   const [config, setConfig] = useState("");
   const [configSha256, setConfigSha256] = useState("");
   const [statusMessage, setStatusMessage] = useState(null);
+  const { sendRequestCommon } = useAuth();
 
   useEffect(() => {
     async function fetchDynamicConfig() {
@@ -23,11 +24,14 @@ function ConsoleMeDynamicConfig() {
         "/api/v2/dynamic_config",
         "get"
       );
+      if (!resJson) {
+        return;
+      }
       setConfigSha256(resJson.sha256);
       setConfig(resJson.dynamicConfig);
     }
     fetchDynamicConfig();
-  }, []);
+  }, [sendRequestCommon]);
 
   const updateConfig = async () => {
     const res = await sendRequestCommon(

--- a/ui/src/components/Sidebar.js
+++ b/ui/src/components/Sidebar.js
@@ -18,7 +18,6 @@ const listRecentRoles = (recentRoles, user) => {
     return (
       <Menu.Item as={NavLink} name={role} key={role} to={"/role/" + role}>
         <Header
-          as="a"
           color="blue"
           style={{
             fontSize: "14px",
@@ -27,9 +26,9 @@ const listRecentRoles = (recentRoles, user) => {
           <Header.Content>
             {accountName ? accountName : accountNumber}
             <Header.Subheader
-              as="a"
               style={{
                 fontSize: "14px",
+                color: "grey",
               }}
             >
               {roleName}

--- a/ui/src/components/blocks/AssumeRolePolicyChangeComponent.js
+++ b/ui/src/components/blocks/AssumeRolePolicyChangeComponent.js
@@ -10,10 +10,7 @@ import {
   Segment,
 } from "semantic-ui-react";
 import MonacoDiffComponent from "./MonacoDiffComponent";
-import {
-  sendProposedPolicy,
-  sortAndStringifyNestedJSONObject,
-} from "../../helpers/utils";
+import { sortAndStringifyNestedJSONObject } from "../../helpers/utils";
 
 class AssumeRolePolicyChangeComponent extends Component {
   constructor(props) {
@@ -46,7 +43,6 @@ class AssumeRolePolicyChangeComponent extends Component {
     this.onLintError = this.onLintError.bind(this);
     this.onValueChange = this.onValueChange.bind(this);
     this.onSubmitChange = this.onSubmitChange.bind(this);
-    this.sendProposedPolicy = sendProposedPolicy.bind(this);
     this.updatePolicyDocument = props.updatePolicyDocument;
     this.reloadDataFromBackend = props.reloadDataFromBackend;
   }
@@ -110,7 +106,11 @@ class AssumeRolePolicyChangeComponent extends Component {
   }
 
   onSubmitChange() {
-    this.sendProposedPolicy("apply_change");
+    const applyChange = this.props.sendProposedPolicy.bind(
+      this,
+      "apply_change"
+    );
+    applyChange();
   }
 
   render() {
@@ -157,7 +157,7 @@ class AssumeRolePolicyChangeComponent extends Component {
             positive
             fluid
             disabled={isError || noChangesDetected}
-            onClick={sendProposedPolicy.bind(this, "update_change")}
+            onClick={this.props.sendProposedPolicy.bind(this, "update_change")}
           />
         </Grid.Column>
       ) : null;
@@ -172,7 +172,7 @@ class AssumeRolePolicyChangeComponent extends Component {
             negative
             fluid
             disabled={isError}
-            onClick={sendProposedPolicy.bind(this, "cancel_change")}
+            onClick={this.props.sendProposedPolicy.bind(this, "cancel_change")}
           />
         </Grid.Column>
       ) : null;

--- a/ui/src/components/blocks/CommentsFeedBlockComponent.js
+++ b/ui/src/components/blocks/CommentsFeedBlockComponent.js
@@ -9,7 +9,6 @@ import {
   Message,
   Segment,
 } from "semantic-ui-react";
-import { sendRequestCommon } from "../../helpers/utils";
 
 class CommentsFeedBlockComponent extends Component {
   constructor(props) {
@@ -45,11 +44,16 @@ class CommentsFeedBlockComponent extends Component {
             comment_text: commentText,
           },
         };
-        const response = await sendRequestCommon(
+        const response = await this.props.sendRequestCommon(
           request,
           "/api/v2/requests/" + requestID,
           "PUT"
         );
+
+        if (!response) {
+          return;
+        }
+
         if (response.status === 403 || response.status === 400) {
           // Error occurred making the request
           this.setState({

--- a/ui/src/components/blocks/ConsoleMeDataTable.js
+++ b/ui/src/components/blocks/ConsoleMeDataTable.js
@@ -20,7 +20,6 @@ import ReactMarkdown from "react-markdown";
 import SemanticDatepicker from "react-semantic-ui-datepickers";
 import "react-semantic-ui-datepickers/dist/react-semantic-ui-datepickers.css";
 import { Link, Redirect, BrowserRouter } from "react-router-dom";
-import { sendRequestCommon } from "../../helpers/utils";
 
 const expandNestedJson = (data) => {
   Object.keys(data).forEach((key) => {
@@ -88,12 +87,16 @@ class ConsoleMeDataTable extends Component {
         isLoading: true,
       },
       async () => {
-        let data = await sendRequestCommon(
+        let data = await this.props.sendRequestCommon(
           {
             limit: tableConfig.totalRows,
           },
           tableConfig.dataEndpoint
         );
+
+        if (!data) {
+          return;
+        }
 
         // This means it raised an exception from fetching data
         if (data.status) {
@@ -420,13 +423,19 @@ class ConsoleMeDataTable extends Component {
 
   async filterColumnServerSide(event, filters) {
     const { tableConfig } = this.state;
-    let filteredData = await sendRequestCommon(
+    let filteredData = await this.props.sendRequestCommon(
       { filters },
       tableConfig.dataEndpoint
     );
+
+    if (!filteredData) {
+      return;
+    }
+
     if (filteredData.status) {
       filteredData = [];
     }
+
     this.setState({
       expandedRow: null,
       filteredData,

--- a/ui/src/components/blocks/InlinePolicyChangeComponent.js
+++ b/ui/src/components/blocks/InlinePolicyChangeComponent.js
@@ -10,10 +10,7 @@ import {
   Segment,
 } from "semantic-ui-react";
 import MonacoDiffComponent from "./MonacoDiffComponent";
-import {
-  sendProposedPolicy,
-  sortAndStringifyNestedJSONObject,
-} from "../../helpers/utils";
+import { sortAndStringifyNestedJSONObject } from "../../helpers/utils";
 
 class InlinePolicyChangeComponent extends Component {
   constructor(props) {
@@ -46,7 +43,6 @@ class InlinePolicyChangeComponent extends Component {
     this.onLintError = this.onLintError.bind(this);
     this.onValueChange = this.onValueChange.bind(this);
     this.onSubmitChange = this.onSubmitChange.bind(this);
-    this.sendProposedPolicy = sendProposedPolicy.bind(this);
     this.updatePolicyDocument = props.updatePolicyDocument;
     this.reloadDataFromBackend = props.reloadDataFromBackend;
   }
@@ -110,7 +106,11 @@ class InlinePolicyChangeComponent extends Component {
   }
 
   onSubmitChange() {
-    this.sendProposedPolicy("apply_change");
+    const applyChange = this.props.sendProposedPolicy.bind(
+      this,
+      "apply_change"
+    );
+    applyChange();
   }
 
   render() {
@@ -164,7 +164,7 @@ class InlinePolicyChangeComponent extends Component {
             positive
             fluid
             disabled={isError || noChangesDetected}
-            onClick={sendProposedPolicy.bind(this, "update_change")}
+            onClick={this.props.sendProposedPolicy.bind(this, "update_change")}
           />
         </Grid.Column>
       ) : null;
@@ -179,7 +179,7 @@ class InlinePolicyChangeComponent extends Component {
             negative
             fluid
             disabled={isError}
-            onClick={sendProposedPolicy.bind(this, "cancel_change")}
+            onClick={this.props.sendProposedPolicy.bind(this, "cancel_change")}
           />
         </Grid.Column>
       ) : null;

--- a/ui/src/components/blocks/ManagedPolicyChangeComponent.js
+++ b/ui/src/components/blocks/ManagedPolicyChangeComponent.js
@@ -9,7 +9,6 @@ import {
   Loader,
   Dimmer,
 } from "semantic-ui-react";
-import { sendProposedPolicy } from "../../helpers/utils";
 
 class ManagedPolicyChangeComponent extends Component {
   constructor(props) {
@@ -24,7 +23,6 @@ class ManagedPolicyChangeComponent extends Component {
       requestReadOnly: this.props.requestReadOnly,
     };
 
-    this.sendProposedPolicy = sendProposedPolicy.bind(this);
     this.onSubmitChange = this.onSubmitChange.bind(this);
     this.onCancelChange = this.onCancelChange.bind(this);
     this.reloadDataFromBackend = props.reloadDataFromBackend;
@@ -53,11 +51,19 @@ class ManagedPolicyChangeComponent extends Component {
   }
 
   onSubmitChange() {
-    this.sendProposedPolicy("apply_change");
+    const applyChange = this.props.sendProposedPolicy.bind(
+      this,
+      "apply_change"
+    );
+    applyChange();
   }
 
   onCancelChange() {
-    this.sendProposedPolicy("cancel_change");
+    const cancelChange = this.props.sendProposedPolicy.bind(
+      this,
+      "cancel_change"
+    );
+    cancelChange();
   }
 
   render() {

--- a/ui/src/components/blocks/ResourcePolicyChangeComponent.js
+++ b/ui/src/components/blocks/ResourcePolicyChangeComponent.js
@@ -10,10 +10,7 @@ import {
   Segment,
 } from "semantic-ui-react";
 import MonacoDiffComponent from "./MonacoDiffComponent";
-import {
-  sendProposedPolicy,
-  sortAndStringifyNestedJSONObject,
-} from "../../helpers/utils";
+import { sortAndStringifyNestedJSONObject } from "../../helpers/utils";
 
 class ResourcePolicyChangeComponent extends Component {
   constructor(props) {
@@ -47,7 +44,6 @@ class ResourcePolicyChangeComponent extends Component {
     this.onValueChange = this.onValueChange.bind(this);
     this.onSubmitChange = this.onSubmitChange.bind(this);
     this.onCancelChange = this.onCancelChange.bind(this);
-    this.sendProposedPolicy = sendProposedPolicy.bind(this);
     this.updatePolicyDocument = props.updatePolicyDocument;
     this.reloadDataFromBackend = props.reloadDataFromBackend;
   }
@@ -111,11 +107,19 @@ class ResourcePolicyChangeComponent extends Component {
   }
 
   onSubmitChange() {
-    this.sendProposedPolicy("apply_change");
+    const applyChange = this.props.sendProposedPolicy.bind(
+      this,
+      "apply_change"
+    );
+    applyChange();
   }
 
   onCancelChange() {
-    this.sendProposedPolicy("cancel_change");
+    const cancelChange = this.props.sendProposedPolicy.bind(
+      this,
+      "cancel_change"
+    );
+    cancelChange();
   }
 
   render() {
@@ -187,7 +191,7 @@ class ResourcePolicyChangeComponent extends Component {
             positive
             fluid
             disabled={isError || noChangesDetected}
-            onClick={sendProposedPolicy.bind(this, "update_change")}
+            onClick={this.props.sendProposedPolicy.bind(this, "update_change")}
           />
         </Grid.Column>
       ) : null;

--- a/ui/src/components/blocks/ResourceTagChangeComponent.js
+++ b/ui/src/components/blocks/ResourceTagChangeComponent.js
@@ -9,12 +9,13 @@ import {
   Loader,
   Dimmer,
 } from "semantic-ui-react";
-import { sendProposedPolicyWithHooks } from "../../helpers/utils";
+import { useAuth } from "../../auth/AuthProviderDefault";
 
 const ResourceTagChangeComponent = (props) => {
   const change = props.change;
   const [isLoading, setIsLoading] = useState(false);
   const [buttonResponseMessage, setButtonResponseMessage] = useState([]);
+  const { sendProposedPolicyWithHooks } = useAuth();
 
   const getTagActionSpan = () => {
     if (change.tag_action === "create") {

--- a/ui/src/components/blocks/TypeaheadBlockComponent.js
+++ b/ui/src/components/blocks/TypeaheadBlockComponent.js
@@ -1,14 +1,16 @@
 import _ from "lodash";
 import React, { Component } from "react";
 import { Form, Search } from "semantic-ui-react";
-import { sendRequestCommon } from "../../helpers/utils";
 
 class TypeaheadBlockComponent extends Component {
-  state = {
-    isLoading: false,
-    results: [],
-    value: "",
-  };
+  constructor(props) {
+    super(props);
+    this.state = {
+      isLoading: false,
+      results: [],
+      value: "",
+    };
+  }
 
   handleResultSelect(e, { result }) {
     this.setState(
@@ -51,12 +53,14 @@ class TypeaheadBlockComponent extends Component {
       const isMatch = (result) => re.test(result.title);
 
       const TYPEAHEAD_API = typeahead.replace("{query}", value);
-      sendRequestCommon(null, TYPEAHEAD_API, "get").then((source) => {
-        this.setState({
-          isLoading: false,
-          results: _.filter(source, isMatch),
+      this.props
+        .sendRequestCommon(null, TYPEAHEAD_API, "get")
+        .then((source) => {
+          this.setState({
+            isLoading: false,
+            results: _.filter(source, isMatch),
+          });
         });
-      });
     }, 300);
   }
 

--- a/ui/src/components/challenge/ConsoleMeChallengeValidator.js
+++ b/ui/src/components/challenge/ConsoleMeChallengeValidator.js
@@ -1,21 +1,25 @@
 import React, { useEffect, useState } from "react";
-import { sendRequestCommon } from "../../helpers/utils";
 import { useParams } from "react-router-dom";
+import { useAuth } from "../../auth/AuthProviderDefault";
 
 const ConsoleMeChallengeValidator = () => {
   const { challengeToken } = useParams();
   const [result, setResult] = useState("");
+  const { sendRequestCommon } = useAuth();
+
   useEffect(() => {
     (async () => {
-      setResult(
-        await sendRequestCommon(
-          null,
-          "/api/v2/challenge_validator/" + challengeToken,
-          "get"
-        )
+      const result = await sendRequestCommon(
+        null,
+        "/api/v2/challenge_validator/" + challengeToken,
+        "get"
       );
+      if (!result) {
+        return;
+      }
+      setResult(result);
     })();
-  }, [challengeToken]);
+  }, [challengeToken, sendRequestCommon]);
 
   return <p>{result && result.message}</p>;
 };

--- a/ui/src/components/policy/AssumeRolePolicy.js
+++ b/ui/src/components/policy/AssumeRolePolicy.js
@@ -1,17 +1,15 @@
 import React from "react";
 import { Header, Segment } from "semantic-ui-react";
-import { usePolicyContext } from "./hooks/PolicyProvider";
 import useAssumeRolePolicy from "./hooks/useAssumeRolePolicy";
 import { PolicyMonacoEditor } from "./PolicyMonacoEditor";
 import { JustificationModal } from "./PolicyModals";
 
 const AssumeRolePolicy = () => {
-  const { resource = {} } = usePolicyContext();
   const {
     assumeRolePolicy = {},
     setAssumeRolePolicy,
     handleAssumeRolePolicySubmit,
-  } = useAssumeRolePolicy(resource);
+  } = useAssumeRolePolicy();
 
   return (
     <>

--- a/ui/src/components/policy/ManagedPolicy.js
+++ b/ui/src/components/policy/ManagedPolicy.js
@@ -12,11 +12,10 @@ import {
 } from "semantic-ui-react";
 import useManagedPolicy from "./hooks/useManagedPolicy";
 import { JustificationModal } from "./PolicyModals";
-import { sendRequestCommon } from "../../helpers/utils";
 import { useAuth } from "../../auth/AuthProviderDefault";
 
 const ManagedPolicy = () => {
-  const { user } = useAuth();
+  const { user, sendRequestCommon } = useAuth();
   const {
     accountID = "",
     managedPolicies = [],
@@ -37,9 +36,12 @@ const ManagedPolicy = () => {
         `/api/v2/managed_policies/${accountID}`,
         "get"
       );
+      if (!result) {
+        return;
+      }
       setAvailableManagedPolicies(result);
     })();
-  }, [accountID]);
+  }, [accountID, sendRequestCommon]);
 
   const onManagePolicyChange = (e, { value }) => {
     addManagedPolicy(value);

--- a/ui/src/components/policy/PolicyEditor.js
+++ b/ui/src/components/policy/PolicyEditor.js
@@ -12,7 +12,7 @@ import { PolicyProvider, usePolicyContext } from "./hooks/PolicyProvider";
 import IAMRolePolicy from "./IAMRolePolicy";
 import ResourcePolicy from "./ResourcePolicy";
 import ResourceDetail from "./ResourceDetail";
-import { DeleteResourceModel } from "./PolicyModals";
+import { DeleteResourceModal } from "./PolicyModals";
 import { useAuth } from "../../auth/AuthProviderDefault";
 
 const PolicyEditor = () => {
@@ -55,7 +55,7 @@ const PolicyEditor = () => {
       </>
       <ResourceDetail />
       <EditPolicy />
-      <DeleteResourceModel />
+      <DeleteResourceModal />
       <Dimmer active={isPolicyEditorLoading} inverted>
         <Loader />
       </Dimmer>

--- a/ui/src/components/policy/PolicyModals.js
+++ b/ui/src/components/policy/PolicyModals.js
@@ -153,7 +153,7 @@ export const JustificationModal = ({ handleSubmit }) => {
   );
 };
 
-export const DeleteResourceModel = () => {
+export const DeleteResourceModal = () => {
   const {
     isSuccess = false,
     toggleDeleteRole = false,

--- a/ui/src/components/policy/PolicyMonacoEditor.js
+++ b/ui/src/components/policy/PolicyMonacoEditor.js
@@ -5,7 +5,6 @@ import * as monaco from "monaco-editor/esm/vs/editor/editor.api.js";
 import {
   getMonacoCompletions,
   getMonacoTriggerCharacters,
-  sendRequestCommon,
 } from "../../helpers/utils";
 import { usePolicyContext } from "./hooks/PolicyProvider";
 import { useAuth } from "../../auth/AuthProviderDefault";
@@ -178,7 +177,7 @@ export const PolicyMonacoEditor = ({
 };
 
 export const NewPolicyMonacoEditor = ({ addPolicy, setIsNewPolicy }) => {
-  const { user } = useAuth();
+  const { user, sendRequestCommon } = useAuth();
   const { setModalWithAdminAutoApprove } = usePolicyContext();
 
   const [newPolicyName, setNewPolicyName] = useState("");
@@ -205,6 +204,9 @@ export const NewPolicyMonacoEditor = ({ addPolicy, setIsNewPolicy }) => {
         "/api/v2/permission_templates/",
         "get"
       );
+      if (!data) {
+        return;
+      }
       setTemplateOptions(data.permission_templates);
       setPolicyDocument(
         JSON.stringify(JSON.parse(templateOptions[0].value), null, "\t")

--- a/ui/src/components/policy/PolicyTable.js
+++ b/ui/src/components/policy/PolicyTable.js
@@ -1,10 +1,12 @@
 import React, { useEffect, useState } from "react";
 import { Header } from "semantic-ui-react";
 import ConsoleMeDataTable from "../blocks/ConsoleMeDataTable";
-import { sendRequestCommon } from "../../helpers/utils";
 import ReactMarkdown from "react-markdown";
+import { useAuth } from "../../auth/AuthProviderDefault";
 
 const PolicyTable = () => {
+  const auth = useAuth();
+  const { sendRequestCommon } = auth;
   const [pageConfig, setPageConfig] = useState(null);
 
   useEffect(() => {
@@ -14,9 +16,12 @@ const PolicyTable = () => {
         "/api/v2/policies_page_config",
         "get"
       );
+      if (!data) {
+        return;
+      }
       setPageConfig(data);
     })();
-  }, []);
+  }, [sendRequestCommon]);
 
   if (!pageConfig) {
     return null;
@@ -36,7 +41,7 @@ const PolicyTable = () => {
           />
         </Header.Subheader>
       </Header>
-      <ConsoleMeDataTable config={tableConfig} />
+      <ConsoleMeDataTable config={tableConfig} {...auth} />
     </>
   );
 };

--- a/ui/src/components/policy/hooks/PolicyProvider.js
+++ b/ui/src/components/policy/hooks/PolicyProvider.js
@@ -1,13 +1,15 @@
 import React, { useContext, useEffect, useReducer } from "react";
 import { useParams } from "react-router-dom";
 import { initialState, reducer } from "./policyReducer";
-import { getResourceEndpoint, sendRequestCommon } from "../../../helpers/utils";
+import { getResourceEndpoint } from "../../../helpers/utils";
+import { useAuth } from "../../../auth/AuthProviderDefault";
 
 const PolicyContext = React.createContext(initialState);
 
 export const usePolicyContext = () => useContext(PolicyContext);
 
 export const PolicyProvider = ({ children }) => {
+  const { sendRequestCommon, sendRequestV2 } = useAuth();
   const [state, dispatch] = useReducer(reducer, initialState);
   const { accountID, serviceType, region, resourceName } = useParams();
 
@@ -40,6 +42,9 @@ export const PolicyProvider = ({ children }) => {
       setIsPolicyEditorLoading(true);
       // retrieve resource from the endpoint and set resource state
       const resource = await sendRequestCommon(null, endpoint, "get");
+      if (!resource) {
+        return;
+      }
       setResource(resource);
       setIsPolicyEditorLoading(false);
     })();
@@ -62,6 +67,9 @@ export const PolicyProvider = ({ children }) => {
         `${endpoint}?force_refresh=true`,
         "get"
       );
+      if (!resource) {
+        return;
+      }
       setResource(resource);
       setIsPolicyEditorLoading(false);
       setToggleRefreshRole(false);
@@ -96,6 +104,7 @@ export const PolicyProvider = ({ children }) => {
         setTogglePolicyModal,
         setModalWithAdminAutoApprove,
         handleDeleteRole,
+        sendRequestV2,
       }}
     >
       {children}

--- a/ui/src/components/policy/hooks/useAssumeRolePolicy.js
+++ b/ui/src/components/policy/hooks/useAssumeRolePolicy.js
@@ -1,8 +1,9 @@
 import { useEffect, useReducer } from "react";
 import { initialState, reducer } from "./assumeRolePolicyReducer";
-import { sendRequestV2 } from "../../../helpers/utils";
+import { usePolicyContext } from "./PolicyProvider";
 
-const useAssumeRolePolicy = (resource) => {
+const useAssumeRolePolicy = () => {
+  const { resource, sendRequestV2 } = usePolicyContext();
   const [state, dispatch] = useReducer(reducer, initialState);
 
   useEffect(() => {

--- a/ui/src/components/policy/hooks/useInlinePolicy.js
+++ b/ui/src/components/policy/hooks/useInlinePolicy.js
@@ -1,10 +1,9 @@
 import { useCallback, useEffect, useReducer } from "react";
 import { usePolicyContext } from "./PolicyProvider";
 import { initialState, reducer } from "./inlinePolicyReducer";
-import { sendRequestV2 } from "../../../helpers/utils";
 
 const useInlinePolicy = () => {
-  const { resource = {} } = usePolicyContext();
+  const { resource = {}, sendRequestV2 } = usePolicyContext();
   const [state, dispatch] = useReducer(reducer, initialState);
 
   useEffect(() => {

--- a/ui/src/components/policy/hooks/useManagedPolicy.js
+++ b/ui/src/components/policy/hooks/useManagedPolicy.js
@@ -1,7 +1,6 @@
 import { useEffect, useReducer } from "react";
 import { initialState, reducer } from "./managedPolicyReducer";
 import { usePolicyContext } from "./PolicyProvider";
-import { sendRequestV2 } from "../../../helpers/utils";
 
 const useManagedPolicy = () => {
   const [state, dispatch] = useReducer(reducer, initialState);
@@ -9,6 +8,7 @@ const useManagedPolicy = () => {
     params = {},
     resource = {},
     setModalWithAdminAutoApprove,
+    sendRequestV2,
   } = usePolicyContext();
 
   useEffect(() => {

--- a/ui/src/components/policy/hooks/usePolicyTag.js
+++ b/ui/src/components/policy/hooks/usePolicyTag.js
@@ -1,10 +1,13 @@
 import { useEffect, useReducer } from "react";
 import { initialState, reducer } from "./tagReducer";
 import { usePolicyContext } from "./PolicyProvider";
-import { sendRequestV2 } from "../../../helpers/utils";
 
 const usePolicyTag = () => {
-  const { resource = {}, setModalWithAdminAutoApprove } = usePolicyContext();
+  const {
+    resource = {},
+    setModalWithAdminAutoApprove,
+    sendRequestV2,
+  } = usePolicyContext();
   const [state, dispatch] = useReducer(reducer, initialState);
 
   const setTags = (tags) => dispatch({ type: "SET_TAGS", tags });

--- a/ui/src/components/policy/hooks/useResourcePolicy.js
+++ b/ui/src/components/policy/hooks/useResourcePolicy.js
@@ -1,10 +1,9 @@
 import { useEffect, useReducer } from "react";
 import { initialState, reducer } from "./resourcePolicyReducer";
 import { usePolicyContext } from "./PolicyProvider";
-import { sendRequestV2 } from "../../../helpers/utils";
 
 const useResourcePolicy = () => {
-  const { resource = {} } = usePolicyContext();
+  const { resource = {}, sendRequestV2 } = usePolicyContext();
   const [state, dispatch] = useReducer(reducer, initialState);
 
   useEffect(() => {

--- a/ui/src/components/request/PolicyRequestsReview.js
+++ b/ui/src/components/request/PolicyRequestsReview.js
@@ -16,11 +16,6 @@ import InlinePolicyChangeComponent from "../blocks/InlinePolicyChangeComponent";
 import ManagedPolicyChangeComponent from "../blocks/ManagedPolicyChangeComponent";
 import AssumeRolePolicyChangeComponent from "../blocks/AssumeRolePolicyChangeComponent";
 import ResourcePolicyChangeComponent from "../blocks/ResourcePolicyChangeComponent";
-import {
-  sendProposedPolicy,
-  sendRequestCommon,
-  updateRequestStatus,
-} from "../../helpers/utils";
 import ResourceTagChangeComponent from "../blocks/ResourceTagChangeComponent";
 
 class PolicyRequestReview extends Component {
@@ -38,12 +33,122 @@ class PolicyRequestReview extends Component {
     };
     this.reloadDataFromBackend = this.reloadDataFromBackend.bind(this);
     this.updatePolicyDocument = this.updatePolicyDocument.bind(this);
-    this.updateRequestStatus = updateRequestStatus.bind(this);
-    this.sendProposedPolicy = sendProposedPolicy.bind(this);
   }
 
   componentDidMount() {
     this.reloadDataFromBackend();
+  }
+
+  async sendProposedPolicy(command) {
+    const { change, newStatement, requestID } = this.state;
+    this.setState(
+      {
+        isLoading: true,
+      },
+      async () => {
+        const request = {
+          modification_model: {
+            command,
+            change_id: change.id,
+          },
+        };
+        if (newStatement) {
+          request.modification_model.policy_document = JSON.parse(newStatement);
+        }
+        this.props
+          .sendRequestCommon(request, "/api/v2/requests/" + requestID, "PUT")
+          .then((response) => {
+            if (!response) {
+              return;
+            }
+            if (
+              response.status === 403 ||
+              response.status === 400 ||
+              response.status === 500
+            ) {
+              // Error occurred making the request
+              this.setState({
+                isLoading: false,
+                buttonResponseMessage: [
+                  {
+                    status: "error",
+                    message: response.message,
+                  },
+                ],
+              });
+            } else {
+              // Successful request
+              this.setState({
+                isLoading: false,
+                buttonResponseMessage: response.action_results.reduce(
+                  (resultsReduced, result) => {
+                    if (result.visible === true) {
+                      resultsReduced.push(result);
+                    }
+                    return resultsReduced;
+                  },
+                  []
+                ),
+              });
+              this.reloadDataFromBackend();
+            }
+          });
+      }
+    );
+  }
+
+  async updateRequestStatus(command) {
+    const { requestID } = this.state;
+    this.setState(
+      {
+        isLoading: true,
+      },
+      async () => {
+        const request = {
+          modification_model: {
+            command,
+          },
+        };
+        await this.props
+          .sendRequestCommon(request, "/api/v2/requests/" + requestID, "PUT")
+          .then((response) => {
+            if (!response) {
+              return;
+            }
+            if (
+              response.status === 403 ||
+              response.status === 400 ||
+              response.status === 500
+            ) {
+              // Error occurred making the request
+              this.setState({
+                isLoading: false,
+                buttonResponseMessage: [
+                  {
+                    status: "error",
+                    message: response.message,
+                  },
+                ],
+              });
+            } else {
+              // Successful request
+              this.setState({
+                isLoading: false,
+                buttonResponseMessage: response.action_results.reduce(
+                  (resultsReduced, result) => {
+                    if (result.visible === true) {
+                      resultsReduced.push(result);
+                    }
+                    return resultsReduced;
+                  },
+                  []
+                ),
+              });
+              this.reloadDataFromBackend();
+            }
+          });
+      }
+    );
   }
 
   updatePolicyDocument(changeID, policyDocument) {
@@ -61,8 +166,12 @@ class PolicyRequestReview extends Component {
         loading: true,
       },
       () => {
-        sendRequestCommon(null, `/api/v2/requests/${requestID}`, "get").then(
-          (response) => {
+        this.props
+          .sendRequestCommon(null, `/api/v2/requests/${requestID}`, "get")
+          .then((response) => {
+            if (!response) {
+              return;
+            }
             if (response.status === 404 || response.status === 500) {
               this.setState({
                 loading: false,
@@ -77,8 +186,7 @@ class PolicyRequestReview extends Component {
                 loading: false,
               });
             }
-          }
-        );
+          });
       }
     );
   }
@@ -266,6 +374,7 @@ class PolicyRequestReview extends Component {
         comments={extendedRequest.comments}
         reloadDataFromBackend={this.reloadDataFromBackend}
         requestID={requestID}
+        sendRequestCommon={this.props.sendRequestCommon}
       />
     ) : null;
 
@@ -288,6 +397,8 @@ class PolicyRequestReview extends Component {
                   updatePolicyDocument={this.updatePolicyDocument}
                   reloadDataFromBackend={this.reloadDataFromBackend}
                   requestID={requestID}
+                  sendProposedPolicy={this.sendProposedPolicy}
+                  sendRequestCommon={this.props.sendRequestCommon}
                 />
               );
             }
@@ -299,6 +410,8 @@ class PolicyRequestReview extends Component {
                   requestReadOnly={requestReadOnly}
                   reloadDataFromBackend={this.reloadDataFromBackend}
                   requestID={requestID}
+                  sendProposedPolicy={this.sendProposedPolicy}
+                  sendRequestCommon={this.props.sendRequestCommon}
                 />
               );
             }
@@ -311,6 +424,8 @@ class PolicyRequestReview extends Component {
                   updatePolicyDocument={this.updatePolicyDocument}
                   reloadDataFromBackend={this.reloadDataFromBackend}
                   requestID={requestID}
+                  sendProposedPolicy={this.sendProposedPolicy}
+                  sendRequestCommon={this.props.sendRequestCommon}
                 />
               );
             }
@@ -335,6 +450,8 @@ class PolicyRequestReview extends Component {
                   updatePolicyDocument={this.updatePolicyDocument}
                   reloadDataFromBackend={this.reloadDataFromBackend}
                   requestID={requestID}
+                  sendProposedPolicy={this.sendProposedPolicy}
+                  sendRequestCommon={this.props.sendRequestCommon}
                 />
               );
             }

--- a/ui/src/components/request/RequestTable.js
+++ b/ui/src/components/request/RequestTable.js
@@ -1,11 +1,13 @@
 import React, { useEffect, useState } from "react";
 import { Header } from "semantic-ui-react";
 import ConsoleMeDataTable from "../blocks/ConsoleMeDataTable";
-import { sendRequestCommon } from "../../helpers/utils";
+import { useAuth } from "../../auth/AuthProviderDefault";
 import ReactMarkdown from "react-markdown";
 
 const RequestTable = () => {
   const [pageConfig, setPageConfig] = useState(null);
+  const auth = useAuth();
+  const { sendRequestCommon } = auth;
 
   useEffect(() => {
     (async () => {
@@ -14,9 +16,12 @@ const RequestTable = () => {
         "/api/v2/requests_page_config",
         "get"
       );
+      if (!data) {
+        return;
+      }
       setPageConfig(data);
     })();
-  }, []);
+  }, [sendRequestCommon]);
 
   if (!pageConfig) {
     return null;
@@ -36,7 +41,7 @@ const RequestTable = () => {
           />
         </Header.Subheader>
       </Header>
-      <ConsoleMeDataTable config={tableConfig} />
+      <ConsoleMeDataTable config={tableConfig} {...auth} />
     </>
   );
 };

--- a/ui/src/components/roles/CreateCloneFeature.js
+++ b/ui/src/components/roles/CreateCloneFeature.js
@@ -14,7 +14,6 @@ import {
   Icon,
   Feed,
 } from "semantic-ui-react";
-import { sendRequestCommon } from "../../helpers/utils";
 
 const clone_options = [
   { text: "Assume Role Policy Document", value: "assume_role_policy" },
@@ -29,28 +28,31 @@ const clone_default_selected_options = clone_options.map(
 );
 
 class CreateCloneFeature extends Component {
-  state = {
-    isLoading: false,
-    isLoadingAccount: false,
-    results: [],
-    resultsAccount: [],
-    value: "",
-    source_role: null,
-    source_role_value: "",
-    dest_account_id: null,
-    dest_account_id_value: "",
-    dest_role_name: "",
-    searchType: "",
-    description: "",
-    messages: null,
-    requestSent: false,
-    requestResults: [],
-    isSubmitting: false,
-    roleCreated: false,
-    options: clone_default_selected_options,
-    copy_description: true,
-    feature_type: "create",
-  };
+  constructor(props) {
+    super(props);
+    this.state = {
+      isLoading: false,
+      isLoadingAccount: false,
+      results: [],
+      resultsAccount: [],
+      value: "",
+      source_role: null,
+      source_role_value: "",
+      dest_account_id: null,
+      dest_account_id_value: "",
+      dest_role_name: "",
+      searchType: "",
+      description: "",
+      messages: null,
+      requestSent: false,
+      requestResults: [],
+      isSubmitting: false,
+      roleCreated: false,
+      options: clone_default_selected_options,
+      copy_description: true,
+      feature_type: "create",
+    };
+  }
 
   handleSearchChange(event, { name, value }) {
     if (name === "source_role") {
@@ -94,19 +96,24 @@ class CreateCloneFeature extends Component {
       const TYPEAHEAD_API =
         "/policies/typeahead?resource=" + searchType + "&search=" + value;
 
-      sendRequestCommon(null, TYPEAHEAD_API, "get").then((source) => {
-        if (searchType === "account") {
-          this.setState({
-            isLoadingAccount: false,
-            resultsAccount: source.filter((result) => re.test(result.title)),
-          });
-        } else {
-          this.setState({
-            isLoading: false,
-            results: source.filter((result) => re.test(result.title)),
-          });
-        }
-      });
+      this.props
+        .sendRequestCommon(null, TYPEAHEAD_API, "get")
+        .then((source) => {
+          if (!source) {
+            return;
+          }
+          if (searchType === "account") {
+            this.setState({
+              isLoadingAccount: false,
+              resultsAccount: source.filter((result) => re.test(result.title)),
+            });
+          } else {
+            this.setState({
+              isLoading: false,
+              results: source.filter((result) => re.test(result.title)),
+            });
+          }
+        });
     }, 300);
   }
 
@@ -205,7 +212,7 @@ class CreateCloneFeature extends Component {
         isSubmitting: true,
       },
       async () => {
-        const response = await sendRequestCommon(payload, url);
+        const response = await this.props.sendRequestCommon(payload, url);
         const messages = [];
         let requestResults = [];
         let requestSent = false;

--- a/ui/src/components/roles/SelectRoles.js
+++ b/ui/src/components/roles/SelectRoles.js
@@ -1,11 +1,13 @@
 import React, { useEffect, useState } from "react";
 import { Header } from "semantic-ui-react";
 import ConsoleMeDataTable from "../blocks/ConsoleMeDataTable";
-import { sendRequestCommon } from "../../helpers/utils";
 import ReactMarkdown from "react-markdown";
+import { useAuth } from "../../auth/AuthProviderDefault";
 
 const SelectRoles = () => {
   const [pageConfig, setPageConfig] = useState(null);
+  const auth = useAuth();
+  const { sendRequestCommon } = auth;
 
   useEffect(() => {
     (async () => {
@@ -14,9 +16,12 @@ const SelectRoles = () => {
         "/api/v2/eligible_roles_page_config",
         "get"
       );
+      if (!data) {
+        return;
+      }
       setPageConfig(data);
     })();
-  }, []);
+  }, [sendRequestCommon]);
 
   if (!pageConfig) {
     return null;
@@ -35,7 +40,7 @@ const SelectRoles = () => {
           />
         </Header.Subheader>
       </Header>
-      <ConsoleMeDataTable config={tableConfig} />
+      <ConsoleMeDataTable config={tableConfig} {...auth} />
     </>
   );
 };

--- a/ui/src/components/selfservice/SelfService.js
+++ b/ui/src/components/selfservice/SelfService.js
@@ -7,29 +7,34 @@ import SelfServiceStep1 from "./SelfServiceStep1";
 import SelfServiceStep2 from "./SelfServiceStep2";
 import SelfServiceStep3 from "./SelfServiceStep3";
 import { SelfServiceStepEnum } from "./SelfServiceEnums";
-import { sendRequestCommon } from "../../helpers/utils";
 
 const arnRegex = /^arn:aws:iam::(?<accountId>\d{12}):role\/(.+\/)?(?<roleName>(.+))/;
 
 class SelfService extends Component {
-  state = {
-    config: null,
-    currStep: SelfServiceStepEnum.STEP1,
-    messages: null,
-    permissions: [],
-    role: null,
-    services: [],
-    admin_bypass_approval_enabled: false,
-  };
+  constructor(props) {
+    super(props);
+    this.state = {
+      config: null,
+      currStep: SelfServiceStepEnum.STEP1,
+      messages: null,
+      permissions: [],
+      role: null,
+      services: [],
+      admin_bypass_approval_enabled: false,
+    };
+  }
 
   async componentDidMount() {
-    const config = await sendRequestCommon(
+    const config = await this.props.sendRequestCommon(
       null,
       "/api/v2/self_service_config",
       "get"
     );
+    if (!config) {
+      return;
+    }
     const { services } = this.state;
-    Object.keys(config.permissions_map).forEach((name) => {
+    Object.keys(config.permissions_map || []).forEach((name) => {
       const service = config.permissions_map[name];
       services.push({
         actions: service.action_map,
@@ -158,6 +163,7 @@ class SelfService extends Component {
             config={config}
             role={role}
             handleRoleUpdate={this.handleRoleUpdate.bind(this)}
+            {...this.props}
           />
         );
         break;
@@ -169,6 +175,7 @@ class SelfService extends Component {
             services={services}
             permissions={permissions}
             handlePermissionsUpdate={this.handlePermissionsUpdate.bind(this)}
+            {...this.props}
           />
         );
         break;
@@ -180,6 +187,7 @@ class SelfService extends Component {
             services={services}
             permissions={permissions}
             admin_bypass_approval_enabled={admin_bypass_approval_enabled}
+            {...this.props}
           />
         );
         break;

--- a/ui/src/components/selfservice/SelfServiceComponent.js
+++ b/ui/src/components/selfservice/SelfServiceComponent.js
@@ -110,6 +110,7 @@ class SelfServiceComponent extends Component {
               required={input.required || false}
               typeahead={input.typeahead_endpoint}
               label={input.text}
+              sendRequestCommon={this.props.sendRequestCommon}
             />
           );
         default:

--- a/ui/src/components/selfservice/SelfServiceStep2.js
+++ b/ui/src/components/selfservice/SelfServiceStep2.js
@@ -18,9 +18,12 @@ import SelfServiceComponent from "./SelfServiceComponent";
 const DEFAULT_AWS_SERVICE = "s3";
 
 class SelfServiceStep2 extends Component {
-  state = {
-    service: DEFAULT_AWS_SERVICE,
-  };
+  constructor(props) {
+    super(props);
+    this.state = {
+      service: DEFAULT_AWS_SERVICE,
+    };
+  }
 
   handleServiceTypeChange(e, { value }) {
     this.setState({
@@ -148,6 +151,7 @@ class SelfServiceStep2 extends Component {
                   role={role}
                   service={service}
                   updatePermission={this.handlePermissionAdd.bind(this)}
+                  {...this.props}
                 />
               ) : null}
             </Grid.Column>

--- a/ui/src/components/selfservice/SelfServiceStep3.js
+++ b/ui/src/components/selfservice/SelfServiceStep3.js
@@ -15,8 +15,6 @@ import {
 } from "semantic-ui-react";
 import AceEditor from "react-ace";
 import "brace";
-import ace from "brace";
-import { getCompletions, sendRequestCommon } from "../../helpers/utils";
 import "brace/ext/language_tools";
 import "brace/theme/monokai";
 import "brace/mode/json";
@@ -44,8 +42,6 @@ class SelfServiceStep3 extends Component {
   }
 
   async componentDidMount() {
-    const langTools = ace.require("ace/ext/language_tools");
-    langTools.setCompleters([{ getCompletions }]);
     const { role, permissions } = this.props;
     const payload = {
       changes: [],
@@ -64,7 +60,7 @@ class SelfServiceStep3 extends Component {
       return change;
     });
 
-    const response = await sendRequestCommon(
+    const response = await this.props.sendRequestCommon(
       payload,
       "/api/v2/generate_changes"
     );
@@ -244,7 +240,10 @@ class SelfServiceStep3 extends Component {
         isLoading: true,
       },
       async () => {
-        const response = await sendRequestCommon(requestV2, "/api/v2/request");
+        const response = await this.props.sendRequestCommon(
+          requestV2,
+          "/api/v2/request"
+        );
 
         const messages = [];
         if (response) {

--- a/ui/src/helpers/utils.js
+++ b/ui/src/helpers/utils.js
@@ -1,5 +1,3 @@
-import { sendRequestTarget } from "../auth/AuthProviderDefault";
-
 const ALPHABET =
   "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
 
@@ -19,101 +17,65 @@ export function generate_temp_id(expiration_date) {
   return "temp_" + expiration_date + "_" + random_id();
 }
 
-export async function getCookie(name) {
+export function getCookie(name) {
   const r = document.cookie.match("\\b" + name + "=([^;]*)\\b");
   return r ? r[1] : undefined;
 }
 
-export async function sendRequestCommon(
+// NOTE: avoid using sendRequestCommon from utils file.
+async function sendRequestCommon(
   json,
   location = window.location.href,
   method = "post"
 ) {
-  const xsrf = await getCookie("_xsrf");
-  return await sendRequestTarget(json, location, method, xsrf);
-}
-
-export function PolicyTypeahead(value, callback, limit = 20) {
-  const url =
-    "/api/v2/typeahead/resources?typeahead=" + value + "&limit=" + limit;
-
-  sendRequestCommon(null, url, "get").then((results) => {
-    const matching_resources = [];
-    results.forEach((result) => {
-      // Strip out what the user has currently typed (`row`) from the full value returned from typeahead
-      matching_resources.push({
-        name: result,
-        value: result,
-        meta: "Resource",
-        score: 1000,
-      });
-    });
-    callback(null, matching_resources);
+  const xsrf = getCookie("_xsrf");
+  let body = null;
+  if (json) {
+    body = JSON.stringify(json);
+  }
+  const rawResponse = await fetch(location, {
+    method: method,
+    headers: {
+      "Content-type": "application/json",
+      "X-Xsrftoken": xsrf,
+      "X-Requested-With": "XMLHttpRequest",
+      Accept: "application/json",
+    },
+    body: body,
   });
-}
+  const response = await rawResponse;
 
-export function getCompletions(editor, session, pos, prefix, callback) {
-  let resource = false;
-  let action = false;
-
-  const lines = editor.getValue().split("\n");
-  for (let i = pos.row; i >= 0; i--) {
-    if (lines[i].indexOf('"Resource"') > -1) {
-      resource = true;
-      break;
+  let resJson;
+  try {
+    resJson = await response.json();
+    if (
+      response.status === 403 &&
+      resJson.type === "redirect" &&
+      resJson.reason === "unauthenticated"
+    ) {
+      const auth = await fetch("/auth?redirect_url=" + window.location.href, {
+        headers: {
+          "X-Requested-With": "XMLHttpRequest",
+          Accept: "application/json",
+        },
+      }).then((res) => res.json());
+      // redirect to IDP for authentication.
+      if (auth.type === "redirect") {
+        window.location.href = auth.redirect_url;
+      }
+    } else if (response.status === 401) {
+      return null;
     }
-
-    if (lines[i].indexOf('"Action"') > -1) {
-      action = true;
-      break;
-    }
-  }
-  // Only start typeahead if we have more than 3 characters to work with
-  if (resource && prefix.length <= 3) {
-    callback(null, []);
-    return;
-  }
-  // Check for other statements? The beginning of the statement? The curly bracket?
-  // if not action or resource do nothing?
-  if (prefix.length === 0 || (action === false && resource === false)) {
-    callback(null, []);
-    return;
+  } catch (e) {
+    resJson = response;
   }
 
-  const row = session.getDocument().getLine(pos.row).trim().replace(/"/g, "");
-  if (action === true) {
-    sendRequestCommon(
-      null,
-      "/api/v1/policyuniverse/autocomplete?prefix=" + row,
-      "get"
-    ).then((wordList) => {
-      // wordList like [{"permission":"s3:GetObject"}]
-      callback(
-        null,
-        wordList.map((ea) => {
-          let value = ea.permission;
-          if (row.indexOf(":") > -1) {
-            value = value.split(":")[1];
-          }
-          return {
-            name: ea.permission,
-            value,
-            meta: "Permission",
-            score: 1000,
-          };
-        })
-      );
-    });
-  } else if (resource === true) {
-    // We know we're in the Resource section, so let's help type the ARN
-    new PolicyTypeahead(row, callback, 500000);
-  }
+  return resJson;
 }
 
 export async function getMonacoCompletions(model, position, monaco) {
   let resource = false;
   let action = false;
-
   const lines = model.getLinesContent();
 
   for (let i = position.lineNumber - 1; i >= 0; i--) {
@@ -193,167 +155,6 @@ export function sortAndStringifyNestedJSONObject(input = {}) {
   return JSON.stringify(input, allOldKeys.sort(), 4);
 }
 
-export function updateRequestStatus(command) {
-  const { requestID } = this.state;
-  this.setState(
-    {
-      isLoading: true,
-    },
-    async () => {
-      const request = {
-        modification_model: {
-          command,
-        },
-      };
-      await sendRequestCommon(
-        request,
-        "/api/v2/requests/" + requestID,
-        "PUT"
-      ).then((response) => {
-        if (
-          response.status === 403 ||
-          response.status === 400 ||
-          response.status === 500
-        ) {
-          // Error occurred making the request
-          this.setState({
-            isLoading: false,
-            buttonResponseMessage: [
-              {
-                status: "error",
-                message: response.message,
-              },
-            ],
-          });
-        } else {
-          // Successful request
-          this.setState({
-            isLoading: false,
-            buttonResponseMessage: response.action_results.reduce(
-              (resultsReduced, result) => {
-                if (result.visible === true) {
-                  resultsReduced.push(result);
-                }
-                return resultsReduced;
-              },
-              []
-            ),
-          });
-          this.reloadDataFromBackend();
-        }
-      });
-    }
-  );
-}
-
-export async function sendProposedPolicyWithHooks(
-  command,
-  change,
-  newStatement,
-  requestID,
-  setIsLoading,
-  setButtonResponseMessage,
-  reloadDataFromBackend
-) {
-  setIsLoading(true);
-  const request = {
-    modification_model: {
-      command,
-      change_id: change.id,
-    },
-  };
-  if (newStatement) {
-    request.modification_model.policy_document = JSON.parse(newStatement);
-  }
-  await sendRequestCommon(request, "/api/v2/requests/" + requestID, "PUT").then(
-    (response) => {
-      if (
-        response.status === 403 ||
-        response.status === 400 ||
-        response.status === 500
-      ) {
-        // Error occurred making the request
-        setIsLoading(false);
-        setButtonResponseMessage([
-          {
-            status: "error",
-            message: response.message,
-          },
-        ]);
-      } else {
-        // Successful request
-        setIsLoading(false);
-        setButtonResponseMessage(
-          response.action_results.reduce((resultsReduced, result) => {
-            if (result.visible === true) {
-              resultsReduced.push(result);
-            }
-            return resultsReduced;
-          }, [])
-        );
-        reloadDataFromBackend();
-      }
-    }
-  );
-}
-
-export function sendProposedPolicy(command) {
-  const { change, newStatement, requestID } = this.state;
-  this.setState(
-    {
-      isLoading: true,
-    },
-    async () => {
-      const request = {
-        modification_model: {
-          command,
-          change_id: change.id,
-        },
-      };
-      if (newStatement) {
-        request.modification_model.policy_document = JSON.parse(newStatement);
-      }
-      await sendRequestCommon(
-        request,
-        "/api/v2/requests/" + requestID,
-        "PUT"
-      ).then((response) => {
-        if (
-          response.status === 403 ||
-          response.status === 400 ||
-          response.status === 500
-        ) {
-          // Error occurred making the request
-          this.setState({
-            isLoading: false,
-            buttonResponseMessage: [
-              {
-                status: "error",
-                message: response.message,
-              },
-            ],
-          });
-        } else {
-          // Successful request
-          this.setState({
-            isLoading: false,
-            buttonResponseMessage: response.action_results.reduce(
-              (resultsReduced, result) => {
-                if (result.visible === true) {
-                  resultsReduced.push(result);
-                }
-                return resultsReduced;
-              },
-              []
-            ),
-          });
-          this.reloadDataFromBackend();
-        }
-      });
-    }
-  );
-}
-
 export const getResourceEndpoint = (
   accountID,
   serviceType,
@@ -381,51 +182,6 @@ export const getResourceEndpoint = (
   })(accountID, serviceType, region, resourceName);
 
   return endpoint;
-};
-
-export const sendRequestV2 = async (requestV2) => {
-  const response = await sendRequestCommon(requestV2, "/api/v2/request");
-
-  if (response) {
-    const { request_created, request_id, request_url, errors } = response;
-    if (request_created === true) {
-      if (requestV2.admin_auto_approve && errors === 0) {
-        return {
-          message: `Successfully created and applied request: [${request_id}](${request_url}).`,
-          request_created,
-          error: false,
-        };
-      } else if (errors === 0) {
-        return {
-          message: `Successfully created request: [${request_id}](${request_url}).`,
-          request_created,
-          error: false,
-        };
-      } else {
-        return {
-          // eslint-disable-next-line max-len
-          message: `This request was created and partially successful: : [${request_id}](${request_url}). But the server reported some errors with the request: ${JSON.stringify(
-            response
-          )}`,
-          request_created,
-          error: true,
-        };
-      }
-    }
-    return {
-      message: `Server reported an error with the request: ${JSON.stringify(
-        response
-      )}`,
-      request_created,
-      error: true,
-    };
-  } else {
-    return {
-      message: `"Failed to submit request: ${JSON.stringify(response)}`,
-      request_created: false,
-      error: true,
-    };
-  }
 };
 
 export const parseLocalStorageCache = (key) => {


### PR DESCRIPTION
This is the proof of concept of how to handle 401 status so that users can be informed and provide a chance to reauthenticate if the session is expired.

Followings are the changes done:
- added a state called isSessionExpired to track session expiration status.
- moved sendRequestCommon to be part of AuthProvider hook so that if 401 status is returned from the backend via sendRequestCommon then it can set the states in AuthProvider which sits on top of any other components in ConsoleMe to control things globally.
- Searched places where sendRequestCommon is being used and replaced with this logic including components that are not yet React Hooks.
- Components in blocks directory and some of helper util.js are not updated yet which requires more work. I will do this once this proof of concept is valid.

How to test this:
- First visit Self Service Page then it will pop up a modal for reauthentication.
- I have updated the backend endpoint /api/v2/self_service_config to return 401 via AJAX and sendRequestCommon will set isSessionExpired to true so that a Modal will be returned to allow people to reauthenticate
- Once you click the button in the modal, we want to redirect the user to the IDP for login once more. The redirect URL should be configurable and returned from the backend so that it can bet set to the state and the modal can use it.
