### PR TITLE
Remove console errors caused by duplicate configuration of Dropdown

### DIFF
--- a/ui/src/components/Header.js
+++ b/ui/src/components/Header.js
@@ -50,7 +50,7 @@ const ConsoleMeHeader = () => {
   };
 
   const getAvatarImage = () => {
-    const dropdownOptions = [
+    let dropdownOptions = [
       {
         key: user.user,
         text: user.user,
@@ -58,21 +58,21 @@ const ConsoleMeHeader = () => {
         image: { avatar: true, src: user?.employee_photo_url },
       },
     ];
+    if (user?.can_logout) {
+      dropdownOptions.push({
+        key: "logout",
+        as: NavLink,
+        to: "/logout",
+        text: "Logout",
+      });
+    }
     return (
       <Dropdown
         inline
         options={dropdownOptions}
         defaultValue={dropdownOptions[0].value}
         icon={null}
-      >
-        <Dropdown.Menu>
-          {user?.can_logout ? (
-            <Dropdown.Item as={NavLink} to="/logout">
-              Logout
-            </Dropdown.Item>
-          ) : null}
-        </Dropdown.Menu>
-      </Dropdown>
+      />
     );
   };
 


### PR DESCRIPTION
 * Use only `options` param, removing the use of `children`

When developing locally, the `Dropdown` in the `Header` component throws a couple errors regarding how the component is configured.

![Screen Shot 2021-04-21 at 2 26 22 PM](https://user-images.githubusercontent.com/176965/115623172-af5bc100-a2ad-11eb-8a21-e12cd569a710.png)

I opted to stick with using `options`.  In the case that the logout option is needed I think we can get away with pushing that additional menu option and clear out the errors.