### PR TITLE
Change verbiage from 'no s3 errors' to 'no errors'.

### DIFF
--- a/ui/src/components/policy/Issues.js
+++ b/ui/src/components/policy/Issues.js
@@ -153,10 +153,9 @@ const Issues = () => {
     return (
       <>
         <Header as="h2">
-          No S3 Errors
+          No errors
           <Header.Subheader>
-            We didn&apos;t find any recent S3 errors associated with this
-            resource.
+            We didn&apos;t find any recent errors associated with this resource.
           </Header.Subheader>
         </Header>
       </>


### PR DESCRIPTION
Change error verbiage to specify `errors` generically, instead of `S3 errors`. This verbiage appears for SQS and SNS resources, where `S3 errors` are not relevant.