### PR TITLE
Direct users to use pre-built docker image when testing ConsoleMe locally

### DIFF
--- a/docker-compose-deploy-dockerhub.yaml
+++ b/docker-compose-deploy-dockerhub.yaml
@@ -1,0 +1,25 @@
+version: "3"
+# Never use this in a production environment.
+services:
+  consoleme-deploy:
+    image: "consoleme/consoleme"
+    ports:
+      # Serve ConsoleMe's backend (Python Tornado) port, which is used to serve the frontend when built
+      - "8081:8081"
+    environment:
+      - SETUPTOOLS_USE_DISTUTILS=stdlib
+    # Run commands to install Consoleme, run the service, and never exit in the event of failure (For dev debugging)
+    command: >
+      bash -c 'python consoleme/__main__.py'
+  consoleme-celery-deploy:
+    image: "consoleme/consoleme"
+    environment:
+      - SETUPTOOLS_USE_DISTUTILS=stdlib
+      - COLUMNS=80 # Needed for Celery: https://github.com/celery/celery/issues/5761
+    # Run Redis with ConsoleMe configuration
+    command: >
+      bash -c '
+      python scripts/retrieve_or_decode_configuration.py;
+      python scripts/initialize_dynamodb_oss.py;
+      python scripts/initialize_redis_oss.py --use_celery=true;
+      celery -A consoleme.celery.celery_tasks worker -l DEBUG -B -E --concurrency=8'

--- a/docker-compose-dockerhub.yaml
+++ b/docker-compose-dockerhub.yaml
@@ -8,13 +8,9 @@ services:
     tty: true
     stdin_open: true
     volumes:
-      - .:/apps/consoleme:delegated
       - ~/.aws:/root/.aws:cached
       - ~/.ssh:/root/.ssh:cached
       - ~/.config/consoleme:/etc/consoleme/
-      # We shouldn't be using node_modules from host : https://medium.com/@semur.nabiev/how-to-make-docker-compose-volumes-ignore-the-node-modules-directory-99f9ec224561
-      - /apps/consoleme/node_modules/
-      - /apps/consoleme/ui/node_modules/
     environment:
       - CONFIG_LOCATION=/apps/consoleme/example_config/example_config_docker_development.yaml
       - SETUPTOOLS_USE_DISTUTILS=stdlib
@@ -40,13 +36,9 @@ services:
     tty: true
     stdin_open: true
     volumes:
-      - .:/apps/consoleme:delegated
       - ~/.aws:/root/.aws:cached
       - ~/.ssh:/root/.ssh:cached
       - ~/.config/consoleme:/etc/consoleme/
-        # We shouldn't be using node_modules from host : https://medium.com/@semur.nabiev/how-to-make-docker-compose-volumes-ignore-the-node-modules-directory-99f9ec224561
-      - /apps/consoleme/node_modules/
-      - /apps/consoleme/ui/node_modules/
     environment:
       - CONFIG_LOCATION=/apps/consoleme/example_config/example_config_docker_development.yaml
       - SETUPTOOLS_USE_DISTUTILS=stdlib

--- a/docker-compose-dockerhub.yaml
+++ b/docker-compose-dockerhub.yaml
@@ -1,0 +1,67 @@
+version: "3"
+# Never use this in a production environment.
+services:
+  consoleme:
+    image: "consoleme/consoleme"
+    ports:
+      - "3000:3000"
+    tty: true
+    stdin_open: true
+    volumes:
+      - .:/apps/consoleme:delegated
+      - ~/.aws:/root/.aws:cached
+      - ~/.ssh:/root/.ssh:cached
+      - ~/.config/consoleme:/etc/consoleme/
+      # We shouldn't be using node_modules from host : https://medium.com/@semur.nabiev/how-to-make-docker-compose-volumes-ignore-the-node-modules-directory-99f9ec224561
+      - /apps/consoleme/node_modules/
+      - /apps/consoleme/ui/node_modules/
+    environment:
+      - CONFIG_LOCATION=/apps/consoleme/example_config/example_config_docker_development.yaml
+      - SETUPTOOLS_USE_DISTUTILS=stdlib
+    # Run commands to install Consoleme, run the service, and never exit in the event of failure (For dev debugging)
+    # We're running `FORCE_COLOR=true yarn --cwd /apps/consoleme/ui/ start | cat` instead of
+    # `yarn --cwd /apps/consoleme/ui/ start`  to prevent Yarn from clearing the console, as this affects how docker logs
+    # are displayed
+    command: >
+      bash -c '
+      python scripts/retrieve_or_decode_configuration.py;
+      pip install argh watchdog;
+      pip install -e /apps/consoleme/default_plugins;
+      watchmedo auto-restart --recursive --pattern="*.py;*.yaml" --directory="." python consoleme/__main__.py &
+      FORCE_COLOR=true yarn --cwd /apps/consoleme/ui/ start | cat'
+    depends_on:
+      - consoleme-redis
+      - consoleme-dynamodb
+    links:
+      - consoleme-redis
+      - consoleme-dynamodb
+  consoleme-celery:
+    image: "consoleme/consoleme"
+    tty: true
+    stdin_open: true
+    volumes:
+      - .:/apps/consoleme:delegated
+      - ~/.aws:/root/.aws:cached
+      - ~/.ssh:/root/.ssh:cached
+      - ~/.config/consoleme:/etc/consoleme/
+        # We shouldn't be using node_modules from host : https://medium.com/@semur.nabiev/how-to-make-docker-compose-volumes-ignore-the-node-modules-directory-99f9ec224561
+      - /apps/consoleme/node_modules/
+      - /apps/consoleme/ui/node_modules/
+    environment:
+      - CONFIG_LOCATION=/apps/consoleme/example_config/example_config_docker_development.yaml
+      - SETUPTOOLS_USE_DISTUTILS=stdlib
+      - COLUMNS=80 # Needed for Celery: https://github.com/celery/celery/issues/5761
+    # Run Redis with ConsoleMe configuration
+    command: >
+      bash -c '
+      python scripts/retrieve_or_decode_configuration.py;
+      python scripts/initialize_dynamodb_oss.py;
+      python scripts/initialize_redis_oss.py --use_celery=true;
+      celery -A consoleme.celery.celery_tasks worker -l DEBUG -B -E --concurrency=8
+      '
+    depends_on:
+      - consoleme-redis
+      - consoleme-dynamodb
+    links:
+      - consoleme-redis
+      - consoleme-dynamodb

--- a/docs/gitbook/quick-start/docker.md
+++ b/docs/gitbook/quick-start/docker.md
@@ -24,7 +24,9 @@ To start up ConsoleMe in docker, run the following command:
 # Ensure that you have valid AWS Credentials in your ~/.aws/credentials file under your `default` profile
 # before running this command. This command will cache AWS resources for the
 # account.
-docker-compose -f docker-compose.yaml -f docker-compose-dependencies.yaml up -d
+docker-compose -f docker-compose-dockerhub.yaml -f docker-compose-dependencies.yaml up -d
+# If you wish to build ConsoleMe instead of using a pre-build image, run this command:
+# docker-compose -f docker-compose.yaml -f docker-compose-dependencies.yaml up -d
 ```
 
 At this point you should the below command and verify you have 4 ConsoleMe related containers running.


### PR DESCRIPTION
- [X] Adds docker-compose-dockerhub.yaml file, which uses the pre-built consoleme image from Dockerhub
- [X] Modifies Quick Start guide to use docker-compose-dockerhub.yaml file instead of requiring the user to build the image themselves. 