### PR TITLE
Daemonize config threads for better Python 3.9 compatibility

### DIFF
--- a/consoleme/config/config.py
+++ b/consoleme/config/config.py
@@ -194,22 +194,28 @@ class Configuration(object):
         # We use different Timer intervals for our background threads to prevent logger objects from clashing, which
         # could cause duplicate log entries.
         if allow_start_background_threads and self.get("redis.use_redislite"):
-            Timer(1, self.purge_redislite_cache, ()).start()
+            t = Timer(1, self.purge_redislite_cache, ())
+            t.daemon = True
+            t.start()
 
         if allow_start_background_threads and self.get("config.load_from_dynamo", True):
-            Timer(2, self.load_config_from_dynamo_bg_thread, ()).start()
+            t = Timer(2, self.load_config_from_dynamo_bg_thread, ())
+            t.daemon = True
+            t.start()
 
         if allow_start_background_threads and self.get(
             "config.run_recurring_internal_tasks"
         ):
-            Timer(
-                3, config_plugin.internal_functions, kwargs={"cfg": self.config}
-            ).start()
+            t = Timer(3, config_plugin.internal_functions, kwargs={"cfg": self.config})
+            t.daemon = True
+            t.start()
 
         if allow_automatically_reload_configuration and self.get(
             "config.automatically_reload_configuration"
         ):
-            Timer(4, self.reload_config, ()).start()
+            t = Timer(4, self.reload_config, ())
+            t.daemon = True
+            t.start()
 
     def get(
         self, key: str, default: Optional[Union[List[str], int, bool, str, Dict]] = None


### PR DESCRIPTION
This change prevents Python threads from hanging when an application script's main thread has executed. This is a problem primarily in Python 3.9