### PR TITLE
Add security enhancements to Challenge URL authentication flow

### DIFF
--- a/consoleme/lib/challenge.py
+++ b/consoleme/lib/challenge.py
@@ -1,0 +1,62 @@
+from datetime import datetime
+
+import pytz
+import ujson as json
+from asgiref.sync import async_to_sync
+
+from consoleme.config import config
+from consoleme.lib.redis import RedisHandler
+
+log = config.get_logger()
+red = async_to_sync(RedisHandler().redis)()
+
+
+async def delete_expired_challenges(all_challenges):
+    current_time = int(datetime.utcnow().replace(tzinfo=pytz.UTC).timestamp())
+    expired_challenge_tokens = []
+    for token, challenge_j in all_challenges.items():
+        challenge = json.loads(challenge_j)
+        if challenge.get("ttl", 0) < current_time:
+            expired_challenge_tokens.append(token)
+    if expired_challenge_tokens:
+        red.hdel(
+            config.get("challenge_url.redis_key", "TOKEN_CHALLENGES_TEMP"),
+            *expired_challenge_tokens,
+        )
+
+
+async def retrieve_user_challenge(request, requested_challenge_token, log_data):
+    current_time = int(datetime.utcnow().replace(tzinfo=pytz.UTC).timestamp())
+    # Get fresh challenge for user's request
+    user_challenge_j = red.hget(
+        config.get("challenge_url.redis_key", "TOKEN_CHALLENGES_TEMP"),
+        requested_challenge_token,
+    )
+    if not user_challenge_j:
+        message = "The requested challenge URL was not found. Please try requesting a new challenge URL."
+        request.write({"message": message})
+        return
+    # Do a double-take check on the ttl
+    # Delete the token
+    user_challenge = json.loads(user_challenge_j)
+    if user_challenge.get("ttl", 0) < current_time:
+        message = (
+            "This challenge URL has expired. Please try requesting a new challenge URL."
+        )
+        request.write({"message": message})
+        return
+    if request.user != user_challenge.get("user"):
+        log_data = {
+            **log_data,
+            "message": "Authenticated user is different then user that requested token",
+            "authenticated_user": request.user,
+            "challenge_user": user_challenge.get("user"),
+        }
+        log.error(log_data)
+        message = (
+            "This challenge URL is associated with a different user. Ensure that your client "
+            "configuration is specifying the correct user."
+        )
+        request.write({"message": message})
+        return
+    return user_challenge

--- a/consoleme/routes.py
+++ b/consoleme/routes.py
@@ -145,7 +145,6 @@ def make_app(jwt_validator=None):
         (
             r"/api/v2/challenge_validator/([a-zA-Z0-9_-]+)",
             ChallengeValidatorHandler,
-            {"type": "api"},
         ),
         (r"/noauth/v1/challenge_generator/(.*)", ChallengeGeneratorHandler),
         (r"/noauth/v1/challenge_poller/([a-zA-Z0-9_-]+)", ChallengePollerHandler),

--- a/ui/src/components/challenge/ConsoleMeChallengeValidator.js
+++ b/ui/src/components/challenge/ConsoleMeChallengeValidator.js
@@ -1,27 +1,53 @@
 import React, { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import { useAuth } from "../../auth/AuthProviderDefault";
+import { Button } from "semantic-ui-react";
+import ReactMarkdown from "react-markdown";
 
 const ConsoleMeChallengeValidator = () => {
   const { challengeToken } = useParams();
   const [result, setResult] = useState("");
+  const [showApproveButton, setShowApproveButton] = useState(false);
   const { sendRequestCommon } = useAuth();
 
   useEffect(() => {
     (async () => {
-      const result = await sendRequestCommon(
+      const res = await sendRequestCommon(
         null,
         "/api/v2/challenge_validator/" + challengeToken,
         "get"
       );
-      if (!result) {
+      if (!res) {
         return;
       }
-      setResult(result);
+      setResult(res);
+      setShowApproveButton(res?.show_approve_button || false);
     })();
   }, [challengeToken, sendRequestCommon]);
 
-  return <p>{result && result.message}</p>;
+  const validateChallengeToken = async () => {
+    const res = await sendRequestCommon(
+      { nonce: result?.nonce },
+      "/api/v2/challenge_validator/" + challengeToken,
+      "post"
+    );
+    if (!res) {
+      return;
+    }
+    setResult(res);
+    setShowApproveButton(false);
+  };
+
+  return (
+    <>
+      <ReactMarkdown linkTarget="_blank" source={result && result.message} />
+      {showApproveButton ? (
+        <Button primary type="submit" onClick={validateChallengeToken}>
+          Approve Credential Request
+        </Button>
+      ) : null}
+    </>
+  );
 };
 
 export default ConsoleMeChallengeValidator;


### PR DESCRIPTION
- [X] Adds a confirmation to the user, and requires manual approval of CLI credential request
![image](https://user-images.githubusercontent.com/7538233/109068347-974c3480-76a4-11eb-96ce-199d690ee95c.png)

- [X]  Only lets user view challenge verification page once
![image](https://user-images.githubusercontent.com/7538233/109068408-acc15e80-76a4-11eb-9e4b-0693cf6e6ac7.png)

- [X] Adds a one-time Nonce when user first visits challenge url verification page. This nonce must be sent with the POST request to verify the challenge
![image](https://user-images.githubusercontent.com/7538233/109068549-e1351a80-76a4-11eb-9b41-51bb7341c4c3.png)

If they don't post with the correct nonce, they get an error:
![image](https://user-images.githubusercontent.com/7538233/109068712-15a8d680-76a5-11eb-8964-e7926ebc0580.png)

