### PR TITLE
Add pkg-config to Linux local dependencies

### DIFF
--- a/docs/gitbook/quick-start/local-development.md
+++ b/docs/gitbook/quick-start/local-development.md
@@ -22,7 +22,7 @@ Ubuntu disco/19.04+, Debian buster/10+
 
 ```text
 # Additional dependencies
-sudo apt-get install build-essential libxml2-dev libxmlsec1 libxmlsec1-dev libxmlsec1-openssl musl-dev libcurl4-nss-dev python3-dev -y
+sudo apt-get install build-essential libxml2-dev libxmlsec1 libxmlsec1-dev libxmlsec1-openssl musl-dev libcurl4-nss-dev python3-dev pkg-config -y
 # Nodejs/Yarn (Frontend dependencies)
 curl -sL https://deb.nodesource.com/setup_14.x | sudo bash
 sudo apt-get install -y nodejs


### PR DESCRIPTION
pkg-config was needed on a fresh Amazon Linux instance for xmlsec to install.