### PR TITLE
add some CSS overrides to modify the vertical Tabs component layout

### DIFF
--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -14,3 +14,21 @@ code {
   max-width: 1920px;
   width: 100%;
 }
+
+/*
+  There are some layout issues with the Semantic UI vertical Tabs
+  component at lower resolutions, when used in combination with Labels.
+  This is our attempt at overriding some of this default behavior to
+  accommodate some more screen real estate.
+ */
+.ui.vertical.tabular.menu .item {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: space-between;
+  flex-wrap: wrap;
+}
+
+.ui.vertical.tabular.menu .item > .label {
+  margin: 0.5rem 0 0 0;
+}


### PR DESCRIPTION
Some layout issues were found with our implementation of the vertical Tabs menu at smaller screen sizes.  Without writing our own custom implementation of this menu, we can first try to add some custom CSS overrides to improve upon this behavior.  

You'll notice that I added `flex` behavior to the menu items, while allowing the items and labels to wrap when there is not enough horizontal space.  Hopefully this works, but do let me know if you see anything strange.  The wrapping will occur based on the combination of the tab text and the label text.

### Before
![Screen Shot 2021-05-13 at 11 08 00 AM](https://user-images.githubusercontent.com/176965/118167401-82498c80-b3db-11eb-8a60-5201ec28e99a.png)

### After
![Screen Shot 2021-05-13 at 11 42 37 AM](https://user-images.githubusercontent.com/176965/118171979-b5424f00-b3e0-11eb-9f0a-1c24300b3bc6.png)
