### PR TITLE
chore: Upgrade lxml to 4.6.3

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -432,7 +432,7 @@ logmatic-python==0.1.7
     # via
     #   -c requirements.txt
     #   -r requirements.txt
-lxml==4.6.2
+lxml==4.6.3
     # via
     #   -c requirements.txt
     #   -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -211,7 +211,7 @@ lazy-object-proxy==1.5.2
     # via astroid
 logmatic-python==0.1.7
     # via -r requirements.in
-lxml==4.6.2
+lxml==4.6.3
     # via
     #   -r requirements.in
     #   python3-saml


### PR DESCRIPTION
Resolves CVE-2021-28957