### PR TITLE
Celery task caching enhancements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ redis:
 
 .PHONY: test
 test: clean
-	CONSOLEME_CONFIG_ENTRYPOINT=$(CONSOLEME_CONFIG_ENTRYPOINT) CONFIG_LOCATION=example_config/example_config_test.yaml $(pytest)
+	ASYNC_TEST_TIMEOUT=60 CONSOLEME_CONFIG_ENTRYPOINT=$(CONSOLEME_CONFIG_ENTRYPOINT) CONFIG_LOCATION=example_config/example_config_test.yaml $(pytest)
 
 .PHONY: bandit
 bandit: clean
@@ -58,7 +58,7 @@ bandit: clean
 
 .PHONY: testhtml
 testhtml: clean
-	CONSOLEME_CONFIG_ENTRYPOINT=$(CONSOLEME_CONFIG_ENTRYPOINT) CONFIG_LOCATION=example_config/example_config_test.yaml $(pytest) $(html_report) && open htmlcov/index.html
+	ASYNC_TEST_TIMEOUT=60 CONSOLEME_CONFIG_ENTRYPOINT=$(CONSOLEME_CONFIG_ENTRYPOINT) CONFIG_LOCATION=example_config/example_config_test.yaml $(pytest) $(html_report) && open htmlcov/index.html
 
 .PHONY: clean
 clean:

--- a/consoleme/celery_tasks/celery_tasks.py
+++ b/consoleme/celery_tasks/celery_tasks.py
@@ -122,15 +122,15 @@ if config.get("redis.use_redislite"):
     redislite_socket_path = f"redis+socket://{redislite_client.socket_file}"
     app = Celery(
         "tasks",
-        broker=config.get(f"{redislite_socket_path}/1"),
-        backend=config.get(f"{redislite_socket_path}/2"),
+        broker=f"{redislite_socket_path}?virtual_host=1",
+        backend=f"{redislite_socket_path}?virtual_host=2",
     )
 
 app.conf.result_expires = config.get("celery.result_expires", 60)
 app.conf.worker_prefetch_multiplier = config.get("celery.worker_prefetch_multiplier", 4)
 app.conf.task_acks_late = config.get("celery.task_acks_late", True)
 
-if config.get("celery.purge") and not config.get("redis.use_redislite"):
+if config.get("celery.purge"):
     # Useful to clear celery queue in development
     with Timeout(seconds=5, error_message="Timeout: Are you sure Redis is running?"):
         app.control.purge()
@@ -438,6 +438,28 @@ def report_revoked_task(**kwargs):
     stats.timer("celery.revoked_task", tags=error_tags)
 
 
+def is_task_already_running(fun, args):
+    """
+    Returns True if an identical task for a given function (and arguments) is already being
+    ran by Celery.
+    """
+    task_id = None
+    if celery.current_task:
+        task_id = celery.current_task.request.id
+    if not task_id:
+        return False
+    log.debug(task_id)
+
+    active_tasks = app.control.inspect()._request("active")
+    for _, tasks in active_tasks.items():
+        for task in tasks:
+            if task.get("id") == task_id:
+                continue
+            if task.get("name") == fun and task.get("args") == args:
+                return True
+    return False
+
+
 @retry(
     stop_max_attempt_number=4,
     wait_exponential_multiplier=1000,
@@ -460,7 +482,7 @@ def _add_role_to_redis(redis_key: str, role_entry: Dict) -> None:
         'templated': None, 'ttl': 1562510908, 'policy': '<json_formatted_policy>'}
     """
     try:
-        red.hset(redis_key, role_entry["arn"], json.dumps(role_entry))
+        red.hset(redis_key, str(role_entry["arn"]), str(json.dumps(role_entry)))
     except Exception as e:  # noqa
         stats.count(
             "cache_roles_for_account.error",
@@ -761,13 +783,15 @@ def cache_roles_for_account(account_id: str) -> bool:
 
 
 @app.task(soft_time_limit=3600)
-def cache_roles_across_accounts(wait_for_subtask_completion=True) -> Dict:
+def cache_roles_across_accounts(
+    run_subtasks: bool = True, wait_for_subtask_completion: bool = True
+) -> Dict:
     function = f"{__name__}.{sys._getframe().f_code.co_name}"
 
     cache_key = config.get("aws.iamroles_redis_key", "IAM_ROLE_CACHE")
 
     log_data = {"function": function, "cache_key": cache_key}
-    accounts_d = async_to_sync(get_account_id_to_name_mapping)()
+    accounts_d: Dict[str, str] = async_to_sync(get_account_id_to_name_mapping)()
     tasks = []
     if config.region == config.get("celery.active_region", config.region) or config.get(
         "environment"
@@ -780,11 +804,11 @@ def cache_roles_across_accounts(wait_for_subtask_completion=True) -> Dict:
             else:
                 if account_id in config.get("celery.test_account_ids", []):
                     tasks.append(cache_roles_for_account.s(account_id))
-
-        results = group(*tasks).apply_async()
-        if wait_for_subtask_completion:
-            # results.join() forces function to wait until all tasks are complete
-            results.join(disable_sync_subtasks=False)
+        if run_subtasks:
+            results = group(*tasks).apply_async()
+            if wait_for_subtask_completion:
+                # results.join() forces function to wait until all tasks are complete
+                results.join(disable_sync_subtasks=False)
     else:
         dynamo = IAMRoleDynamoHandler()
         # In non-active regions, we just want to sync DDB data to Redis
@@ -838,6 +862,7 @@ def cache_managed_policies_for_account(account_id: str) -> Dict[str, Union[str, 
     log_data = {
         "function": f"{__name__}.{sys._getframe().f_code.co_name}",
         "account_id": account_id,
+        "message": "Successfully cached IAM managed policies for account",
         "number_managed_policies": len(all_policies),
     }
     log.debug(log_data)
@@ -863,7 +888,7 @@ def cache_managed_policies_for_account(account_id: str) -> Dict[str, Union[str, 
     return log_data
 
 
-@app.task(soft_time_limit=120)
+@app.task(soft_time_limit=3600)
 def cache_managed_policies_across_accounts() -> bool:
     function = f"{__name__}.{sys._getframe().f_code.co_name}"
     # First, get list of accounts
@@ -880,51 +905,180 @@ def cache_managed_policies_across_accounts() -> bool:
     return True
 
 
-@app.task(soft_time_limit=120)
-def cache_s3_buckets_across_accounts() -> bool:
+@app.task(soft_time_limit=3600)
+def cache_s3_buckets_across_accounts(
+    run_subtasks: bool = True, wait_for_subtask_completion: bool = True
+) -> Dict[str, Any]:
     function: str = f"{__name__}.{sys._getframe().f_code.co_name}"
-    # First, get list of accounts
-    accounts_d: List = async_to_sync(get_account_id_to_name_mapping)()
-    # Second, call tasks to enumerate all the roles across all accounts
-    for account_id in accounts_d.keys():
-        if config.get("environment") == "prod":
-            cache_s3_buckets_for_account.delay(account_id)
-        else:
-            if account_id in config.get("celery.test_account_ids", []):
-                cache_s3_buckets_for_account.delay(account_id)
+    s3_bucket_redis_key: str = config.get("redis.s3_buckets_key", "S3_BUCKETS")
+    s3_bucket = config.get("account_resource_cache.s3_combined.bucket")
+    s3_key = config.get(
+        "account_resource_cache.s3_combined.file",
+        "account_resource_cache/cache_s3_combined_v1.json.gz",
+    )
+
+    accounts_d: Dict[str, str] = async_to_sync(get_account_id_to_name_mapping)()
+    log_data = {
+        "function": function,
+        "num_accounts": len(accounts_d.keys()),
+        "run_subtasks": run_subtasks,
+        "wait_for_subtask_completion": wait_for_subtask_completion,
+    }
+    tasks = []
+    if config.region == config.get("celery.active_region", config.region) or config.get(
+        "environment"
+    ) in ["dev"]:
+        # Call tasks to enumerate all S3 buckets across all accounts
+        for account_id in accounts_d.keys():
+            if config.get("environment") in ["prod", "dev"]:
+                tasks.append(cache_s3_buckets_for_account.s(account_id))
+            else:
+                if account_id in config.get("celery.test_account_ids", []):
+                    tasks.append(cache_s3_buckets_for_account.s(account_id))
+    log_data["num_tasks"] = len(tasks)
+    if tasks and run_subtasks:
+        results = group(*tasks).apply_async()
+        if wait_for_subtask_completion:
+            # results.join() forces function to wait until all tasks are complete
+            results.join(disable_sync_subtasks=False)
+    if config.region == config.get("celery.active_region", config.region) or config.get(
+        "environment"
+    ) in ["dev", "test"]:
+        all_buckets = red.hgetall(s3_bucket_redis_key)
+        async_to_sync(store_json_results_in_redis_and_s3)(
+            all_buckets, s3_bucket=s3_bucket, s3_key=s3_key
+        )
+    else:
+        redis_result_set = async_to_sync(retrieve_json_data_from_redis_or_s3)(
+            s3_bucket=s3_bucket, s3_key=s3_key
+        )
+        async_to_sync(store_json_results_in_redis_and_s3)(
+            redis_result_set,
+            redis_key=s3_bucket_redis_key,
+            redis_data_type="hash",
+        )
+    log.debug(
+        {**log_data, "message": "Successfully cached s3 buckets across known accounts"}
+    )
     stats.count(f"{function}.success")
-    return True
+    return log_data
 
 
-@app.task(soft_time_limit=120)
-def cache_sqs_queues_across_accounts() -> bool:
+@app.task(soft_time_limit=3600)
+def cache_sqs_queues_across_accounts(
+    run_subtasks: bool = True, wait_for_subtask_completion: bool = True
+) -> Dict[str, Any]:
     function: str = f"{__name__}.{sys._getframe().f_code.co_name}"
-    # First, get list of accounts
-    accounts_d: List = async_to_sync(get_account_id_to_name_mapping)()
-    # Second, call tasks to enumerate all the roles across all accounts
-    for account_id in accounts_d.keys():
-        if config.get("environment") == "prod":
-            cache_sqs_queues_for_account.delay(account_id)
-        else:
-            if account_id in config.get("celery.test_account_ids", []):
-                cache_sqs_queues_for_account.delay(account_id)
+    sqs_queue_redis_key: str = config.get("redis.sqs_queues_key", "SQS_QUEUES")
+    s3_bucket = config.get("account_resource_cache.sqs_combined.bucket")
+    s3_key = config.get(
+        "account_resource_cache.sqs_combined.file",
+        "account_resource_cache/cache_sqs_queues_combined_v1.json.gz",
+    )
+
+    accounts_d: Dict[str, str] = async_to_sync(get_account_id_to_name_mapping)()
+    log_data = {
+        "function": function,
+        "num_accounts": len(accounts_d.keys()),
+        "run_subtasks": run_subtasks,
+        "wait_for_subtask_completion": wait_for_subtask_completion,
+    }
+    tasks = []
+    if config.region == config.get("celery.active_region", config.region) or config.get(
+        "environment"
+    ) in ["dev"]:
+        for account_id in accounts_d.keys():
+            if config.get("environment") in ["prod", "dev"]:
+                tasks.append(cache_sqs_queues_for_account.s(account_id))
+            else:
+                if account_id in config.get("celery.test_account_ids", []):
+                    tasks.append(cache_sqs_queues_for_account.s(account_id))
+    log_data["num_tasks"] = len(tasks)
+    if tasks and run_subtasks:
+        results = group(*tasks).apply_async()
+        if wait_for_subtask_completion:
+            # results.join() forces function to wait until all tasks are complete
+            results.join(disable_sync_subtasks=False)
+    if config.region == config.get("celery.active_region", config.region) or config.get(
+        "environment"
+    ) in ["dev", "test"]:
+        all_queues = red.hgetall(sqs_queue_redis_key)
+        async_to_sync(store_json_results_in_redis_and_s3)(
+            all_queues, s3_bucket=s3_bucket, s3_key=s3_key
+        )
+    else:
+        redis_result_set = async_to_sync(retrieve_json_data_from_redis_or_s3)(
+            s3_bucket=s3_bucket, s3_key=s3_key
+        )
+        async_to_sync(store_json_results_in_redis_and_s3)(
+            redis_result_set,
+            redis_key=sqs_queue_redis_key,
+            redis_data_type="hash",
+        )
+    log.debug(
+        {**log_data, "message": "Successfully cached SQS queues across known accounts"}
+    )
     stats.count(f"{function}.success")
-    return True
+    return log_data
 
 
-@app.task(soft_time_limit=120)
-def cache_sns_topics_across_accounts() -> bool:
+@app.task(soft_time_limit=3600)
+def cache_sns_topics_across_accounts(
+    run_subtasks: bool = True, wait_for_subtask_completion: bool = True
+) -> Dict[str, Any]:
     function: str = f"{__name__}.{sys._getframe().f_code.co_name}"
+    sns_topic_redis_key: str = config.get("redis.sns_topics_key", "SNS_TOPICS")
+    s3_bucket = config.get("account_resource_cache.sns_topics_combined.bucket")
+    s3_key = config.get(
+        "account_resource_cache.{resource_type}_topics_combined.file",
+        "account_resource_cache/cache_{resource_type}_combined_v1.json.gz",
+    ).format(resource_type="sns_topics")
+
     # First, get list of accounts
-    accounts_d: List = async_to_sync(get_account_id_to_name_mapping)()
-    for account_id in accounts_d.keys():
-        if config.get("environment") == "prod":
-            cache_sns_topics_for_account.delay(account_id)
-        else:
-            if account_id in config.get("celery.test_account_ids", []):
-                cache_sns_topics_for_account.delay(account_id)
+    accounts_d: Dict[str, str] = async_to_sync(get_account_id_to_name_mapping)()
+    log_data = {
+        "function": function,
+        "num_accounts": len(accounts_d.keys()),
+        "run_subtasks": run_subtasks,
+        "wait_for_subtask_completion": wait_for_subtask_completion,
+    }
+    tasks = []
+    if config.region == config.get("celery.active_region", config.region) or config.get(
+        "environment"
+    ) in ["dev"]:
+        for account_id in accounts_d.keys():
+            if config.get("environment") in ["prod", "dev"]:
+                tasks.append(cache_sns_topics_for_account.s(account_id))
+            else:
+                if account_id in config.get("celery.test_account_ids", []):
+                    tasks.append(cache_sns_topics_for_account.s(account_id))
+    log_data["num_tasks"] = len(tasks)
+    if tasks and run_subtasks:
+        results = group(*tasks).apply_async()
+        if wait_for_subtask_completion:
+            # results.join() forces function to wait until all tasks are complete
+            results.join(disable_sync_subtasks=False)
+    if config.region == config.get("celery.active_region", config.region) or config.get(
+        "environment"
+    ) in ["dev", "test"]:
+        all_topics = red.hgetall(sns_topic_redis_key)
+        async_to_sync(store_json_results_in_redis_and_s3)(
+            all_topics, s3_bucket=s3_bucket, s3_key=s3_key
+        )
+    else:
+        redis_result_set = async_to_sync(retrieve_json_data_from_redis_or_s3)(
+            s3_bucket=s3_bucket, s3_key=s3_key
+        )
+        async_to_sync(store_json_results_in_redis_and_s3)(
+            redis_result_set,
+            redis_key=sns_topic_redis_key,
+            redis_data_type="hash",
+        )
+    log.debug(
+        {**log_data, "message": "Successfully cached SNS topics across known accounts"}
+    )
     stats.count(f"{function}.success")
-    return True
+    return log_data
 
 
 @app.task(soft_time_limit=1800, **default_retry_kwargs)
@@ -958,6 +1112,7 @@ def cache_sqs_queues_for_account(account_id: str) -> Dict[str, Union[str, int]]:
     log_data = {
         "function": f"{__name__}.{sys._getframe().f_code.co_name}",
         "account_id": account_id,
+        "message": "Successfully cached SQS queues for account",
         "number_sqs_queues": len(all_queues),
     }
     log.debug(log_data)
@@ -969,9 +1124,9 @@ def cache_sqs_queues_for_account(account_id: str) -> Dict[str, Union[str, int]]:
     if config.region == config.get("celery.active_region", config.region) or config.get(
         "environment"
     ) in ["dev", "test"]:
-        s3_bucket = config.get("account_resource_cache.s3.bucket")
+        s3_bucket = config.get("account_resource_cache.sqs.bucket")
         s3_key = config.get(
-            "account_resource_cache.s3.file",
+            "account_resource_cache.{resource_type}.file",
             "account_resource_cache/cache_{resource_type}_{account_id}_v1.json.gz",
         ).format(resource_type="sqs_queues", account_id=account_id)
         async_to_sync(store_json_results_in_redis_and_s3)(
@@ -1004,6 +1159,7 @@ def cache_sns_topics_for_account(account_id: str) -> Dict[str, Union[str, int]]:
     log_data = {
         "function": f"{__name__}.{sys._getframe().f_code.co_name}",
         "account_id": account_id,
+        "message": "Successfully cached SNS topics for account",
         "number_sns_topics": len(all_topics),
     }
     log.debug(log_data)
@@ -1043,6 +1199,7 @@ def cache_s3_buckets_for_account(account_id: str) -> Dict[str, Union[str, int]]:
     log_data = {
         "function": f"{__name__}.{sys._getframe().f_code.co_name}",
         "account_id": account_id,
+        "message": "Successfully cached S3 buckets for account",
         "number_s3_buckets": len(buckets),
     }
     log.debug(log_data)
@@ -1186,6 +1343,7 @@ def cache_resources_from_aws_config_for_account(account_id) -> dict:
     log_data = {
         "function": function,
         "account_id": account_id,
+        "message": "Successfully cached resources from AWS Config for account",
         "number_resources_synced": len(redis_result_set),
     }
     log.debug(log_data)
@@ -1194,7 +1352,8 @@ def cache_resources_from_aws_config_for_account(account_id) -> dict:
 
 @app.task(soft_time_limit=3600)
 def cache_resources_from_aws_config_across_accounts(
-    wait_for_subtask_completion=True,
+    run_subtasks: bool = True,
+    wait_for_subtask_completion: bool = True,
 ) -> Dict[str, Union[Union[str, int], Any]]:
     function = f"{__name__}.{sys._getframe().f_code.co_name}"
     resource_redis_cache_key = config.get(
@@ -1217,9 +1376,12 @@ def cache_resources_from_aws_config_across_accounts(
             if account_id in config.get("celery.test_account_ids", []):
                 tasks.append(cache_resources_from_aws_config_for_account.s(account_id))
     if tasks:
-        results = group(*tasks).apply_async()
-        if wait_for_subtask_completion:
-            results.join(disable_sync_subtasks=False)
+        if run_subtasks:
+            results = group(*tasks).apply_async()
+            if wait_for_subtask_completion:
+                # results.join() forces function to wait until all tasks are complete
+                results.join(disable_sync_subtasks=False)
+
     # Delete roles in Redis cache with expired TTL
     all_resources = red.hgetall(resource_redis_cache_key)
     if all_resources:
@@ -1370,18 +1532,25 @@ def cache_cloud_account_mapping() -> Dict:
 @app.task(soft_time_limit=1800, **default_retry_kwargs)
 def cache_credential_authorization_mapping() -> Dict:
     function = f"{__name__}.{sys._getframe().f_code.co_name}"
+    log_data = {
+        "function": function,
+    }
+    if is_task_already_running(function, []):
+        log_data["message"] = "Skipping task: An identical task is currently running"
+        log.debug(log_data)
+        return log_data
 
     authorization_mapping = async_to_sync(
         generate_and_store_credential_authorization_mapping
     )()
 
-    log_data = {
-        "function": function,
-        "message": "Successfully cached cloud credential authorization mapping",
-        "num_group_authorizations": len(authorization_mapping),
-    }
-
-    log.debug(log_data)
+    log_data["num_group_authorizations"] = len(authorization_mapping)
+    log.debug(
+        {
+            **log_data,
+            "message": "Successfully cached cloud credential authorization mapping",
+        }
+    )
     return log_data
 
 
@@ -1431,7 +1600,7 @@ def cache_self_service_typeahead_task() -> Dict:
     log_data = {
         "function": function,
         "message": "Successfully cached roles and templates for self service typeahead",
-        "num_templated_files": len(self_service_typeahead.typeahead_entries),
+        "num_typeahead_entries": len(self_service_typeahead.typeahead_entries),
     }
     log.debug(log_data)
     return log_data
@@ -1548,6 +1717,7 @@ schedule = {
     },
 }
 
+
 if internal_celery_tasks and isinstance(internal_celery_tasks, dict):
     schedule = {**schedule, **internal_celery_tasks}
 
@@ -1556,3 +1726,6 @@ if config.get("celery.clear_tasks_for_development", False):
 
 app.conf.beat_schedule = schedule
 app.conf.timezone = "UTC"
+
+cache_credential_authorization_mapping.delay()
+cache_credential_authorization_mapping.apply_async(countdown=4)

--- a/consoleme/celery_tasks/celery_tasks.py
+++ b/consoleme/celery_tasks/celery_tasks.py
@@ -482,7 +482,7 @@ def _add_role_to_redis(redis_key: str, role_entry: Dict) -> None:
         'templated': None, 'ttl': 1562510908, 'policy': '<json_formatted_policy>'}
     """
     try:
-        red.hset(redis_key, str(role_entry["arn"]), str(json.dumps(role_entry)))
+        red.hset(redis_key, role_entry["arn"], json.dumps(role_entry))
     except Exception as e:  # noqa
         stats.count(
             "cache_roles_for_account.error",
@@ -1726,6 +1726,3 @@ if config.get("celery.clear_tasks_for_development", False):
 
 app.conf.beat_schedule = schedule
 app.conf.timezone = "UTC"
-
-cache_credential_authorization_mapping.delay()
-cache_credential_authorization_mapping.apply_async(countdown=4)

--- a/consoleme/handlers/v1/policies.py
+++ b/consoleme/handlers/v1/policies.py
@@ -8,6 +8,7 @@ from consoleme.config import config
 from consoleme.exceptions.exceptions import InvalidRequestParameter, MustBeFte
 from consoleme.handlers.base import BaseAPIV1Handler, BaseHandler, BaseMtlsHandler
 from consoleme.lib.account_indexers import get_account_id_to_name_mapping
+from consoleme.lib.cache import retrieve_json_data_from_redis_or_s3
 from consoleme.lib.plugins import get_plugin_by_name
 from consoleme.lib.redis import redis_get, redis_hgetall
 
@@ -108,20 +109,53 @@ async def handle_resource_type_ahead_request(cls):
     role_name = False
     if resource_type == "s3":
         topic = config.get("redis.s3_bucket_key", "S3_BUCKETS")
+        s3_bucket = config.get("account_resource_cache.s3_combined.bucket")
+        s3_key = config.get(
+            "account_resource_cache.s3_combined.file",
+            "account_resource_cache/cache_s3_combined_v1.json.gz",
+        )
     elif resource_type == "sqs":
         topic = config.get("redis.sqs_queues_key", "SQS_QUEUES")
+        s3_bucket = config.get("account_resource_cache.sqs_combined.bucket")
+        s3_key = config.get(
+            "account_resource_cache.sqs_combined.file",
+            "account_resource_cache/cache_sqs_queues_combined_v1.json.gz",
+        )
     elif resource_type == "sns":
         topic = config.get("redis.sns_topics_key ", "SNS_TOPICS")
+        s3_bucket = config.get("account_resource_cache.sns_topics_combined.bucket")
+        s3_key = config.get(
+            "account_resource_cache.sns_topics_topics_combined.file",
+            "account_resource_cache/cache_sns_topics_combined_v1.json.gz",
+        )
     elif resource_type == "iam_arn":
         topic = config.get("aws.iamroles_redis_key ", "IAM_ROLE_CACHE")
+        s3_bucket = config.get(
+            "cache_roles_across_accounts.all_roles_combined.s3.bucket"
+        )
+        s3_key = config.get(
+            "cache_roles_across_accounts.all_roles_combined.s3.file",
+            "account_resource_cache/cache_all_roles_v1.json.gz",
+        )
     elif resource_type == "iam_role":
         topic = config.get("aws.iamroles_redis_key ", "IAM_ROLE_CACHE")
+        s3_bucket = config.get(
+            "cache_roles_across_accounts.all_roles_combined.s3.bucket"
+        )
+        s3_key = config.get(
+            "cache_roles_across_accounts.all_roles_combined.s3.file",
+            "account_resource_cache/cache_all_roles_v1.json.gz",
+        )
         role_name = True
     elif resource_type == "account":
         topic = None
+        s3_bucket = None
+        s3_key = None
         topic_is_hash = False
     elif resource_type == "app":
         topic = config.get("celery.apps_to_roles.redis_key", "APPS_TO_ROLES")
+        s3_bucket = None
+        s3_key = None
         topic_is_hash = False
     else:
         cls.send_error(404, message=f"Invalid resource_type: {resource_type}")
@@ -130,8 +164,10 @@ async def handle_resource_type_ahead_request(cls):
     if not topic and resource_type != "account":
         raise InvalidRequestParameter("Invalid resource_type specified")
 
-    if topic and topic_is_hash:
-        data = await redis_hgetall(topic)
+    if topic and topic_is_hash and s3_key:
+        data = await retrieve_json_data_from_redis_or_s3(
+            redis_key=topic, redis_data_type="hash", s3_bucket=s3_bucket, s3_key=s3_key
+        )
     elif topic:
         data = await redis_get(topic)
 
@@ -200,6 +236,8 @@ async def handle_resource_type_ahead_request(cls):
                 )
 
     else:
+        if not data:
+            return []
         for k, v in data.items():
             if account_id and k != account_id:
                 continue

--- a/consoleme/lib/redis.py
+++ b/consoleme/lib/redis.py
@@ -374,7 +374,7 @@ class RedisHandler:
             REDIS_DB_PATH = os.path.join(
                 config.get("redis.redislite.db_path", default_redislite_db_path)
             )
-            return redislite.StrictRedis(REDIS_DB_PATH)
+            return redislite.StrictRedis(REDIS_DB_PATH, decode_responses=True)
         self.red = await sync_to_async(ConsoleMeRedis)(
             host=self.host,
             port=self.port,
@@ -389,7 +389,7 @@ class RedisHandler:
             REDIS_DB_PATH = os.path.join(
                 config.get("redis.redislite.db_path", default_redislite_db_path)
             )
-            return redislite.StrictRedis(REDIS_DB_PATH)
+            return redislite.StrictRedis(REDIS_DB_PATH, decode_responses=True)
         self.red = ConsoleMeRedis(
             host=self.host,
             port=self.port,

--- a/consoleme/lib/self_service/typeahead.py
+++ b/consoleme/lib/self_service/typeahead.py
@@ -18,6 +18,8 @@ async def cache_self_service_typeahead() -> SelfServiceTypeaheadModelArray:
     app_name_tag = config.get("cache_self_service_typeahead.app_name_tag")
     # Cache role and app information
     role_data = await retrieve_json_data_from_redis_or_s3(
+        redis_key=config.get("aws.iamroles_redis_key", "IAM_ROLE_CACHE"),
+        redis_data_type="hash",
         s3_bucket=config.get(
             "cache_roles_across_accounts.all_roles_combined.s3.bucket"
         ),

--- a/docker-compose-deploy-dockerhub.yaml
+++ b/docker-compose-deploy-dockerhub.yaml
@@ -23,5 +23,5 @@ services:
       bash -c '
       python scripts/retrieve_or_decode_configuration.py;
       python scripts/initialize_dynamodb_oss.py;
-      python scripts/initialize_redis_oss.py --use_celery=true;
+      python scripts/initialize_redis_oss.py;
       celery -A consoleme.celery_tasks.celery_tasks worker -l DEBUG -B -E --concurrency=8'

--- a/docker-compose-deploy.yaml
+++ b/docker-compose-deploy.yaml
@@ -23,5 +23,5 @@ services:
       bash -c '
       python scripts/retrieve_or_decode_configuration.py;
       python scripts/initialize_dynamodb_oss.py;
-      python scripts/initialize_redis_oss.py --use_celery=true;
+      python scripts/initialize_redis_oss.py;
       celery -A consoleme.celery_tasks.celery_tasks worker -l DEBUG -B -E --concurrency=8'

--- a/docker-compose-dockerhub.yaml
+++ b/docker-compose-dockerhub.yaml
@@ -49,7 +49,7 @@ services:
       bash -c '
       python scripts/retrieve_or_decode_configuration.py;
       python scripts/initialize_dynamodb_oss.py;
-      python scripts/initialize_redis_oss.py --use_celery=true;
+      python scripts/initialize_redis_oss.py;
       celery -A consoleme.celery_tasks.celery_tasks worker -l DEBUG -B -E --concurrency=8
       '
     depends_on:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -27,7 +27,7 @@ services:
       python scripts/retrieve_or_decode_configuration.py;
       pip install argh watchdog;
       pip install -e /apps/consoleme/default_plugins;
-      watchmedo auto-restart --recursive --pattern="*.py;*.yaml" --directory="." python consoleme/__main__.py &
+      watchmedo auto-restart --recursive --pattern="*.py" --directory="." python consoleme/__main__.py &
       FORCE_COLOR=true yarn --cwd /apps/consoleme/ui/ start | cat'
 
     depends_on:
@@ -57,7 +57,7 @@ services:
       bash -c '
       python scripts/retrieve_or_decode_configuration.py;
       python scripts/initialize_dynamodb_oss.py;
-      python scripts/initialize_redis_oss.py --use_celery=true;
+      python scripts/initialize_redis_oss.py;
       celery -A consoleme.celery_tasks.celery_tasks worker -l DEBUG -B -E --concurrency=8
       '
     depends_on:

--- a/scripts/initialize_redis_oss.py
+++ b/scripts/initialize_redis_oss.py
@@ -1,12 +1,19 @@
 import argparse
+import concurrent.futures
+import os
+import time
+from concurrent.futures.thread import ThreadPoolExecutor
 
 from asgiref.sync import async_to_sync
 
 from consoleme.celery_tasks import celery_tasks as celery
+from consoleme.config import config
 from consoleme.lib.account_indexers import get_account_id_to_name_mapping
 from consoleme_default_plugins.plugins.celery_tasks import (
     celery_tasks as default_celery_tasks,
 )
+
+start_time = int(time.time())
 
 
 def str2bool(v):
@@ -29,6 +36,9 @@ parser.add_argument(
 )
 args = parser.parse_args()
 
+# Force dynamic configuration update synchronously
+config.CONFIG.load_config_from_dynamo()
+
 if args.use_celery:
     # Initialize Redis locally. If use_celery is set to `True`, you must be running a celery beat and worker. You can
     # run this locally with the following command:
@@ -47,20 +57,49 @@ if args.use_celery:
 
 else:
     celery.cache_cloud_account_mapping()
-    accounts_d = async_to_sync(get_account_id_to_name_mapping)()
+    accounts_d = async_to_sync(get_account_id_to_name_mapping)(force_sync=True)
     default_celery_tasks.cache_application_information()
-
+    executor = ThreadPoolExecutor(max_workers=os.cpu_count())
+    futures = []
     for account_id in accounts_d.keys():
-        celery.cache_roles_for_account(account_id)
-        celery.cache_s3_buckets_for_account(account_id)
-        celery.cache_sns_topics_for_account(account_id)
-        celery.cache_sqs_queues_for_account(account_id)
-        celery.cache_managed_policies_for_account(account_id)
-        celery.cache_resources_from_aws_config_for_account(account_id)
+        futures.extend(
+            [
+                executor.submit(celery.cache_roles_for_account, account_id),
+                executor.submit(celery.cache_s3_buckets_for_account, account_id),
+                executor.submit(celery.cache_sns_topics_for_account, account_id),
+                executor.submit(celery.cache_sqs_queues_for_account, account_id),
+                executor.submit(celery.cache_managed_policies_for_account, account_id),
+                executor.submit(
+                    celery.cache_resources_from_aws_config_for_account, account_id
+                ),
+            ]
+        )
+    for future in concurrent.futures.as_completed(futures):
+        try:
+            data = future.result()
+        except Exception as exc:
+            print("%r generated an exception: %s" % (future, exc))
+
     celery.cache_policies_table_details()
     celery.cache_policy_requests()
     celery.cache_credential_authorization_mapping()
     # Forces writing config to S3
-    celery.cache_roles_across_accounts(wait_for_subtask_completion=False)
-
-print("Done caching redis data")
+    celery.cache_roles_across_accounts(
+        wait_for_subtask_completion=False, run_subtasks=False
+    )
+    celery.cache_s3_buckets_across_accounts(
+        wait_for_subtask_completion=False, run_subtasks=False
+    )
+    celery.cache_sns_topics_across_accounts(
+        wait_for_subtask_completion=False, run_subtasks=False
+    )
+    celery.cache_sqs_queues_across_accounts(
+        wait_for_subtask_completion=False, run_subtasks=False
+    )
+    celery.cache_resources_from_aws_config_across_accounts(
+        wait_for_subtask_completion=False, run_subtasks=False
+    )
+    celery.cache_resource_templates_task()
+    celery.cache_self_service_typeahead_task()
+total_time = int(time.time()) - start_time
+print(f"Done caching data in Redis. It took {total_time} seconds")

--- a/tests/handlers/test_policies.py
+++ b/tests/handlers/test_policies.py
@@ -35,8 +35,10 @@ class TestPolicyResourceEditHandler(AsyncHTTPTestCase):
     )
     @patch("consoleme.lib.aws.RedisHandler", mock_policy_redis)
     @patch("consoleme.handlers.base.auth")
-    @patch("consoleme.handlers.v1.policies.redis_hgetall")
-    def test_resource_typeahead(self, mock_redis_hgetall, mock_auth):
+    @patch("consoleme.handlers.v1.policies.retrieve_json_data_from_redis_or_s3")
+    def test_resource_typeahead(
+        self, mock_retrieve_json_data_from_redis_or_s3, mock_auth
+    ):
         from consoleme.config import config
 
         mock_auth.validate_certificate.return_value = create_future(True)
@@ -67,7 +69,7 @@ class TestPolicyResourceEditHandler(AsyncHTTPTestCase):
         )
         self.assertEqual(response.code, 400)
         result = create_future({"123456789012": '["abucket1", "abucket2"]'})
-        mock_redis_hgetall.return_value = result
+        mock_retrieve_json_data_from_redis_or_s3.return_value = result
         account_id = "123456789012"
         resource = "s3"
         search = "a"


### PR DESCRIPTION
- [X] Improved Redislite support for multiple databases in Celery
- [X] Function to determine if a celery task is already running for a given function and arguments
- [X] Options to run celery cache_SOMETHING_across_accounts functions without spawning or waiting for subtasks. This is useful for running these functions outside of a Celery context, like with initialize_redis_oss.py, since we don't have celery running but still want the task function to execute.
- [X] Improved the caching  mechanism of the cache_SOMETHING_across_accounts functions to automatically cache to S3. This makes restoring from S3 possible when data doesn't exist in S3 for our typeahead endpoints
- [X] Improve typeahead caching by restoring data from S3 when unavailable in Redis