### PR TITLE
Adjust name of compliance_restricted log field

### DIFF
--- a/consoleme/lib/google.py
+++ b/consoleme/lib/google.py
@@ -369,7 +369,7 @@ async def raise_if_restricted(user: str, group_info: Any) -> None:
         "user": user,
         "group": group_info.name,
         "restricted": group_info.restricted,
-        "compliance_retricted": group_info.compliance_restricted,
+        "compliance_restricted": group_info.compliance_restricted,
     }
     log.debug(log_data)
     if group_info.restricted:


### PR DESCRIPTION
This log key has a typo.

This is possibly a breaking change for users of consoleme who have created log searches based on this typo, but it'd hopefully be only a minor inconvenience to update that.