### PR TITLE
fix for auth issue by handling exceptions from fetching non-json data

### DIFF
--- a/ui/src/auth/ProtectedRoute.js
+++ b/ui/src/auth/ProtectedRoute.js
@@ -5,20 +5,28 @@ import { Segment } from "semantic-ui-react";
 
 const ProtectedRoute = (props) => {
   const auth = useAuth();
-  const { login, user } = auth;
+  const { login, user, isSessionExpired } = auth;
   const match = useRouteMatch(props);
   const { component: Component, ...rest } = props;
 
   useEffect(() => {
+    // make sure we only handle the registered routes
     if (!match) {
       return;
     }
+
+    // TODO(heewonk), This is a temporary way to prevent multiple logins when 401 type of access deny occurs.
+    // Revisit later to enable this logic only when ALB type of authentication is being used.
+    if (isSessionExpired) {
+      return;
+    }
+
     if (!user) {
       (async () => {
         await login();
       })();
     }
-  }, [match, user]); // eslint-disable-line
+  }, [match, user, isSessionExpired, login]);
 
   if (!user) {
     return null;


### PR DESCRIPTION
If fetch API retrieves data that is not application/json type then it seems it raises an exception which causes the ConsoleMe page to crash. We spent some time addressing this issue by using its response type whether this was due to misappropriate way of handling 401 status but it turns out it is due to parsing the error HTML page showing re-authentication is required instead of a JSON object.
