### PR TITLE
Allow Roles/Config celery tasks to run synchronous subtasks

### DIFF
--- a/consoleme/celery_tasks/celery_tasks.py
+++ b/consoleme/celery_tasks/celery_tasks.py
@@ -761,7 +761,7 @@ def cache_roles_for_account(account_id: str) -> bool:
 
 
 @app.task(soft_time_limit=3600)
-def cache_roles_across_accounts() -> Dict:
+def cache_roles_across_accounts(wait_for_subtask_completion=True) -> Dict:
     function = f"{__name__}.{sys._getframe().f_code.co_name}"
 
     cache_key = config.get("aws.iamroles_redis_key", "IAM_ROLE_CACHE")
@@ -782,8 +782,9 @@ def cache_roles_across_accounts() -> Dict:
                     tasks.append(cache_roles_for_account.s(account_id))
 
         results = group(*tasks).apply_async()
-        # results.join() forces function to wait until all tasks are complete
-        results.join(disable_sync_subtasks=False)
+        if wait_for_subtask_completion:
+            # results.join() forces function to wait until all tasks are complete
+            results.join(disable_sync_subtasks=False)
     else:
         dynamo = IAMRoleDynamoHandler()
         # In non-active regions, we just want to sync DDB data to Redis
@@ -1192,9 +1193,9 @@ def cache_resources_from_aws_config_for_account(account_id) -> dict:
 
 
 @app.task(soft_time_limit=3600)
-def cache_resources_from_aws_config_across_accounts() -> Dict[
-    str, Union[Union[str, int], Any]
-]:
+def cache_resources_from_aws_config_across_accounts(
+    wait_for_subtask_completion=True,
+) -> Dict[str, Union[Union[str, int], Any]]:
     function = f"{__name__}.{sys._getframe().f_code.co_name}"
     resource_redis_cache_key = config.get(
         "aws_config_cache.redis_key", "AWSCONFIG_RESOURCE_CACHE"
@@ -1217,7 +1218,8 @@ def cache_resources_from_aws_config_across_accounts() -> Dict[
                 tasks.append(cache_resources_from_aws_config_for_account.s(account_id))
     if tasks:
         results = group(*tasks).apply_async()
-        results.join(disable_sync_subtasks=False)
+        if wait_for_subtask_completion:
+            results.join(disable_sync_subtasks=False)
     # Delete roles in Redis cache with expired TTL
     all_resources = red.hgetall(resource_redis_cache_key)
     if all_resources:

--- a/scripts/initialize_redis_oss.py
+++ b/scripts/initialize_redis_oss.py
@@ -60,5 +60,7 @@ else:
     celery.cache_policies_table_details()
     celery.cache_policy_requests()
     celery.cache_credential_authorization_mapping()
+    # Forces writing config to S3
+    celery.cache_roles_across_accounts(wait_for_subtask_completion=False)
 
 print("Done caching redis data")


### PR DESCRIPTION
This PR adds the `disable_sync_subtasks=False` argument to `results.join` to the tasks that sync roles and resources from AWS config. 
This is necessary to prevent a RunTimeError from Celery.

In the future, we should refactor to chain tasks that are dependent on other tasks.