### PR TITLE
WIP: Allow clients to pass in session tags

### DIFF
--- a/consoleme/handlers/v2/requests.py
+++ b/consoleme/handlers/v2/requests.py
@@ -134,7 +134,7 @@ class RequestHandler(BaseAPIV2Handler):
                   "policy_document": {
                     "Statement": [
                       {
-                        "Action": "sts:AssumeRole",
+                        "Action": ["sts:AssumeRole", "sts:TagSession"],
                         "Effect": "Allow",
                         "Principal": {
                           "AWS": "arn:aws:iam::123456789012:role/consolemeInstanceProfile"

--- a/consoleme/lib/aws.py
+++ b/consoleme/lib/aws.py
@@ -1182,6 +1182,8 @@ def sanitize_session_tags(metadata):
     final_tags = []
     max_key_length = 128 - len(prepend_string)  # Tag keys have a length limit of 128
     for k, v in metadata.items():
+        k = str(k)
+        v = str(v)
         tag_key = ""
         tag_value = ""
         for char in k[:max_key_length]:

--- a/consoleme/lib/aws.py
+++ b/consoleme/lib/aws.py
@@ -703,6 +703,7 @@ async def create_iam_role(create_model: RoleCreationRequestModel, username):
     }
     log.info(log_data)
 
+    # TODO: Include some sane defaults here
     default_trust_policy = config.get("user_role_creator.default_trust_policy")
     if default_trust_policy is None:
         raise MissingConfigurationValue(

--- a/consoleme/lib/aws.py
+++ b/consoleme/lib/aws.py
@@ -1164,3 +1164,30 @@ async def get_enabled_regions_for_account(account_id: str) -> Set[str]:
 
     regions = await sync_to_async(client.describe_regions)()
     return {r["RegionName"] for r in regions["Regions"]}
+
+
+def sanitize_session_tags(metadata):
+    import re
+
+    if not metadata:
+        return []
+    # Warning: Principal tags can be overridden by session tags. We strongly recommend you prepend user-supplied session
+    # tags with a string and signify that these tags should not be used for authorization. We're doing this for you by
+    # default here.
+    prepend_string = config.get(
+        "sanitize_session_tags.prepend_tag", "session-untrusted-"
+    )
+    final_tags = []
+    max_key_length = 128 - len(prepend_string)  # Tag keys have a length limit of 128
+    for k, v in metadata.items():
+        tag_key = ""
+        tag_value = ""
+        for char in k[:max_key_length]:
+            if re.match(r"^([a-zA-Z0-9\s_\./\=+\-])$", char):
+                tag_key += char
+        for char in v[:256]:
+            if re.match(r"^([a-zA-Z0-9\s_\./\=+\-])$", char):
+                tag_value += char
+        if tag_key and tag_value:
+            final_tags.append({"Key": prepend_string + tag_key, "Value": tag_value})
+    return final_tags

--- a/default_plugins/consoleme_default_plugins/plugins/aws/aws.py
+++ b/default_plugins/consoleme_default_plugins/plugins/aws/aws.py
@@ -2,6 +2,7 @@ import asyncio
 import ssl
 import sys
 from datetime import datetime, timedelta
+from typing import Dict
 
 import bleach
 import boto3
@@ -350,6 +351,7 @@ class Aws:
         user_role: bool = False,
         account_id: str = None,
         custom_ip_restrictions: list = None,
+        session_tags: Dict = None,
     ) -> dict:
         """Get Credentials will return the list of temporary credentials from AWS."""
         log_data = {
@@ -360,6 +362,8 @@ class Aws:
             "custom_ip_restrictions": custom_ip_restrictions,
             "message": "Generating credentials",
         }
+        if not session_tags:
+            session_tags = []
         session = boto3.Session()
         client = session.client(
             "sts",
@@ -403,6 +407,7 @@ class Aws:
                     RoleSessionName=user.lower(),
                     Policy=policy,
                     DurationSeconds=config.get("aws.session_duration", 3600),
+                    Tags=session_tags,
                 )
                 credentials["Credentials"]["Expiration"] = int(
                     credentials["Credentials"]["Expiration"].timestamp()
@@ -433,6 +438,7 @@ class Aws:
                     RoleSessionName=user.lower(),
                     Policy=policy,
                     DurationSeconds=config.get("aws.session_duration", 3600),
+                    Tags=session_tags,
                 )
                 credentials["Credentials"]["Expiration"] = int(
                     credentials["Credentials"]["Expiration"].timestamp()
@@ -443,6 +449,7 @@ class Aws:
                 RoleArn=role,
                 RoleSessionName=user.lower(),
                 DurationSeconds=config.get("aws.session_duration", 3600),
+                Tags=session_tags,
             )
             credentials["Credentials"]["Expiration"] = int(
                 credentials["Credentials"]["Expiration"].timestamp()

--- a/default_plugins/consoleme_default_plugins/plugins/aws/aws.py
+++ b/default_plugins/consoleme_default_plugins/plugins/aws/aws.py
@@ -359,7 +359,10 @@ class Aws:
             "user": user,
             "role": role,
             "enforce_ip_restrictions": enforce_ip_restrictions,
+            "user_role": user_role,
+            "account_id": account_id,
             "custom_ip_restrictions": custom_ip_restrictions,
+            "session_tags": session_tags,
             "message": "Generating credentials",
         }
         if not session_tags:

--- a/docs/gitbook/prerequisites/required-iam-permissions/central-account-consolemeinstanceprofile.md
+++ b/docs/gitbook/prerequisites/required-iam-permissions/central-account-consolemeinstanceprofile.md
@@ -108,7 +108,7 @@ Configure the trust policy with the following settings \(Yes, you'll want to giv
       }
     },
     {
-      "Action": "sts:AssumeRole",
+      "Action": ["sts:AssumeRole", "sts:TagSession"],
       "Effect": "Allow",
       "Principal": {
         "AWS": "arn:aws:iam::1243456789012:role/consolemeInstanceProfile"

--- a/docs/gitbook/prerequisites/required-iam-permissions/spoke-accounts-consoleme.md
+++ b/docs/gitbook/prerequisites/required-iam-permissions/spoke-accounts-consoleme.md
@@ -57,7 +57,7 @@ Assume Role Policy Document:
 {
   "Statement": [
     {
-      "Action": "sts:AssumeRole",
+      "Action": ["sts:AssumeRole", "sts:TagSession"],
       "Effect": "Allow",
       "Principal": {
         "AWS": "arn:aws:iam::1243456789012:role/consolemeInstanceProfile"

--- a/terraform/central-account/iam.tf
+++ b/terraform/central-account/iam.tf
@@ -72,7 +72,7 @@ data "aws_iam_policy_document" "ConsoleMe_trust_policy" {
 
   //  statement {
   //    sid     = "AssumeRoleSelf"
-  //    actions = ["sts:AssumeRole"]
+  //    actions = ["sts:AssumeRole", "sts:TagSession"]
   //    effect  = "Allow"
   //    principals {
   //      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.ConsoleMe_instance_profile_name}"]

--- a/terraform/central-account/iam_example_roles.tf
+++ b/terraform/central-account/iam_example_roles.tf
@@ -36,8 +36,7 @@ resource "aws_iam_role_policy" "consoleme_app_role_policy2" {
 data "aws_iam_policy_document" "consoleme_user_trust_policy" {
   statement {
     sid = "ConsoleMeCanAssumeAllRoles"
-    actions = [
-    "sts:AssumeRole"]
+    actions = ["sts:AssumeRole", "sts:TagSession"]
     effect = "Allow"
     principals {
       identifiers = [

--- a/terraform/central-account/iam_spoke_roles.tf
+++ b/terraform/central-account/iam_spoke_roles.tf
@@ -52,8 +52,7 @@ resource "aws_iam_role_policy" "consoleme_target_role_policy" {
 data "aws_iam_policy_document" "consoleme_target_trust_policy" {
   statement {
     sid = "ConsoleMeAssumesTarget"
-    actions = [
-    "sts:AssumeRole"]
+    actions = ["sts:AssumeRole", "sts:TagSession"]
     effect = "Allow"
     principals {
       identifiers = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,7 +51,7 @@ MOCK_ROLE = {
                     "Principal": {
                         "AWS": "arn:aws:iam::123456789012:role/ConsoleMeInstanceProfile"
                     },
-                    "Action": "sts:AssumeRole",
+                    "Action": ["sts:AssumeRole", "sts:TagSession"],
                 },
             ],
         },
@@ -480,7 +480,7 @@ def iam_sync_roles(iam):
                     "Principal": {
                         "AWS": "arn:aws:iam::123456789012:role/ConsoleMeInstanceProfile"
                     },
-                    "Action": "sts:AssumeRole",
+                    "Action": ["sts:AssumeRole", "sts:TagSession"],
                 }
             ],
         }
@@ -584,7 +584,7 @@ def www_user():
                     "Principal": {
                         "AWS": "arn:aws:iam::123456789012:role/consoleme"
                     },
-                    "Action": "sts:AssumeRole"
+                    "Action": ["sts:AssumeRole", "sts:TagSession"]
                 }
             ]
         },

--- a/tests/lib/role_updater/test_handler.py
+++ b/tests/lib/role_updater/test_handler.py
@@ -124,7 +124,7 @@ class TestHandler(unittest.IsolatedAsyncioTestCase):
                     "Principal": {"AWS": "arn:aws:iam::123456789012:role/testRole"},
                 }
             ],
-            "Action": "sts:AssumeRole",
+            "Action": ["sts:AssumeRole", "sts:TagSession"],
         }
         async_to_sync(self.handler.update_assume_role_document)(
             client, role_name, policy


### PR DESCRIPTION
- [X] Allows clients (such as weep) to pass in metadata to be included in session tags
- [X] Sanitizes tags in accordance with AWS session tag specifications - https://github.com/Netflix/consoleme/compare/session_tag_support?expand=1
- [X] Adds a configurable prefix to user-submitted session tags, to prevent overriding tags on the IAM principal 