### PR TITLE
Replacing hard coding regions by variables

### DIFF
--- a/consoleme/handlers/v2/roles.py
+++ b/consoleme/handlers/v2/roles.py
@@ -43,7 +43,7 @@ class RoleConsoleLoginHandler(BaseAPIV2Handler):
         arguments = {k: self.get_argument(k) for k in self.request.arguments}
         role = role.lower()
         selected_roles = await group_mapping.filter_eligible_roles(role, self)
-        region = arguments.get("r", "us-east-1")
+        region = arguments.get("r", config.get("aws.region", "us-east-1"))
         redirect = arguments.get("redirect")
         log_data = {
             "user": self.user,

--- a/consoleme/lib/policies.py
+++ b/consoleme/lib/policies.py
@@ -1005,7 +1005,11 @@ async def get_url_for_resource(
 
 
 async def get_aws_config_history_url_for_resource(
-    account_id, resource_id, resource_name, technology, region=config.get("aws.region", "us-east-1")
+    account_id,
+    resource_id,
+    resource_name,
+    technology,
+    region=config.get("aws.region", "us-east-1"),
 ):
     if config.get("get_aws_config_history_url_for_resource.generate_conglomo_url"):
         return await get_conglomo_url_for_resource(

--- a/consoleme/lib/policies.py
+++ b/consoleme/lib/policies.py
@@ -1005,7 +1005,7 @@ async def get_url_for_resource(
 
 
 async def get_aws_config_history_url_for_resource(
-    account_id, resource_id, resource_name, technology, region="us-east-1"
+    account_id, resource_id, resource_name, technology, region=config.get("aws.region", "us-east-1")
 ):
     if config.get("get_aws_config_history_url_for_resource.generate_conglomo_url"):
         return await get_conglomo_url_for_resource(

--- a/consoleme/lib/ses.py
+++ b/consoleme/lib/ses.py
@@ -19,7 +19,7 @@ async def send_email(
     subject: str,
     body: str,
     sending_app: str = "consoleme",
-    region: str = "us-west-2",
+    region: str = config.get("ses.region", "us-west-2"),
     charset: str = "UTF-8",
 ) -> None:
     client = boto3.client("ses", region_name=region)

--- a/example_config/example_config_base.yaml
+++ b/example_config/example_config_base.yaml
@@ -63,6 +63,7 @@ cloud_credential_authorization_mapping:
 
 aws:
   issuer: YourCompany
+  region: "us-east-1"
 
 celery:
   # Some jobs should only run in one region. The `active_region` key should define your primary region.
@@ -163,6 +164,7 @@ logging_levels:
 ses:
   support_reference: "Please contact us at consoleme@example.com if you have any questions or concerns."
   arn: "arn:aws:ses:us-east-1:123456789012:identity/example.com"
+  region: "us-west-2"
   consoleme:
     name: ConsoleMe
     sender: consoleme_test@example.com


### PR DESCRIPTION
We deployed ConsoleMe using our home made Helm Chart, but we had problems using AWS SES because of our AWS resources aren't in the AWS US regions.
We spotted some hard coding regions in the code and we propose replacing it by a property in the configuration file. After the replacement the service worked fine.