### PR TITLE
Enable docker environment variable substitution for CONFIG_LOCATION

### DIFF
--- a/docker-compose-deploy-dockerhub.yaml
+++ b/docker-compose-deploy-dockerhub.yaml
@@ -8,6 +8,7 @@ services:
       - "8081:8081"
     environment:
       - SETUPTOOLS_USE_DISTUTILS=stdlib
+      - CONFIG_LOCATION=${CONFIG_LOCATION:-/apps/consoleme/example_config/example_config_docker_development.yaml}
     # Run commands to install Consoleme, run the service, and never exit in the event of failure (For dev debugging)
     command: >
       bash -c 'python consoleme/__main__.py'
@@ -15,6 +16,7 @@ services:
     image: "consoleme/consoleme"
     environment:
       - SETUPTOOLS_USE_DISTUTILS=stdlib
+      - CONFIG_LOCATION=${CONFIG_LOCATION:-/apps/consoleme/example_config/example_config_docker_development.yaml}
       - COLUMNS=80 # Needed for Celery: https://github.com/celery/celery/issues/5761
     # Run Redis with ConsoleMe configuration
     command: >

--- a/docker-compose-deploy.yaml
+++ b/docker-compose-deploy.yaml
@@ -8,6 +8,7 @@ services:
       - "8081:8081"
     environment:
       - SETUPTOOLS_USE_DISTUTILS=stdlib
+      - CONFIG_LOCATION=${CONFIG_LOCATION:-/apps/consoleme/example_config/example_config_docker_development.yaml}
     # Run commands to install Consoleme, run the service, and never exit in the event of failure (For dev debugging)
     command: >
       bash -c 'python consoleme/__main__.py'
@@ -15,6 +16,7 @@ services:
     build: .
     environment:
       - SETUPTOOLS_USE_DISTUTILS=stdlib
+      - CONFIG_LOCATION=${CONFIG_LOCATION:-/apps/consoleme/example_config/example_config_docker_development.yaml}
       - COLUMNS=80 # Needed for Celery: https://github.com/celery/celery/issues/5761
     # Run Redis with ConsoleMe configuration
     command: >

--- a/docker-compose-dockerhub.yaml
+++ b/docker-compose-dockerhub.yaml
@@ -13,7 +13,7 @@ services:
       - ~/.ssh:/root/.ssh:cached
       - ~/.config/consoleme:/etc/consoleme/
     environment:
-      - CONFIG_LOCATION=/apps/consoleme/example_config/example_config_docker_development.yaml
+      - CONFIG_LOCATION=${CONFIG_LOCATION:-/apps/consoleme/example_config/example_config_docker_development.yaml}
       - SETUPTOOLS_USE_DISTUTILS=stdlib
     # Run commands to install Consoleme, run the service, and never exit in the event of failure (For dev debugging)
     # We're running `FORCE_COLOR=true yarn --cwd /apps/consoleme/ui/ start | cat` instead of
@@ -41,7 +41,7 @@ services:
       - ~/.ssh:/root/.ssh:cached
       - ~/.config/consoleme:/etc/consoleme/
     environment:
-      - CONFIG_LOCATION=/apps/consoleme/example_config/example_config_docker_development.yaml
+      - CONFIG_LOCATION=${CONFIG_LOCATION:-/apps/consoleme/example_config/example_config_docker_development.yaml}
       - SETUPTOOLS_USE_DISTUTILS=stdlib
       - COLUMNS=80 # Needed for Celery: https://github.com/celery/celery/issues/5761
     # Run Redis with ConsoleMe configuration

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -16,7 +16,7 @@ services:
       - /apps/consoleme/node_modules/
       - /apps/consoleme/ui/node_modules/
     environment:
-      - CONFIG_LOCATION=/apps/consoleme/example_config/example_config_docker_development.yaml
+      - CONFIG_LOCATION=${CONFIG_LOCATION:-/apps/consoleme/example_config/example_config_docker_development.yaml}
       - SETUPTOOLS_USE_DISTUTILS=stdlib
     # Run commands to install Consoleme, run the service, and never exit in the event of failure (For dev debugging)
     # We're running `FORCE_COLOR=true yarn --cwd /apps/consoleme/ui/ start | cat` instead of
@@ -49,7 +49,7 @@ services:
       - /apps/consoleme/node_modules/
       - /apps/consoleme/ui/node_modules/
     environment:
-      - CONFIG_LOCATION=/apps/consoleme/example_config/example_config_docker_development.yaml
+      - CONFIG_LOCATION=${CONFIG_LOCATION:-/apps/consoleme/example_config/example_config_docker_development.yaml}
       - SETUPTOOLS_USE_DISTUTILS=stdlib
       - COLUMNS=80 # Needed for Celery: https://github.com/celery/celery/issues/5761
     # Run Redis with ConsoleMe configuration

--- a/terraform/central-account/s3.tf
+++ b/terraform/central-account/s3.tf
@@ -26,17 +26,17 @@ resource "aws_s3_bucket_object" "consoleme_config" {
   key    = "config.yaml"
 
   content = templatefile("${path.module}/templates/example_config_terraform.yaml", tomap({
-    demo_target_role_arn                         = aws_iam_role.consoleme_target.arn
-    demo_app_role_arn_1                          = aws_iam_role.consoleme_example_app_role_1.arn
-    demo_app_role_arn_2                          = aws_iam_role.consoleme_example_app_role_2.arn
-    demo_user_role_arn_1                         = aws_iam_role.consoleme_example_user_role_1.arn
-    demo_user_role_arn_2                         = aws_iam_role.consoleme_example_user_role_2.arn
-    current_account_id                           = data.aws_caller_identity.current.account_id
-    application_admin                            = var.application_admin
-    region                                       = data.aws_region.current.name
-    jwt_email_key                                = var.lb-authentication-jwt-email-key
-    jwt_groups_key                               = var.lb-authentication-jwt-groups-key
-    user_facing_url                              = var.user_facing_url == "" ? "https://${aws_lb.public-to-private-lb.dns_name}:${var.lb_port}" : var.user_facing_url
-    logout_url                                   = var.logout_url
+    demo_target_role_arn = aws_iam_role.consoleme_target.arn
+    demo_app_role_arn_1  = aws_iam_role.consoleme_example_app_role_1.arn
+    demo_app_role_arn_2  = aws_iam_role.consoleme_example_app_role_2.arn
+    demo_user_role_arn_1 = aws_iam_role.consoleme_example_user_role_1.arn
+    demo_user_role_arn_2 = aws_iam_role.consoleme_example_user_role_2.arn
+    current_account_id   = data.aws_caller_identity.current.account_id
+    application_admin    = var.application_admin
+    region               = data.aws_region.current.name
+    jwt_email_key        = var.lb-authentication-jwt-email-key
+    jwt_groups_key       = var.lb-authentication-jwt-groups-key
+    user_facing_url      = var.user_facing_url == "" ? "https://${aws_lb.public-to-private-lb.dns_name}:${var.lb_port}" : var.user_facing_url
+    logout_url           = var.logout_url
   }))
 }

--- a/terraform/central-account/s3.tf
+++ b/terraform/central-account/s3.tf
@@ -32,8 +32,6 @@ resource "aws_s3_bucket_object" "consoleme_config" {
     demo_user_role_arn_1                         = aws_iam_role.consoleme_example_user_role_1.arn
     demo_user_role_arn_2                         = aws_iam_role.consoleme_example_user_role_2.arn
     current_account_id                           = data.aws_caller_identity.current.account_id
-    sync_accounts_from_organizations             = var.sync_accounts_from_organizations
-    sync_accounts_from_organizations_account_map = var.sync_accounts_from_organizations_account_map != null ? var.sync_accounts_from_organizations_account_map : list(tomap({ organizations_master_account_id = data.aws_caller_identity.current.account_id }))
     application_admin                            = var.application_admin
     region                                       = data.aws_region.current.name
     jwt_email_key                                = var.lb-authentication-jwt-email-key

--- a/terraform/central-account/templates/example_config_terraform.yaml
+++ b/terraform/central-account/templates/example_config_terraform.yaml
@@ -32,11 +32,6 @@ logging:
 account_ids_to_name:
   "${current_account_id}": default_account
 
-cache_cloud_accounts:
-  from_aws_organizations: ${sync_accounts_from_organizations}
-
-cache_accounts_from_aws_organizations: "${sync_accounts_from_organizations_account_map}"
-
 cloud_credential_authorization_mapping:
   role_tags:
     enabled: true


### PR DESCRIPTION
This PR enables docker environment variable substitution for CONFIG_LOCATION in the relevant docker-compose files. It also removes support for organizational account sync from Terraform until we can find a viable alternative. (The viable alternative might be related to this. Allowing users to bring in their own config via S3 as an alternative to generating it).

1. Create .env file with a CONFIG_LOCATION override:
```
cat << EOT >> .env-test 
CONFIG_LOCATION=s3://BUCKET/path/to/config.yaml
EOT
```
2. Run Docker-Compose with --env-file flag
`docker-compose --env-file .env-test -f docker-compose-dockerhub.yaml -f docker-compose-dependencies.yaml up`

3. The ConsoleMe and Celery docker containers should use the CONFIG_LOCATION you've defined in `.env-test`
