### PR TITLE
Allow automatic static configuration reload

### DIFF
--- a/consoleme/config/config.py
+++ b/consoleme/config/config.py
@@ -128,12 +128,15 @@ class Configuration(object):
         while True:
             async_to_sync(self.load_config)(
                 allow_automatically_reload_configuration=False,
-                allow_start_background_threads=False)
+                allow_start_background_threads=False,
+            )
             time.sleep(self.get("dynamic_config.reload_static_config_interval", 60))
 
-    async def load_config(self,
-                          allow_automatically_reload_configuration=True,
-                          allow_start_background_threads=True):
+    async def load_config(
+        self,
+        allow_automatically_reload_configuration=True,
+        allow_start_background_threads=True,
+    ):
         """Load configuration from the location given to us by config_plugin"""
         path = config_plugin.get_config_location()
 
@@ -158,12 +161,16 @@ class Configuration(object):
         if allow_start_background_threads and self.get("config.load_from_dynamo", True):
             Timer(0, self.load_config_from_dynamo, ()).start()
 
-        if allow_start_background_threads and self.get("config.run_recurring_internal_tasks"):
+        if allow_start_background_threads and self.get(
+            "config.run_recurring_internal_tasks"
+        ):
             Timer(
                 0, config_plugin.internal_functions, kwargs={"cfg": self.config}
             ).start()
 
-        if allow_automatically_reload_configuration and self.get("config.automatically_reload_configuration"):
+        if allow_automatically_reload_configuration and self.get(
+            "config.automatically_reload_configuration"
+        ):
             Timer(0, self.reload_config, ()).start()
 
     def get(

--- a/consoleme/config/config.py
+++ b/consoleme/config/config.py
@@ -130,6 +130,8 @@ class Configuration(object):
                 allow_automatically_reload_configuration=False,
                 allow_start_background_threads=False,
             )
+            if not self.get("config.automatically_reload_configuration"):
+                break
             time.sleep(self.get("dynamic_config.reload_static_config_interval", 60))
 
     async def load_config(


### PR DESCRIPTION
This PR makes it possible to periodically reload ConsoleMe's static configuration file on disk. Ideally, this is a feature that should only be used in development or debugging. 

This also paves the way for a ConsoleMe configuration UI that will allow you to generate a configuration, and have ConsoleMe load the configuration without needing to restart. The `config.automatically_reload_configuration` must be set in ConsoleMe's initial configuration to use this feature. 

- [X] Allow automatically reloading ConsoleMe's static configuration on disk based on the  `config.automatically_reload_configuration` configuration variable


