### PR TITLE
Force aws_config and iam_role celery tasks to wait until works have cached all accounts

### DIFF
--- a/consoleme/handlers/v1/policies.py
+++ b/consoleme/handlers/v1/policies.py
@@ -162,7 +162,9 @@ async def handle_resource_type_ahead_request(cls):
         except Exception as e:  # noqa
             accounts = {}
 
-        app_to_role_map = json.loads(data)
+        app_to_role_map = {}
+        if data:
+            app_to_role_map = json.loads(data)
         seen: Dict = {}
         seen_roles = {}
         for app_name, roles in app_to_role_map.items():

--- a/consoleme/lib/redis.py
+++ b/consoleme/lib/redis.py
@@ -18,7 +18,7 @@ if config.get("redis.use_redislite"):
     import redislite
 
     if not config.get("redis.redis_lite.db_path"):
-        default_redislite_db_path = tempfile.NamedTemporaryFile(delete=False)
+        default_redislite_db_path = tempfile.NamedTemporaryFile().name
 
 region = config.region
 log = config.get_logger()
@@ -372,7 +372,7 @@ class RedisHandler:
     async def redis(self, db: int = 0) -> Redis:
         if config.get("redis.use_redislite"):
             REDIS_DB_PATH = os.path.join(
-                config.get("redis.redis_lite.db_path", default_redislite_db_path)
+                config.get("redis.redislite.db_path", default_redislite_db_path)
             )
             return redislite.StrictRedis(REDIS_DB_PATH)
         self.red = await sync_to_async(ConsoleMeRedis)(
@@ -387,7 +387,7 @@ class RedisHandler:
     def redis_sync(self, db: int = 0) -> Redis:
         if config.get("redis.use_redislite"):
             REDIS_DB_PATH = os.path.join(
-                config.get("redis.redis_lite.db_path", default_redislite_db_path)
+                config.get("redis.redislite.db_path", default_redislite_db_path)
             )
             return redislite.StrictRedis(REDIS_DB_PATH)
         self.red = ConsoleMeRedis(

--- a/tests/celery/test_celery.py
+++ b/tests/celery/test_celery.py
@@ -90,7 +90,17 @@ class TestCelerySync(TestCase):
             {
                 "function": "consoleme.celery_tasks.celery_tasks.cache_roles_across_accounts",
                 "cache_key": "test_cache_roles_for_account",
-                "num_roles": 0,
+                "num_roles": 15,
+                "num_accounts": 1,
+            },
+        )  # This should spin off extra fake celery tasks
+        res = self.celery.cache_roles_across_accounts()
+        self.assertEqual(
+            res,
+            {
+                "function": "consoleme.celery_tasks.celery_tasks.cache_roles_across_accounts",
+                "cache_key": "test_cache_roles_for_account",
+                "num_roles": 15,
                 "num_accounts": 1,
             },
         )


### PR DESCRIPTION
This PR causes the cache_roles_across_accounts and cache_resources_from_aws_config_across_accounts celery tasks to wait for all workers to complete their tasks before caching all roles / resources in S3. This alleviates the need to wait for two full cycles (1 hour) to pass prior to seeing new resources in ConsoleMe. 

This PR also fixes a bug in the configurable redislite integration.