### PR TITLE
Terraform tweaks

### DIFF
--- a/terraform/central-account/data.tf
+++ b/terraform/central-account/data.tf
@@ -13,37 +13,3 @@ data "aws_ami" "amazon_linux" {
   owners = [
   var.ec2_ami_owner_filter]
 }
-
-data "template_file" "consoleme_config" {
-  template = file("${path.module}/templates/example_config_terraform.yaml")
-  vars = {
-    demo_target_role_arn                               = aws_iam_role.consoleme_target.arn
-    demo_app_role_arn_1                                = aws_iam_role.consoleme_example_app_role_1.arn
-    demo_app_role_arn_2                                = aws_iam_role.consoleme_example_app_role_2.arn
-    demo_user_role_arn_1                               = aws_iam_role.consoleme_example_user_role_1.arn
-    demo_user_role_arn_2                               = aws_iam_role.consoleme_example_user_role_2.arn
-    current_account_id                                 = data.aws_caller_identity.current.account_id
-    sync_accounts_from_organizations                   = var.sync_accounts_from_organizations
-    sync_accounts_from_organizations_master_account_id = var.sync_accounts_from_organizations_master_account_id != null ? var.sync_accounts_from_organizations_master_account_id : data.aws_caller_identity.current.account_id
-    sync_accounts_from_organizations_role_to_assume    = var.sync_accounts_from_organizations_role_to_assume
-    application_admin                                  = var.application_admin
-    region                                             = data.aws_region.current.name
-    jwt_email_key                                      = var.lb-authentication-jwt-email-key
-    jwt_groups_key                                     = var.lb-authentication-jwt-groups-key
-    user_facing_url                                    = var.user_facing_url == "" ? "https://${aws_lb.public-to-private-lb.dns_name}:${var.lb_port}" : var.user_facing_url
-    logout_url                                         = var.logout_url
-  }
-}
-
-data "template_file" "consoleme_userdata" {
-  template = file("${path.module}/templates/userdata.sh")
-  vars = {
-    bucket                  = aws_s3_bucket.consoleme_files_bucket.bucket
-    current_account_id      = data.aws_caller_identity.current.account_id
-    region                  = data.aws_region.current.name
-    CONFIG_LOCATION         = "/apps/consoleme/example_config/example_config_terraform.yaml"
-    CONSOLEME_CONFIG_S3     = format("s3://%s/%s", aws_s3_bucket.consoleme_files_bucket.id, aws_s3_bucket_object.consoleme_config.id)
-    custom_user_data_script = var.custom_user_data_script
-    consoleme_repo          = var.consoleme_repo
-  }
-}

--- a/terraform/central-account/main.tf
+++ b/terraform/central-account/main.tf
@@ -8,7 +8,15 @@ module "server" {
   key_name             = var.key_name
   iam_instance_profile = aws_iam_instance_profile.ConsoleMeInstanceProfile.name
   subnet_id            = module.network.private_subnets[0]
-  user_data            = data.template_file.consoleme_userdata.rendered
+  user_data = templatefile("${path.module}/templates/userdata.sh", tomap({
+    bucket                  = aws_s3_bucket.consoleme_files_bucket.bucket
+    current_account_id      = data.aws_caller_identity.current.account_id
+    region                  = data.aws_region.current.name
+    CONFIG_LOCATION         = "/apps/consoleme/example_config/example_config_terraform.yaml"
+    CONSOLEME_CONFIG_S3     = format("s3://%s/%s", aws_s3_bucket.consoleme_files_bucket.id, aws_s3_bucket_object.consoleme_config.id)
+    custom_user_data_script = var.custom_user_data_script
+    consoleme_repo          = var.consoleme_repo
+  }))
 
   root_block_device = [
     {

--- a/terraform/central-account/s3.tf
+++ b/terraform/central-account/s3.tf
@@ -25,7 +25,21 @@ resource "aws_s3_bucket_object" "consoleme_config" {
   bucket = aws_s3_bucket.consoleme_files_bucket.bucket
   key    = "config.yaml"
 
-  content = data.template_file.consoleme_config.rendered
-
-  etag = md5(base64encode(data.template_file.consoleme_config.rendered))
+  content = templatefile("${path.module}/templates/config_terraform.yaml", tomap({
+    demo_target_role_arn                               = aws_iam_role.consoleme_target.arn
+    demo_app_role_arn_1                                = aws_iam_role.consoleme_example_app_role_1.arn
+    demo_app_role_arn_2                                = aws_iam_role.consoleme_example_app_role_2.arn
+    demo_user_role_arn_1                               = aws_iam_role.consoleme_example_user_role_1.arn
+    demo_user_role_arn_2                               = aws_iam_role.consoleme_example_user_role_2.arn
+    current_account_id                                 = data.aws_caller_identity.current.account_id
+    sync_accounts_from_organizations                   = var.sync_accounts_from_organizations
+    sync_accounts_from_organizations_master_account_id = var.sync_accounts_from_organizations_master_account_id != null ? var.sync_accounts_from_organizations_master_account_id : data.aws_caller_identity.current.account_id
+    sync_accounts_from_organizations_role_to_assume    = var.sync_accounts_from_organizations_role_to_assume
+    application_admin                                  = var.application_admin
+    region                                             = data.aws_region.current.name
+    jwt_email_key                                      = var.lb-authentication-jwt-email-key
+    jwt_groups_key                                     = var.lb-authentication-jwt-groups-key
+    user_facing_url                                    = var.user_facing_url == "" ? "https://${aws_lb.public-to-private-lb.dns_name}:${var.lb_port}" : var.user_facing_url
+    logout_url                                         = var.logout_url
+  }))
 }

--- a/terraform/central-account/terraform.tf
+++ b/terraform/central-account/terraform.tf
@@ -2,10 +2,12 @@ provider "aws" {
   region = var.region
 }
 
-provider "template" {
-}
-
 terraform {
+  required_providers {
+    aws = {
+      version = ">= 3"
+    }
+  }
   required_version = ">= 0.13.0"
   // Unfortunately, we can't use variables to specify a backend S3 bucket / DynamoDB table for Terraform state
   // consistency. If you want to make use of this, you'll need to make a copy of these terraform files in your own


### PR DESCRIPTION
template_file has been deprecated for a while. The templatefile() function is better, and as an added benefit (assuming a recent enough aws provider) does not cause a replacement of the ec2 instance on every apply.