### PR TITLE
Add terraform/consoleme template for custom URL

### DIFF
--- a/terraform/central-account/data.tf
+++ b/terraform/central-account/data.tf
@@ -29,7 +29,7 @@ data "template_file" "consoleme_config" {
     application_admin                                  = var.application_admin
     region                                             = data.aws_region.current.name
     jwt_email_key                                      = var.lb-authentication-jwt-email-key
-    user_facing_url                                    = "https://${aws_lb.public-to-private-lb.dns_name}:${var.lb_port}"
+    user_facing_url                                    = var.user_facing_url == "" ? "https://${aws_lb.public-to-private-lb.dns_name}:${var.lb_port}" : var.user_facing_url
   }
 }
 

--- a/terraform/central-account/variables.tf
+++ b/terraform/central-account/variables.tf
@@ -230,3 +230,8 @@ variable "lb-authentication-scope" {
 variable "application_admin" {
   description = "The user or group that will have administrative access in ConsoleMe"
 }
+
+variable "user_facing_url" {
+  type    = string
+  default = ""
+}


### PR DESCRIPTION
If `user_facing_url` is unset, default to the AWS load-balancer URL.
If set, use `user_facing_url`.

Useful for when there's a custom domain/HTTPS certificate; `weep`
retrieves the challege URL from this configuration setting.