### PR TITLE
Fix filename when exporting to JSON or CSV

### DIFF
--- a/ui/src/components/blocks/datatable/DataTableActionsComponent.js
+++ b/ui/src/components/blocks/datatable/DataTableActionsComponent.js
@@ -34,7 +34,7 @@ const DataTableActionsComponent = ({ filters, tableConfig }) => {
     setJsonExportLoading(true);
     fetchAllData()
       .then(({ data }) => {
-        generateFileDownload(JSON.stringify(data), "application/json", ".json");
+        generateFileDownload(JSON.stringify(data), "application/json", "json");
       })
       .catch((error) => console.error("Error during JSON export: ", error))
       .finally(() => setJsonExportLoading(false));
@@ -51,7 +51,7 @@ const DataTableActionsComponent = ({ filters, tableConfig }) => {
               console.error("Error when generating CSV: ", err);
               return;
             }
-            generateFileDownload(csv, "text/csv;charset=utf-8;", ".csv");
+            generateFileDownload(csv, "text/csv;charset=utf-8;", "csv");
           },
           {
             emptyFieldValue: "",


### PR DESCRIPTION
The function `generateFileDownload` already adds the `.` to the extension (on line 27). This was resulting in the filename being `console_me_export_<timestamp>..json` or `console_me_export_<timestamp>..csv`. This PR removes the extra `.` in the downloaded filename.