### PR TITLE
Conditionally render 'Help' items in Sidebar

### DIFF
--- a/consoleme/handlers/v2/user_profile.py
+++ b/consoleme/handlers/v2/user_profile.py
@@ -27,9 +27,13 @@ class UserProfileHandler(BaseAPIV1Handler):
         site_config = {
             "consoleme_logo": await get_random_security_logo(),
             "google_tracking_uri": config.get("google_analytics.tracking_url"),
-            "documentation_url": config.get("documentation_page"),
+            "documentation_url": config.get(
+                "documentation_page", "https://hawkins.gitbook.io/consoleme/"
+            ),
             "support_contact": config.get("support_contact"),
-            "support_chat_url": config.get("support_chat_url"),
+            "support_chat_url": config.get(
+                "support_chat_url", "https://discord.com/invite/nQVpNGGkYu"
+            ),
             "security_logo": config.get("security_logo.image"),
             "security_url": config.get("security_logo.url"),
         }

--- a/ui/src/components/Sidebar.js
+++ b/ui/src/components/Sidebar.js
@@ -91,45 +91,51 @@ const ConsoleMeSidebar = () => {
           <Menu.Item>
             <Menu.Header>Help</Menu.Header>
             <Menu.Menu>
-              <Menu.Item
-                as="a"
-                name="documentation"
-                href={documentation_url || ""}
-                rel="noopener noreferrer"
-                target="_blank"
-                style={{
-                  fontSize: "14px",
-                }}
-              >
-                <Icon name="file" />
-                Documentation
-              </Menu.Item>
-              <Menu.Item
-                as="a"
-                name="email"
-                href={support_contact ? "mailto:" + support_contact : "/"}
-                rel="noopener noreferrer"
-                target="_blank"
-                style={{
-                  fontSize: "14px",
-                }}
-              >
-                <Icon name="send" />
-                Email us
-              </Menu.Item>
-              <Menu.Item
-                as="a"
-                name="slack"
-                href={support_chat_url || "/"}
-                rel="noopener noreferrer"
-                target="_blank"
-                style={{
-                  fontSize: "14px",
-                }}
-              >
-                <Icon name="slack" />
-                Find us on Slack
-              </Menu.Item>
+              {documentation_url ? (
+                <Menu.Item
+                  as="a"
+                  name="documentation"
+                  href={documentation_url}
+                  rel="noopener noreferrer"
+                  target="_blank"
+                  style={{
+                    fontSize: "14px",
+                  }}
+                >
+                  <Icon name="file" />
+                  Documentation
+                </Menu.Item>
+              ) : null}
+              {support_contact ? (
+                <Menu.Item
+                  as="a"
+                  name="email"
+                  href={"mailto:" + support_contact}
+                  rel="noopener noreferrer"
+                  target="_blank"
+                  style={{
+                    fontSize: "14px",
+                  }}
+                >
+                  <Icon name="send" />
+                  Email us
+                </Menu.Item>
+              ) : null}
+              {support_chat_url ? (
+                <Menu.Item
+                  as="a"
+                  name="slack"
+                  href={support_chat_url || "/"}
+                  rel="noopener noreferrer"
+                  target="_blank"
+                  style={{
+                    fontSize: "14px",
+                  }}
+                >
+                  <Icon name="slack" />
+                  Chat with us
+                </Menu.Item>
+              ) : null}
             </Menu.Menu>
           </Menu.Item>
         </div>


### PR DESCRIPTION
This PR will conditionally render `Help` items in the Sidebar based on a configuration provided by the backend. By default, we will provide a `Documentation` link to our Gitbook ( https://hawkins.gitbook.io/consoleme/ ), and a Chat link to our Discord ( https://discord.gg/nQVpNGGkYu ). These can be overridden in configuration.

An ideal follow-up PR would make the Menu items here fully auto-render based on backend configuration. Meaning: We'd return a JSON response detailing each menu item we want to render, the text of that menu item, the link, and (optionally) an Icon.