### PR TITLE
Send email on request creation

### DIFF
--- a/consoleme/lib/ses.py
+++ b/consoleme/lib/ses.py
@@ -333,12 +333,14 @@ async def send_policy_request_status_update_v2(
     extended_request: ExtendedRequestModel, policy_change_uri, sending_app="consoleme"
 ):
     app_name = config.get(f"ses.{sending_app}.name", sending_app)
-
+    to_addresses = [extended_request.requester_email]
     if extended_request.request_status == RequestStatus.pending:
         subject = f"{app_name}: Policy change request for {extended_request.arn} has been created"
         message = (
             f"A policy change request for {extended_request.arn} has been created."
         )
+        # This is a new request, also send email to application admins
+        to_addresses.append(config.get("application_admin"))
     else:
         subject = (
             f"{app_name}: Policy change request for {extended_request.arn} has been "
@@ -348,7 +350,6 @@ async def send_policy_request_status_update_v2(
             f"A policy change request for {extended_request.arn} "
             f"has been updated to {extended_request.request_status.value}"
         )
-    to_addresses = [extended_request.requester_email]
 
     if extended_request.request_status == RequestStatus.approved:
         message += " and committed"

--- a/default_plugins/consoleme_default_plugins/plugins/aws/aws.py
+++ b/default_plugins/consoleme_default_plugins/plugins/aws/aws.py
@@ -29,6 +29,7 @@ from consoleme.exceptions.exceptions import (
 from consoleme.lib.account_indexers import get_account_id_to_name_mapping
 from consoleme.lib.dynamo import IAMRoleDynamoHandler
 from consoleme.lib.plugins import get_plugin_by_name
+from consoleme.lib.policies import send_communications_policy_change_request_v2
 from consoleme.lib.redis import RedisHandler
 
 stats = get_plugin_by_name(config.get("plugins.metrics", "default_metrics"))()
@@ -565,11 +566,7 @@ class Aws:
         :param extended_request:
         :return:
         """
-        log_data: dict = {
-            "function": f"{__name__}.{self.__class__.__name__}.{sys._getframe().f_code.co_name}",
-            "message": "Function is not configured.",
-        }
-        log.warning(log_data)
+        await send_communications_policy_change_request_v2(extended_request)
         return
 
     @staticmethod


### PR DESCRIPTION
Currently, the OSS version doesn't send an email on request creation. With this PR, if you are using the default AWS plugin, then an email will be sent to the original requester + the admins (`application_admin`)