### PR TITLE
Adjust exclude regex for pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-exclude: "docs/gitbook/*"
+exclude: "^docs/gitbook/"
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.3.0 # Use the ref you want to point at


### PR DESCRIPTION
In the current configuration, pre-commit produces this warning:

```
[WARNING] The top-level 'exclude' field is a regex, not a glob -- matching '/*' probably isn't what you want here
```

This PR changes the exclude string to a regular expression that achieves the same goal, eliminating the warning.