### PR TITLE
Add support for AWS Secrets Manager, Redislite

### DIFF
--- a/consoleme/celery_tasks/celery_tasks.py
+++ b/consoleme/celery_tasks/celery_tasks.py
@@ -10,6 +10,7 @@ command: celery -A consoleme.celery_tasks.celery_tasks worker --loglevel=info -l
 from __future__ import absolute_import
 
 import json  # We use a separate SetEncoder here so we cannot use ujson
+import os
 import sys
 import time
 from datetime import datetime, timedelta
@@ -100,11 +101,27 @@ app = Celery(
     backend=config.get(f"celery.backend.{config.region}", "redis://127.0.0.1:6379/2"),
 )
 
+if config.get("redis.use_redislite"):
+    import tempfile
+
+    import redislite
+
+    redislite_db_path = os.path.join(
+        config.get("redis.redislite.db_path", tempfile.NamedTemporaryFile(delete=False))
+    )
+    redislite_client = redislite.Redis(redislite_db_path)
+    redislite_socket_path = f"redis+socket://{redislite_client.socket_file}"
+    app = Celery(
+        "tasks",
+        broker=config.get(f"{redislite_socket_path}/1"),
+        backend=config.get(f"{redislite_socket_path}/2"),
+    )
+
 app.conf.result_expires = config.get("celery.result_expires", 60)
 app.conf.worker_prefetch_multiplier = config.get("celery.worker_prefetch_multiplier", 4)
 app.conf.task_acks_late = config.get("celery.task_acks_late", True)
 
-if config.get("celery.purge"):
+if config.get("celery.purge") and not config.get("redis.use_redislite"):
     # Useful to clear celery queue in development
     with Timeout(seconds=5, error_message="Timeout: Are you sure Redis is running?"):
         app.control.purge()

--- a/consoleme/lib/aws_secret_manager.py
+++ b/consoleme/lib/aws_secret_manager.py
@@ -1,0 +1,16 @@
+import base64
+
+import boto3
+
+
+async def get_aws_secret(secret_name, region):
+    session = boto3.session.Session()
+    client = session.client(
+        service_name="secretsmanager",
+        region_name=region,
+    )
+    get_secret_value_response = client.get_secret_value(SecretId=secret_name)
+    if "SecretString" in get_secret_value_response:
+        return get_secret_value_response["SecretString"]
+    else:
+        return base64.b64decode(get_secret_value_response["SecretBinary"])

--- a/consoleme/lib/dynamo.py
+++ b/consoleme/lib/dynamo.py
@@ -15,7 +15,7 @@ import boto3
 import sentry_sdk
 import simplejson as json
 import yaml
-from asgiref.sync import async_to_sync, sync_to_async
+from asgiref.sync import sync_to_async
 from boto3.dynamodb.types import Binary  # noqa
 from cloudaux import get_iso_string
 from cloudaux.aws.sts import boto3_cached_conn
@@ -260,7 +260,7 @@ class UserDynamoHandler(BaseDynamoHandler):
 
     def get_dynamic_config_dict(self) -> dict:
         """Retrieve dynamic configuration dictionary that can be merged with primary configuration dictionary."""
-        current_config_yaml = async_to_sync(self.get_dynamic_config_yaml)()
+        current_config_yaml = asyncio.run(self.get_dynamic_config_yaml())
         config_d = yaml.safe_load(current_config_yaml)
         return config_d
 

--- a/consoleme/lib/redis.py
+++ b/consoleme/lib/redis.py
@@ -1,3 +1,4 @@
+import os
 import sys
 import threading
 from typing import Optional
@@ -10,6 +11,14 @@ from redis.client import Redis
 
 from consoleme.config import config
 from consoleme.lib.plugins import get_plugin_by_name
+
+if config.get("redis.use_redislite"):
+    import tempfile
+
+    import redislite
+
+    if not config.get("redis.redis_lite.db_path"):
+        default_redislite_db_path = tempfile.NamedTemporaryFile(delete=False)
 
 region = config.region
 log = config.get_logger()
@@ -359,6 +368,11 @@ class RedisHandler:
             self.enabled = False
 
     async def redis(self, db: int = 0) -> Redis:
+        if config.get("redis.use_redislite"):
+            REDIS_DB_PATH = os.path.join(
+                config.get("redis.redis_lite.db_path", default_redislite_db_path)
+            )
+            return redislite.StrictRedis(REDIS_DB_PATH)
         self.red = await sync_to_async(ConsoleMeRedis)(
             host=self.host,
             port=self.port,
@@ -369,6 +383,11 @@ class RedisHandler:
         return self.red
 
     def redis_sync(self, db: int = 0) -> Redis:
+        if config.get("redis.use_redislite"):
+            REDIS_DB_PATH = os.path.join(
+                config.get("redis.redis_lite.db_path", default_redislite_db_path)
+            )
+            return redislite.StrictRedis(REDIS_DB_PATH)
         self.red = ConsoleMeRedis(
             host=self.host,
             port=self.port,

--- a/requirements.in
+++ b/requirements.in
@@ -45,6 +45,7 @@ python-json-logger==0.1.11 # Needed until this is merged and new version created
 python3-saml
 pytz
 redis
+redislite
 requests
 retry
 retrying

--- a/requirements.txt
+++ b/requirements.txt
@@ -276,6 +276,8 @@ protobuf==3.15.6
     # via
     #   google-api-core
     #   googleapis-common-protos
+psutil==5.8.0
+    # via redislite
 ptyprocess==0.7.0
     # via pexpect
 py==1.10.0
@@ -339,6 +341,9 @@ redis==3.5.3
     # via
     #   -r requirements.in
     #   celery
+    #   redislite
+redislite==6.0.674960
+    # via -r requirements.in
 regex==2020.11.13
     # via black
 requests==2.25.1


### PR DESCRIPTION
This PR adds support for leveraging Redislite for situations where you do not want or cannot use a real redis environment. One such use case is deploying ConsoleMe to AWS AppRunner.

This PR also adds support for retrieving a YAML string from AWS Secrets Manager

- [X] Configurable usage of Redislite for Celery and other Redis operations
- [X] Configurable recurring task to periodically purge Redislite database to force a cache refresh
- [X] Add AWS Secrets Manager support to ConsoleMe configuration `extends` feature. Adding an entry to `extends` that starts with   `AWS_SECRETS_MANAGER:<secret_arn_or_name>` will cause ConsoleMe to try to retrieve secret_arn_or_name, convert it from a yaml string to a dictionary, and then merge it with the rest of the configuration.