### PR TITLE
one more small design update to the vertical tab overrides

### DIFF
--- a/ui/src/components/policy/IAMRolePolicy.js
+++ b/ui/src/components/policy/IAMRolePolicy.js
@@ -160,7 +160,7 @@ const IAMRolePolicy = () => {
     <Tab
       menu={{ fluid: true, vertical: true, tabular: true }}
       panes={tabs}
-      style={{ minHeight: "100vh" }}
+      className="vertical-tab-override"
     />
   );
 };

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -21,7 +21,16 @@ code {
   This is our attempt at overriding some of this default behavior to
   accommodate some more screen real estate.
  */
-.ui.vertical.tabular.menu .item {
+.vertical-tab-override,
+.vertical-tab-override .ui.grid {
+  min-height: 100vh;
+}
+
+.vertical-tab-override .ui.vertical.menu.fluid {
+  height: 100%;
+}
+
+.vertical-tab-override .ui.vertical.tabular.menu .item {
   display: flex;
   flex-direction: column;
   align-items: flex-start;
@@ -29,6 +38,11 @@ code {
   flex-wrap: wrap;
 }
 
-.ui.vertical.tabular.menu .item > .label {
+.vertical-tab-override .ui.vertical.tabular.menu .item > .label {
   margin: 0.5rem 0 0 0;
+}
+
+.vertical-tab-override .ui.attached.segment {
+  border: none;
+  padding: 0;
 }


### PR DESCRIPTION
The idea was suggested to remove the border from the active tab and extend the vertical line of the menu all the way down the page.  Test this out and let me know what you think.  Thanks!