### PR TITLE
Update the Sidebar layout to use flexbox to avoid logo overlap

### DIFF
--- a/ui/src/components/Sidebar.js
+++ b/ui/src/components/Sidebar.js
@@ -68,92 +68,99 @@ const ConsoleMeSidebar = () => {
       inverted
       vertical
       style={{
-        paddingTop: "10px",
+        paddingTop: "82px",
         width: "240px",
-        marginTop: "72px",
-        minHeight: "700px",
+        zIndex: "100",
       }}
     >
-      <Menu.Item>
-        <Label>{recentRoles.length}</Label>
-        <Menu.Header>Recent Roles</Menu.Header>
-        <Menu.Menu>{listRecentRoles(recentRoles, user)}</Menu.Menu>
-      </Menu.Item>
-      <Menu.Item>
-        <Menu.Header>Help</Menu.Header>
-        <Menu.Menu>
-          <Menu.Item
-            as="a"
-            name="documentation"
-            href={documentation_url || ""}
-            rel="noopener noreferrer"
-            target="_blank"
-            style={{
-              fontSize: "14px",
-            }}
-          >
-            <Icon name="file" />
-            Documentation
-          </Menu.Item>
-          <Menu.Item
-            as="a"
-            name="email"
-            href={support_contact ? "mailto:" + support_contact : "/"}
-            rel="noopener noreferrer"
-            target="_blank"
-            style={{
-              fontSize: "14px",
-            }}
-          >
-            <Icon name="send" />
-            Email us
-          </Menu.Item>
-          <Menu.Item
-            as="a"
-            name="slack"
-            href={support_chat_url || "/"}
-            rel="noopener noreferrer"
-            target="_blank"
-            style={{
-              fontSize: "14px",
-            }}
-          >
-            <Icon name="slack" />
-            Find us on Slack
-          </Menu.Item>
-        </Menu.Menu>
-      </Menu.Item>
-      <Menu.Menu
+      <div
         style={{
-          position: "absolute",
-          bottom: "70px",
-          left: "0",
+          display: "flex",
+          flexDirection: "column",
+          height: "100%",
+          justifyContent: "space-between",
+          overflowY: "auto",
         }}
       >
-        <Menu.Item>
-          {consoleme_logo && (
-            <a href={"/"} rel="noopener noreferrer" target="_blank">
-              <Image
+        <div>
+          <Menu.Item>
+            <Label>{recentRoles.length}</Label>
+            <Menu.Header>Recent Roles</Menu.Header>
+            <Menu.Menu>{listRecentRoles(recentRoles, user)}</Menu.Menu>
+          </Menu.Item>
+          <Menu.Item>
+            <Menu.Header>Help</Menu.Header>
+            <Menu.Menu>
+              <Menu.Item
+                as="a"
+                name="documentation"
+                href={documentation_url || ""}
+                rel="noopener noreferrer"
+                target="_blank"
                 style={{
-                  height: "250px",
-                  margin: "auto",
+                  fontSize: "14px",
                 }}
-                src={consoleme_logo}
-              />
-            </a>
-          )}
-          <br />
-          {security_logo && (
-            <a
-              href={security_url || "/"}
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              <Image size="medium" src={security_logo} />
-            </a>
-          )}
-        </Menu.Item>
-      </Menu.Menu>
+              >
+                <Icon name="file" />
+                Documentation
+              </Menu.Item>
+              <Menu.Item
+                as="a"
+                name="email"
+                href={support_contact ? "mailto:" + support_contact : "/"}
+                rel="noopener noreferrer"
+                target="_blank"
+                style={{
+                  fontSize: "14px",
+                }}
+              >
+                <Icon name="send" />
+                Email us
+              </Menu.Item>
+              <Menu.Item
+                as="a"
+                name="slack"
+                href={support_chat_url || "/"}
+                rel="noopener noreferrer"
+                target="_blank"
+                style={{
+                  fontSize: "14px",
+                }}
+              >
+                <Icon name="slack" />
+                Find us on Slack
+              </Menu.Item>
+            </Menu.Menu>
+          </Menu.Item>
+        </div>
+        <div>
+          <Menu.Menu>
+            <Menu.Item>
+              {consoleme_logo && (
+                <a href={"/"} rel="noopener noreferrer" target="_blank">
+                  <Image
+                    style={{
+                      height: "250px",
+                      margin: "auto",
+                    }}
+                    src={consoleme_logo}
+                  />
+                </a>
+              )}
+              <br />
+              {security_logo && (
+                <a
+                  href={security_url || "/"}
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  <Image size="medium" src={security_logo} />
+                </a>
+              )}
+            </Menu.Item>
+          </Menu.Menu>
+        </div>
+      </div>
     </Menu>
   );
 };


### PR DESCRIPTION
On shorter screens, there is a possibility that the ConsoleMe logo will sit on top of the Sidebar - especially when there are multiple "Recent Roles" listed. 

To remedy this, I removed the absolute positioning of the logo section and added a flexbox container as a parent to the items that can be justified top/bottom within the Sidebar.  If the content exceeds 100% height of the browser, the Sidebar should be scrollable - which is also why I removed the minHeight: 700px restriction, thus making the Sidebar vertically flexible.

You'll notice a couple other small changes that I made to the Menu styles - namely the margin, padding, and zIndex.  A slightly simpler solution to ensure that the Sidebar is 100% of the browser height.  I removed the margin (which offsets the container) in favor of padding and updated the zIndex to ensure that it sits below the Header.

I'm open to suggestions on this solution as well.  Try it out and let me know what you think.  Thanks!