### PR TITLE
Remove custom docker network from DynamoDB container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,7 +93,7 @@ celerybeat-schedule
 *.sage.py
 
 # Environments
-.env
+.env*
 .venv
 env/
 venv/

--- a/docker-compose-dependencies.yaml
+++ b/docker-compose-dependencies.yaml
@@ -25,6 +25,3 @@ services:
       - DYNAMO_ENDPOINT=http://consoleme-dynamodb:8005
     ports:
       - "8001:8001"
-
-networks:
-  dynamo:

--- a/docker-compose-dependencies.yaml
+++ b/docker-compose-dependencies.yaml
@@ -12,8 +12,6 @@ services:
     container_name: consoleme-dynamodb
     entrypoint: java
     command: "-jar DynamoDBLocal.jar -sharedDb -dbPath /data -port 8005"
-    networks:
-      - dynamo
     ports:
       - "8005:8005"
     restart: always
@@ -23,8 +21,6 @@ services:
   consoleme-dynamodb_admin:
     container_name: consoleme-dynamodb-admin
     image: aaronshaf/dynamodb-admin:latest
-    networks:
-      - dynamo
     environment:
       - DYNAMO_ENDPOINT=http://consoleme-dynamodb:8005
     ports:


### PR DESCRIPTION
This PR removes custom network from DynamoDB container, which is preventing the ConsoleMe docker image from communicating to DynamoDB local when deployed to EC2/Ubuntu