### PR TITLE
logout function with additional cookies, redirect

### DIFF
--- a/consoleme/handlers/v2/logout.py
+++ b/consoleme/handlers/v2/logout.py
@@ -1,0 +1,61 @@
+import sys
+
+from consoleme.config import config
+from consoleme.handlers.base import BaseHandler
+from consoleme.lib.web import handle_generic_error_response
+from consoleme.models import WebResponse
+
+log = config.get_logger()
+
+
+class LogOutHandler(BaseHandler):
+    async def get(self):
+        log_data = {
+            "function": f"{__name__}.{self.__class__.__name__}.{sys._getframe().f_code.co_name}",
+            "message": "Attempting to log out user",
+            "user-agent": self.request.headers.get("User-Agent"),
+            "ip": self.ip,
+        }
+        if not config.get("auth.set_auth_cookie"):
+            await handle_generic_error_response(
+                self,
+                "Unable to log out",
+                [
+                    (
+                        "Configuration value `auth.set_auth_cookie` is not enabled. "
+                        "ConsoleMe isn't able to delete an auth cookie if setting auth "
+                        "cookies is not enabled."
+                    )
+                ],
+                400,
+                "logout_failure",
+                log_data,
+            )
+            return
+        cookie_name: str = config.get("auth_cookie_name", "consoleme_auth")
+        if not cookie_name:
+            await handle_generic_error_response(
+                self,
+                "Unable to log out",
+                [
+                    (
+                        "Configuration value `auth_cookie_name` is not set. "
+                        "ConsoleMe isn't able to delete an auth cookie if the auth cookie name "
+                        "is not known."
+                    )
+                ],
+                400,
+                "logout_failure",
+                log_data,
+            )
+            return
+        self.clear_cookie(cookie_name)
+        res = WebResponse(
+            status="redirect",
+            redirect_url="/",
+            status_code=200,
+            reason="logout_redirect",
+            message="User has successfully logged out. Redirecting to landing page",
+        )
+        log.debug({**log_data, "message": "Successfully logged out user."})
+        self.write(res.json())

--- a/consoleme/handlers/v2/logout.py
+++ b/consoleme/handlers/v2/logout.py
@@ -50,9 +50,15 @@ class LogOutHandler(BaseHandler):
             )
             return
         self.clear_cookie(cookie_name)
+
+        extra_auth_cookies: list = config.get("auth.extra_auth_cookies", [])
+        for cookie in extra_auth_cookies:
+            self.clear_cookie(cookie)
+
+        redirect_url=config.get("auth.logout_redirect_url", "/")
         res = WebResponse(
             status="redirect",
-            redirect_url="/",
+            redirect_url=redirect_url,
             status_code=200,
             reason="logout_redirect",
             message="User has successfully logged out. Redirecting to landing page",

--- a/consoleme/handlers/v2/logout.py
+++ b/consoleme/handlers/v2/logout.py
@@ -55,7 +55,7 @@ class LogOutHandler(BaseHandler):
         for cookie in extra_auth_cookies:
             self.clear_cookie(cookie)
 
-        redirect_url=config.get("auth.logout_redirect_url", "/")
+        redirect_url: str = config.get("auth.logout_redirect_url", "/")
         res = WebResponse(
             status="redirect",
             redirect_url=redirect_url,

--- a/consoleme/handlers/v2/user_profile.py
+++ b/consoleme/handlers/v2/user_profile.py
@@ -34,6 +34,7 @@ class UserProfileHandler(BaseAPIV1Handler):
         user_profile = {
             "site_config": site_config,
             "user": self.user,
+            "can_logout": config.get("auth.set_auth_cookie"),
             "is_contractor": is_contractor,
             "employee_photo_url": config.config_plugin().get_employee_photo_url(
                 self.user

--- a/consoleme/routes.py
+++ b/consoleme/routes.py
@@ -37,6 +37,7 @@ from consoleme.handlers.v2.index import (
     EligibleRolePageConfigHandler,
     FrontendHandler,
 )
+from consoleme.handlers.v2.logout import LogOutHandler
 from consoleme.handlers.v2.policies import (
     CheckPoliciesHandler,
     ManagedPoliciesHandler,
@@ -134,6 +135,7 @@ def make_app(jwt_validator=None):
         (r"/api/v2/managed_policies/(\d{12})", ManagedPoliciesHandler),
         (r"/api/v2/login", LoginHandler),
         (r"/api/v2/login_configuration", LoginConfigurationHandler),
+        (r"/api/v2/logout", LogOutHandler),
         (r"/api/v2/user", UserManagementHandler),
         (r"/api/v2/user_registration", UserRegistrationHandler),
         (r"/api/v2/policies", PoliciesHandler),

--- a/terraform/central-account/data.tf
+++ b/terraform/central-account/data.tf
@@ -30,6 +30,7 @@ data "template_file" "consoleme_config" {
     region                                             = data.aws_region.current.name
     jwt_email_key                                      = var.lb-authentication-jwt-email-key
     user_facing_url                                    = var.user_facing_url == "" ? "https://${aws_lb.public-to-private-lb.dns_name}:${var.lb_port}" : var.user_facing_url
+    logout_url                                         = var.logout_url
   }
 }
 

--- a/terraform/central-account/templates/example_config_terraform.yaml
+++ b/terraform/central-account/templates/example_config_terraform.yaml
@@ -75,7 +75,10 @@ celery:
   active_region: ${region}
 
 auth:
+  logout_redirect_url: "${logout_url}"
   get_user_by_aws_alb_auth: true
+  extra_auth_cookies:
+    - AWSELBAuthSessionCookie-0
   set_auth_cookie: true
 
 get_user_by_aws_alb_auth_settings:

--- a/terraform/central-account/variables.tf
+++ b/terraform/central-account/variables.tf
@@ -231,6 +231,11 @@ variable "application_admin" {
   description = "The user or group that will have administrative access in ConsoleMe"
 }
 
+variable "logout_url" {
+  type    = string
+  default = "/"
+}
+
 variable "user_facing_url" {
   type    = string
   default = ""

--- a/tests/handlers/v2/test_user_profile.py
+++ b/tests/handlers/v2/test_user_profile.py
@@ -49,6 +49,7 @@ class TestUserProfile(AsyncHTTPTestCase):
                     "can_create_roles": False,
                     "can_delete_roles": False,
                 },
+                "can_logout": False,
                 "pages": {
                     "header": {
                         "custom_header_message_title": "",

--- a/ui/src/App.js
+++ b/ui/src/App.js
@@ -13,6 +13,7 @@ import ConsoleLogin from "./components/ConsoleLogin";
 import ConsoleMeChallengeValidator from "./components/challenge/ConsoleMeChallengeValidator";
 import CreateCloneFeature from "./components/roles/CreateCloneFeature";
 import Login from "./components/Login";
+import Logout from "./components/Logout";
 import NoMatch from "./components/NoMatch";
 import AuthenticateModal from "./components/AuthenticateModal";
 
@@ -84,6 +85,7 @@ function App() {
           path="/create_role"
           component={CreateCloneFeature}
         />
+        <ProtectedRoute key="logout" exact path="/logout" component={Logout} />
         <Route key="login" exact path="/login" component={Login} />
         <Route component={NoMatch} />
       </Switch>

--- a/ui/src/components/Header.js
+++ b/ui/src/components/Header.js
@@ -50,22 +50,30 @@ const ConsoleMeHeader = () => {
   };
 
   const getAvatarImage = () => {
-    if (user?.employee_photo_url) {
-      return (
-        <>
-          <Image
-            alt={user.user}
-            avatar
-            src={user.employee_photo_url}
-            title={user.user}
-          />
-          {user.user}
-        </>
-      );
-    } else if (user?.user) {
-      return user.user;
-    }
-    return null;
+    const dropdownOptions = [
+      {
+        key: user.user,
+        text: user.user,
+        value: user.user,
+        image: { avatar: true, src: user?.employee_photo_url },
+      },
+    ];
+    return (
+      <Dropdown
+        inline
+        options={dropdownOptions}
+        defaultValue={dropdownOptions[0].value}
+        icon={null}
+      >
+        <Dropdown.Menu>
+          {user?.can_logout ? (
+            <Dropdown.Item as={NavLink} to="/logout">
+              Logout
+            </Dropdown.Item>
+          ) : null}
+        </Dropdown.Menu>
+      </Dropdown>
+    );
   };
 
   const headerMessage = () => {

--- a/ui/src/components/Logout.js
+++ b/ui/src/components/Logout.js
@@ -1,0 +1,53 @@
+import React, { useCallback, useEffect, useState } from "react";
+import { delay, setRecentRoles } from "../helpers/utils";
+import { useAuth } from "../auth/AuthProviderDefault";
+import { Icon, Message } from "semantic-ui-react";
+import LoginForm from "./Login";
+
+const Logout = () => {
+  const { sendRequestCommon } = useAuth();
+  const [errorMessage, setErrorMessage] = useState("");
+  const onSignOut = useCallback(async () => {
+    const signOutResponse = await sendRequestCommon(
+      null,
+      "/api/v2/logout",
+      "get"
+    );
+
+    if (!signOutResponse) {
+      return;
+    }
+
+    if (signOutResponse.redirect_url) {
+      window.location.assign(signOutResponse.redirect_url);
+    }
+
+    setErrorMessage(signOutResponse.message);
+  }, [sendRequestCommon]);
+
+  useEffect(() => {
+    (async () => {
+      await onSignOut();
+    })();
+  }, [onSignOut]);
+  return (
+    <>
+      {errorMessage ? (
+        <Message negative>
+          <Message.Header>Oops! there was a problem</Message.Header>
+          <p>{errorMessage}</p>
+        </Message>
+      ) : (
+        <Message icon>
+          <Icon name="circle notched" loading />
+          <Message.Content>
+            <Message.Header>Just a moment...</Message.Header>
+            Attempting to log out
+          </Message.Content>
+        </Message>
+      )}
+    </>
+  );
+};
+
+export default Logout;

--- a/ui/src/components/Logout.js
+++ b/ui/src/components/Logout.js
@@ -1,8 +1,6 @@
 import React, { useCallback, useEffect, useState } from "react";
-import { delay, setRecentRoles } from "../helpers/utils";
 import { useAuth } from "../auth/AuthProviderDefault";
 import { Icon, Message } from "semantic-ui-react";
-import LoginForm from "./Login";
 
 const Logout = () => {
   const { sendRequestCommon } = useAuth();


### PR DESCRIPTION
This PR's commits starts from the work at
#9046 and is addressing the
issue #9045

The improvements here are required for logouts in an AWS ALB + Cognito
environment, but are intended to be generic through YAML configuration.

New YAML keys:

- `auth.logout_url`: where this application redirects after the cookies
are cleared
- `auth.extra_auth_cookies` a list of any extra cookies that need to be
  cleared, beyond the consoleme one

Both are given as an example in `example_config_terraform.yaml`

The `auth.logout_url` value can be set through Terraform to the templated
configuration file.