### PR TITLE
ALB: remove ? from path_pattern

### DIFF
--- a/terraform/central-account/lb.tf
+++ b/terraform/central-account/lb.tf
@@ -40,7 +40,7 @@ resource "aws_lb_listener_rule" "unauthenticated-routes-1" {
 
   condition {
     path_pattern {
-      values = ["/api/v1/get_credentials", "/api/v1/get_roles", "/noauth/v1/challenge_generator/*",
+      values = ["/api/v1/get_credentials*", "/api/v1/get_roles*", "/noauth/v1/challenge_generator/*",
       "/noauth/v1/challenge_poller/*", "/api/v2/mtls/roles/*"]
     }
   }

--- a/terraform/central-account/lb.tf
+++ b/terraform/central-account/lb.tf
@@ -40,7 +40,7 @@ resource "aws_lb_listener_rule" "unauthenticated-routes-1" {
 
   condition {
     path_pattern {
-      values = ["/api/v1/get_credentials?", "/api/v1/get_roles?", "/noauth/v1/challenge_generator/*",
+      values = ["/api/v1/get_credentials", "/api/v1/get_roles", "/noauth/v1/challenge_generator/*",
       "/noauth/v1/challenge_poller/*", "/api/v2/mtls/roles/*"]
     }
   }


### PR DESCRIPTION
The ALB docs say:

```
? (matches exactly 1 character)
```

so this requires a character at the end. At least in `weep`, the URL is a
simple string, so `weep` fails to list roles or get credentials without
this change. The error looks like:

```
Error: failed to unmarshal JSON: invalid character '<' looking for
beginning of value
```

since `/get_roles` or `/get_credentials` gets redirected to the ALB OIDC
login.

Ref:
https://github.com/Netflix/weep/blob/master/creds/consoleme.go#L148
https://github.com/Netflix/weep/blob/master/creds/consoleme.go#L237