### PR TITLE
Make AWS Config resilient to errors

### DIFF
--- a/consoleme/lib/aws_config/aws_config.py
+++ b/consoleme/lib/aws_config/aws_config.py
@@ -48,7 +48,7 @@ def query(
         available_regions = session.get_available_regions("config")
         excluded_regions = config.get(
             "api_protect.exclude_regions",
-            ["af-south-1", "ap-east-1", "eu-south-1", "me-south-1"],
+            ["af-south-1", "ap-east-1", "ap-northeast-3", "eu-south-1", "me-south-1"],
         )
         regions = [x for x in available_regions if x not in excluded_regions]
         for region in regions:

--- a/consoleme/lib/aws_config/aws_config.py
+++ b/consoleme/lib/aws_config/aws_config.py
@@ -85,7 +85,8 @@ def query(
                         "account_id": account_id,
                         "region": region,
                         "error": str(e),
-                    }
+                    },
+                    exc_info=True,
                 )
                 sentry_sdk.capture_exception()
         return resources


### PR DESCRIPTION
We started seeing AWS Config `AccessDenied` errors on `ap-northeast-3`. This PR adds `ap-northeast-3` to the default region exclusion list when we query AWS Config. In addition, if we encounter an error, we log and report the error to sentry instead of failing the query.