### PR TITLE
fix(terraform): fix 'multiple VPC Endpoint Services matched' error

### DIFF
--- a/terraform/central-account/network.tf
+++ b/terraform/central-account/network.tf
@@ -1,5 +1,5 @@
 module "network" {
-  source = "github.com/terraform-aws-modules/terraform-aws-vpc?ref=v2.7.0"
+  source = "github.com/terraform-aws-modules/terraform-aws-vpc?ref=v2.77.0"
 
   name = module.network_label.id
   cidr = var.vpc_cidr


### PR DESCRIPTION
Bump the vpc module to latest in order to fix the following error:

```
Error: multiple VPC Endpoint Services matched; use additional constraints to reduce matches to a single VPC Endpoint Service
  on .terraform/modules/network/main.tf line 830, in data "aws_vpc_endpoint_service" "s3":
 830: data "aws_vpc_endpoint_service" "s3" {
```

This seems related to the following issue within the vpc module:
https://github.com/terraform-aws-modules/terraform-aws-vpc/issues/582

After upgrading the module terraform can plan/apply successfully.