### PR TITLE
Layout fix - reinstate overflow-x on the body tag to allow scrolling on wide pages

### DIFF
--- a/ui/.gitignore
+++ b/ui/.gitignore
@@ -21,3 +21,4 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.eslintcache

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -1,10 +1,8 @@
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen",
-    "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue",
-    sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  overflow-x: auto;
 }
 
 code {

--- a/ui/src/index.js
+++ b/ui/src/index.js
@@ -1,7 +1,7 @@
 import React from "react";
 import ReactDOM from "react-dom";
-import "./index.css";
 import "semantic-ui-css/semantic.min.css";
+import "./index.css";
 import App from "./App";
 import * as serviceWorker from "./serviceWorker";
 


### PR DESCRIPTION
On certain views - especially views with a Datatable - the content can extend beyond the browser window horizontally, but no scrollbars appear to allow for scrolling in the x direction.  This is a default CSS property on the `body` in semantic-ui, which I think for our use case should be overridden.

In order to do so (without using `!important` in our stylesheet) I swapped the order of the semantic-ui stylesheet and `index.css` and added the `overflow-x` property to the `body`. 

A side effect of this was that the `font-family` used in the custom `index.css` file differed from what semantic-ui uses by default.  I did a visual sweep of the app and the only font issue that stood out to me was that the Datatable cells would use the font from `index.css`.  For the sake of consistency throughout the app, I opted to take this custom font-family stack out of `index.css` in favor of what we get from semantic-ui.  If this is not a preferred change just let me know - it can very easily be added back :) 

I also added `.eslintcache` to the `.gitignore` for the UI.