### PR TITLE
Verify resource in cache for get_resource_url endpoint

### DIFF
--- a/consoleme/lib/s3_helpers.py
+++ b/consoleme/lib/s3_helpers.py
@@ -123,6 +123,7 @@ def map_operation_to_api(operation, default):
         "REST.GET.WEBSITE": "s3:GetBucketWebsite",
         "REST.HEAD.BUCKET": "s3:ListBucket",
         "REST.HEAD.OBJECT": "s3:GetObject",
+        "REST.COPY.PART_GET": "s3:GetObject",
         "REST.POST.BUCKET": "REST.POST.BUCKET",
         "REST.POST.MULTI_OBJECT_DELETE": "s3:DeleteObject",
         "REST.POST.RESTORE": "s3:RestoreObject",

--- a/consoleme/lib/s3_helpers.py
+++ b/consoleme/lib/s3_helpers.py
@@ -29,7 +29,7 @@ async def is_object_older_than_seconds(
     if not s3_client:
         s3_client = boto3.client("s3")
     try:
-        res = sync_to_async(s3_client.head_object)(Bucket=bucket, Key=key)
+        res = await sync_to_async(s3_client.head_object)(Bucket=bucket, Key=key)
     except ClientError as e:
         # If file is not found, we'll tell the user it's older than the specified time
         if e.response.get("Error", {}).get("Code") == "404":

--- a/consoleme/lib/s3_helpers.py
+++ b/consoleme/lib/s3_helpers.py
@@ -1,9 +1,12 @@
 import sys
+from datetime import datetime
 from typing import Any, Dict, List, Union
 
 import boto3
+import pytz
 import ujson as json
 from asgiref.sync import sync_to_async
+from botocore.exceptions import ClientError
 from cloudaux import sts_conn
 from cloudaux.aws.decorators import rate_limited
 from cloudaux.aws.sts import boto3_cached_conn
@@ -13,6 +16,29 @@ from consoleme.lib.plugins import get_plugin_by_name
 
 log = config.get_logger("consoleme")
 stats = get_plugin_by_name(config.get("plugins.metrics", "default_metrics"))()
+
+
+async def is_object_older_than_seconds(
+    bucket: str, key: str, older_than_seconds: int, s3_client=None
+) -> bool:
+    """
+    This function checks if an S3 object is older than the specified number of seconds. if the object doesn't
+    exist, this function will return True.
+    """
+    now = datetime.utcnow().replace(tzinfo=pytz.utc)
+    if not s3_client:
+        s3_client = boto3.client("s3")
+    try:
+        res = sync_to_async(s3_client.head_object)(Bucket=bucket, Key=key)
+    except ClientError as e:
+        # If file is not found, we'll tell the user it's older than the specified time
+        if e.response.get("Error", {}).get("Code") == "404":
+            return True
+        raise
+    datetime_value = res["LastModified"]
+    if (now - datetime_value).total_seconds() > older_than_seconds:
+        return True
+    return False
 
 
 @rate_limited()

--- a/docker-compose-dependencies.yaml
+++ b/docker-compose-dependencies.yaml
@@ -12,8 +12,23 @@ services:
     container_name: consoleme-dynamodb
     entrypoint: java
     command: "-jar DynamoDBLocal.jar -sharedDb -dbPath /data -port 8005"
+    networks:
+      - dynamo
     ports:
       - "8005:8005"
     restart: always
     volumes:
       - ./dynamodb-data:/data:delegated
+
+  consoleme-dynamodb_admin:
+    container_name: consoleme-dynamodb-admin
+    image: aaronshaf/dynamodb-admin:latest
+    networks:
+      - dynamo
+    environment:
+      - DYNAMO_ENDPOINT=http://consoleme-dynamodb:8005
+    ports:
+      - "8001:8001"
+
+networks:
+  dynamo:


### PR DESCRIPTION
- [X] Validates a resource exists in our cache before returning a URL to the user
- [X] Adds `is_object_older_than_seconds` function used by internal functionality to check age of S3 object
- [X] Adds S3 log mapping for `REST.COPY.PART_GET`
- [X] Adds dynamodb-admin to docker-compose-dependencies.yaml (Thanks @patricksanders!)