### PR TITLE
Add endpoint to audit access to roles

### DIFF
--- a/consoleme/celery_tasks/celery_tasks.py
+++ b/consoleme/celery_tasks/celery_tasks.py
@@ -64,6 +64,7 @@ from consoleme.lib.cache import (
 )
 from consoleme.lib.cloud_credential_authorization_mapping import (
     generate_and_store_credential_authorization_mapping,
+    generate_and_store_reverse_authorization_mapping,
 )
 from consoleme.lib.dynamo import IAMRoleDynamoHandler, UserDynamoHandler
 from consoleme.lib.event_bridge.role_updates import detect_role_changes_and_update_cache
@@ -1553,7 +1554,12 @@ def cache_credential_authorization_mapping() -> Dict:
         generate_and_store_credential_authorization_mapping
     )()
 
+    reverse_mapping = async_to_sync(generate_and_store_reverse_authorization_mapping)(
+        authorization_mapping
+    )
+
     log_data["num_group_authorizations"] = len(authorization_mapping)
+    log_data["num_identities"] = len(reverse_mapping)
     log.debug(
         {
             **log_data,

--- a/consoleme/handlers/v2/audit.py
+++ b/consoleme/handlers/v2/audit.py
@@ -15,7 +15,7 @@ credential_mapping = CredentialAuthorizationMapping()
 
 
 class RoleAccessHandler(BaseMtlsHandler):
-    """Handler for /api/v2/audit/role/{accountNumber}/{roleName}/access
+    """Handler for /api/v2/audit/roles/{accountNumber}/{roleName}/access
 
     Returns a list of groups with access to the requested role
     """
@@ -27,7 +27,7 @@ class RoleAccessHandler(BaseMtlsHandler):
 
     async def get(self, account_id, role_name):
         """
-        GET /api/v2/audit/role/{accountNumber}/{roleName}/access
+        GET /api/v2/audit/roles/{accountNumber}/{roleName}/access
         """
         log_data = {
             "function": f"{__name__}.{self.__class__.__name__}.{sys._getframe().f_code.co_name}",

--- a/consoleme/handlers/v2/audit.py
+++ b/consoleme/handlers/v2/audit.py
@@ -1,0 +1,81 @@
+import sys
+
+from consoleme.config import config
+from consoleme.handlers.base import BaseMtlsHandler
+from consoleme.lib.auth import can_audit
+from consoleme.lib.cloud_credential_authorization_mapping import (
+    CredentialAuthorizationMapping,
+)
+from consoleme.lib.plugins import get_plugin_by_name
+from consoleme.models import Status2, WebResponse
+
+log = config.get_logger()
+stats = get_plugin_by_name(config.get("plugins.metrics", "default_metrics"))()
+credential_mapping = CredentialAuthorizationMapping()
+
+
+class RoleAccessHandler(BaseMtlsHandler):
+    """Handler for /api/v2/audit/role/{accountNumber}/{roleName}/access
+
+    Returns a list of groups with access to the requested role
+    """
+
+    allowed_methods = ["GET"]
+
+    def check_xsrf_cookie(self) -> None:
+        pass
+
+    async def get(self, account_id, role_name):
+        """
+        GET /api/v2/audit/role/{accountNumber}/{roleName}/access
+        """
+        log_data = {
+            "function": f"{__name__}.{self.__class__.__name__}.{sys._getframe().f_code.co_name}",
+            "user-agent": self.request.headers.get("User-Agent"),
+            "request_id": self.request_uuid,
+            "account_id": account_id,
+            "role_name": role_name,
+        }
+
+        app_name = self.requester.get("name") or self.requester.get("username")
+        is_authorized = can_audit(app_name)
+
+        if not is_authorized:
+            stats.count(
+                f"{log_data['function']}.unauthorized",
+                tags={
+                    "app_name": app_name,
+                    "account_id": account_id,
+                    "role_name": role_name,
+                    "authorized": is_authorized,
+                },
+            )
+            log_data["message"] = "App is unauthorized to retrieve audit data"
+            log_data["app_name"] = app_name
+            log.error(log_data)
+            self.write_error(403, message="App is unauthorized to retrieve audit data")
+            return
+
+        groups = await credential_mapping.determine_role_authorized_groups(
+            account_id, role_name
+        )
+        if not groups:
+            log_data[
+                "message"
+            ] = f"No authorized groups found for {role_name} in {account_id}"
+            log.warning(log_data)
+            self.set_status(404)
+            self.write(
+                WebResponse(
+                    status=Status2.error,
+                    status_code=404,
+                    message="No groups found for requested role",
+                ).json(exclude_unset=True)
+            )
+            return
+
+        self.write(
+            WebResponse(status=Status2.success, status_code=200, data=groups).json(
+                exclude_unset=True
+            )
+        )

--- a/consoleme/lib/auth.py
+++ b/consoleme/lib/auth.py
@@ -194,6 +194,16 @@ def can_delete_roles_app(app_name):
     return False
 
 
+def can_audit(app_name):
+    allowed = [
+        *config.get("groups.can_audit_apps", []),
+        *config.get("dynamic_config.groups.can_audit_apps", []),
+    ]
+    if app_name in allowed:
+        return True
+    return False
+
+
 def can_delete_roles(
     user: str,
     user_groups: List[str],

--- a/consoleme/lib/cloud_credential_authorization_mapping/__init__.py
+++ b/consoleme/lib/cloud_credential_authorization_mapping/__init__.py
@@ -140,9 +140,9 @@ async def generate_and_store_reverse_authorization_mapping(
     reverse_mapping = defaultdict(list)
     for identity, roles in authorization_mapping.items():
         for role in roles.authorized_roles:
-            reverse_mapping[role].append(identity)
+            reverse_mapping[role.lower()].append(identity)
         for role in roles.authorized_roles_cli_only:
-            reverse_mapping[role].append(identity)
+            reverse_mapping[role.lower()].append(identity)
 
     # Store in S3 and Redis
     redis_topic = config.get(

--- a/consoleme/lib/cloud_credential_authorization_mapping/__init__.py
+++ b/consoleme/lib/cloud_credential_authorization_mapping/__init__.py
@@ -112,7 +112,7 @@ class CredentialAuthorizationMapping(metaclass=Singleton):
         return self.reverse_mapping
 
     async def determine_role_authorized_groups(self, account_id: str, role_name: str):
-        arn = f"arn:aws:iam::{account_id}:role/{role_name}"
+        arn = f"arn:aws:iam::{account_id}:role/{role_name.lower()}"
         reverse_mapping = await self.retrieve_reverse_authorization_mapping()
         groups = reverse_mapping.get(arn, [])
         return set(groups)

--- a/consoleme/routes.py
+++ b/consoleme/routes.py
@@ -23,6 +23,7 @@ from consoleme.handlers.v1.policies import (
 )
 from consoleme.handlers.v1.roles import GetRolesHandler
 from consoleme.handlers.v1.saml import SamlHandler
+from consoleme.handlers.v2.audit import RoleAccessHandler
 from consoleme.handlers.v2.challenge import (
     ChallengeGeneratorHandler,
     ChallengePollerHandler,
@@ -186,6 +187,7 @@ def make_app(jwt_validator=None):
         ),
         (r"/noauth/v1/challenge_generator/(.*)", ChallengeGeneratorHandler),
         (r"/noauth/v1/challenge_poller/([a-zA-Z0-9_-]+)", ChallengePollerHandler),
+        (r"/api/v2/audit/roles/(\d{12})/(.*)/access", RoleAccessHandler),
         (r"/api/v2/.*", V2NotFoundHandler),
         (
             r"/(.*)",

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -382,6 +382,28 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/WebResponse"
+  /audit/roles/{account_id}/{role_name}/access:
+    get:
+      summary:
+      tags:
+        - audit
+        - privileged
+      parameters:
+        - $ref: "#/components/parameters/AccountId"
+        - $ref: "#/components/parameters/RoleName"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RoleAccessArray"
+        "404":
+          description: Missing or Malformed data, please check errors for details
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WebResponse"
 components:
   responses:
     DefaultErrorResponse:
@@ -1686,3 +1708,18 @@ components:
       type: array
       items:
         $ref: "#/components/schemas/ServiceControlPolicyModel"
+    RoleAccessModel:
+      type: object
+      properties:
+        id:
+          type: string
+          example: owner@example.com
+        type:
+          type: string
+          enum:
+            - group
+            - user
+    RoleAccessArray:
+      type: array
+      items:
+        $ref: "#/components/schemas/RoleAccessModel"

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -397,7 +397,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/RoleAccessArray"
+                $ref: "#/components/schemas/WebResponse"
         "404":
           description: Missing or Malformed data, please check errors for details
           content:
@@ -1708,18 +1708,3 @@ components:
       type: array
       items:
         $ref: "#/components/schemas/ServiceControlPolicyModel"
-    RoleAccessResponseModel:
-      type: object
-      properties:
-        authorized_roles:
-          type: string
-          example: owner@example.com
-        authorized_roles_cli_only:
-          type: string
-          enum:
-            - group
-            - user
-    RoleAccessArray:
-      type: array
-      items:
-        $ref: "#/components/schemas/RoleAccessModel"

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -1708,13 +1708,13 @@ components:
       type: array
       items:
         $ref: "#/components/schemas/ServiceControlPolicyModel"
-    RoleAccessModel:
+    RoleAccessResponseModel:
       type: object
       properties:
-        id:
+        authorized_roles:
           type: string
           example: owner@example.com
-        type:
+        authorized_roles_cli_only:
           type: string
           enum:
             - group

--- a/tests/lib/test_cloud_credential_authorization_mapping/test_cloud_credential_authorization_mapping.py
+++ b/tests/lib/test_cloud_credential_authorization_mapping/test_cloud_credential_authorization_mapping.py
@@ -494,68 +494,68 @@ class TestCloudCredentialAuthorizationMapping(unittest.IsolatedAsyncioTestCase):
         )
 
         expected = {
-            "arn:aws:iam::123456789012:role/RoleNumber0": [
+            "arn:aws:iam::123456789012:role/rolenumber0": [
                 "group0",
                 "group0@example.com",
                 "group0-cli",
                 "group0-cli@example.com",
             ],
-            "arn:aws:iam::123456789012:role/RoleNumber1": [
+            "arn:aws:iam::123456789012:role/rolenumber1": [
                 "group1",
                 "group1@example.com",
                 "group1-cli",
                 "group1-cli@example.com",
             ],
-            "arn:aws:iam::123456789012:role/RoleNumber2": [
+            "arn:aws:iam::123456789012:role/rolenumber2": [
                 "group2",
                 "group2@example.com",
                 "group2-cli",
                 "group2-cli@example.com",
             ],
-            "arn:aws:iam::123456789012:role/RoleNumber3": [
+            "arn:aws:iam::123456789012:role/rolenumber3": [
                 "group3",
                 "group3@example.com",
                 "group3-cli",
                 "group3-cli@example.com",
             ],
-            "arn:aws:iam::123456789012:role/RoleNumber4": [
+            "arn:aws:iam::123456789012:role/rolenumber4": [
                 "group4",
                 "group4@example.com",
                 "group4-cli",
                 "group4-cli@example.com",
             ],
-            "arn:aws:iam::123456789012:role/RoleNumber5": [
+            "arn:aws:iam::123456789012:role/rolenumber5": [
                 "group5",
                 "group5@example.com",
                 "group5-cli",
                 "group5-cli@example.com",
             ],
-            "arn:aws:iam::123456789012:role/RoleNumber6": [
+            "arn:aws:iam::123456789012:role/rolenumber6": [
                 "group6",
                 "group6@example.com",
                 "group6-cli",
                 "group6-cli@example.com",
             ],
-            "arn:aws:iam::123456789012:role/RoleNumber7": [
+            "arn:aws:iam::123456789012:role/rolenumber7": [
                 "group7",
                 "group7@example.com",
                 "group7-cli",
                 "group7-cli@example.com",
             ],
-            "arn:aws:iam::123456789012:role/RoleNumber8": [
+            "arn:aws:iam::123456789012:role/rolenumber8": [
                 "group8",
                 "group8@example.com",
                 "group8-cli",
                 "group8-cli@example.com",
             ],
-            "arn:aws:iam::123456789012:role/RoleNumber9": [
+            "arn:aws:iam::123456789012:role/rolenumber9": [
                 "group9",
                 "group9@example.com",
                 "group9-cli",
                 "group9-cli@example.com",
             ],
-            "arn:aws:iam::123456789012:role/roleA": ["groupa@example.com"],
-            "arn:aws:iam::123456789012:role/roleB": ["groupa@example.com"],
+            "arn:aws:iam::123456789012:role/rolea": ["groupa@example.com"],
+            "arn:aws:iam::123456789012:role/roleb": ["groupa@example.com"],
             "arn:aws:iam::123456789012:role/rolename": ["group1@example.com"],
             "arn:aws:iam::123456789012:role/rolename2": ["group1@example.com"],
             "arn:aws:iam::123456789012:role/userrolename": ["someuser@example.com"],

--- a/tests/lib/test_cloud_credential_authorization_mapping/test_cloud_credential_authorization_mapping.py
+++ b/tests/lib/test_cloud_credential_authorization_mapping/test_cloud_credential_authorization_mapping.py
@@ -266,6 +266,303 @@ class TestCloudCredentialAuthorizationMapping(unittest.IsolatedAsyncioTestCase):
         for k, v in expected.items():
             self.assertEqual(mapping.get(k), v)
 
+    async def test_generate_and_store_reverse_authorization_mapping(self):
+        from consoleme.lib.cloud_credential_authorization_mapping import (
+            RoleAuthorizations,
+            generate_and_store_reverse_authorization_mapping,
+        )
+
+        authorization_mapping = {
+            "group8": RoleAuthorizations(
+                authorized_roles={"arn:aws:iam::123456789012:role/RoleNumber8"},
+                authorized_roles_cli_only=set(),
+            ),
+            "group8@example.com": RoleAuthorizations(
+                authorized_roles={"arn:aws:iam::123456789012:role/RoleNumber8"},
+                authorized_roles_cli_only=set(),
+            ),
+            "group8-cli": RoleAuthorizations(
+                authorized_roles=set(),
+                authorized_roles_cli_only={
+                    "arn:aws:iam::123456789012:role/RoleNumber8"
+                },
+            ),
+            "group8-cli@example.com": RoleAuthorizations(
+                authorized_roles=set(),
+                authorized_roles_cli_only={
+                    "arn:aws:iam::123456789012:role/RoleNumber8"
+                },
+            ),
+            "group3": RoleAuthorizations(
+                authorized_roles={"arn:aws:iam::123456789012:role/RoleNumber3"},
+                authorized_roles_cli_only=set(),
+            ),
+            "group3@example.com": RoleAuthorizations(
+                authorized_roles={"arn:aws:iam::123456789012:role/RoleNumber3"},
+                authorized_roles_cli_only=set(),
+            ),
+            "group3-cli": RoleAuthorizations(
+                authorized_roles=set(),
+                authorized_roles_cli_only={
+                    "arn:aws:iam::123456789012:role/RoleNumber3"
+                },
+            ),
+            "group3-cli@example.com": RoleAuthorizations(
+                authorized_roles=set(),
+                authorized_roles_cli_only={
+                    "arn:aws:iam::123456789012:role/RoleNumber3"
+                },
+            ),
+            "group6": RoleAuthorizations(
+                authorized_roles={"arn:aws:iam::123456789012:role/RoleNumber6"},
+                authorized_roles_cli_only=set(),
+            ),
+            "group6@example.com": RoleAuthorizations(
+                authorized_roles={"arn:aws:iam::123456789012:role/RoleNumber6"},
+                authorized_roles_cli_only=set(),
+            ),
+            "group6-cli": RoleAuthorizations(
+                authorized_roles=set(),
+                authorized_roles_cli_only={
+                    "arn:aws:iam::123456789012:role/RoleNumber6"
+                },
+            ),
+            "group6-cli@example.com": RoleAuthorizations(
+                authorized_roles=set(),
+                authorized_roles_cli_only={
+                    "arn:aws:iam::123456789012:role/RoleNumber6"
+                },
+            ),
+            "group9": RoleAuthorizations(
+                authorized_roles={"arn:aws:iam::123456789012:role/RoleNumber9"},
+                authorized_roles_cli_only=set(),
+            ),
+            "group9@example.com": RoleAuthorizations(
+                authorized_roles={"arn:aws:iam::123456789012:role/RoleNumber9"},
+                authorized_roles_cli_only=set(),
+            ),
+            "group9-cli": RoleAuthorizations(
+                authorized_roles=set(),
+                authorized_roles_cli_only={
+                    "arn:aws:iam::123456789012:role/RoleNumber9"
+                },
+            ),
+            "group9-cli@example.com": RoleAuthorizations(
+                authorized_roles=set(),
+                authorized_roles_cli_only={
+                    "arn:aws:iam::123456789012:role/RoleNumber9"
+                },
+            ),
+            "group5": RoleAuthorizations(
+                authorized_roles={"arn:aws:iam::123456789012:role/RoleNumber5"},
+                authorized_roles_cli_only=set(),
+            ),
+            "group5@example.com": RoleAuthorizations(
+                authorized_roles={"arn:aws:iam::123456789012:role/RoleNumber5"},
+                authorized_roles_cli_only=set(),
+            ),
+            "group5-cli": RoleAuthorizations(
+                authorized_roles=set(),
+                authorized_roles_cli_only={
+                    "arn:aws:iam::123456789012:role/RoleNumber5"
+                },
+            ),
+            "group5-cli@example.com": RoleAuthorizations(
+                authorized_roles=set(),
+                authorized_roles_cli_only={
+                    "arn:aws:iam::123456789012:role/RoleNumber5"
+                },
+            ),
+            "group2": RoleAuthorizations(
+                authorized_roles={"arn:aws:iam::123456789012:role/RoleNumber2"},
+                authorized_roles_cli_only=set(),
+            ),
+            "group2@example.com": RoleAuthorizations(
+                authorized_roles={"arn:aws:iam::123456789012:role/RoleNumber2"},
+                authorized_roles_cli_only=set(),
+            ),
+            "group2-cli": RoleAuthorizations(
+                authorized_roles=set(),
+                authorized_roles_cli_only={
+                    "arn:aws:iam::123456789012:role/RoleNumber2"
+                },
+            ),
+            "group2-cli@example.com": RoleAuthorizations(
+                authorized_roles=set(),
+                authorized_roles_cli_only={
+                    "arn:aws:iam::123456789012:role/RoleNumber2"
+                },
+            ),
+            "group1": RoleAuthorizations(
+                authorized_roles={"arn:aws:iam::123456789012:role/RoleNumber1"},
+                authorized_roles_cli_only=set(),
+            ),
+            "group1@example.com": RoleAuthorizations(
+                authorized_roles={
+                    "arn:aws:iam::123456789012:role/RoleNumber1",
+                    "arn:aws:iam::123456789012:role/rolename",
+                },
+                authorized_roles_cli_only={"arn:aws:iam::123456789012:role/rolename2"},
+            ),
+            "group1-cli": RoleAuthorizations(
+                authorized_roles=set(),
+                authorized_roles_cli_only={
+                    "arn:aws:iam::123456789012:role/RoleNumber1"
+                },
+            ),
+            "group1-cli@example.com": RoleAuthorizations(
+                authorized_roles=set(),
+                authorized_roles_cli_only={
+                    "arn:aws:iam::123456789012:role/RoleNumber1"
+                },
+            ),
+            "group7": RoleAuthorizations(
+                authorized_roles={"arn:aws:iam::123456789012:role/RoleNumber7"},
+                authorized_roles_cli_only=set(),
+            ),
+            "group7@example.com": RoleAuthorizations(
+                authorized_roles={"arn:aws:iam::123456789012:role/RoleNumber7"},
+                authorized_roles_cli_only=set(),
+            ),
+            "group7-cli": RoleAuthorizations(
+                authorized_roles=set(),
+                authorized_roles_cli_only={
+                    "arn:aws:iam::123456789012:role/RoleNumber7"
+                },
+            ),
+            "group7-cli@example.com": RoleAuthorizations(
+                authorized_roles=set(),
+                authorized_roles_cli_only={
+                    "arn:aws:iam::123456789012:role/RoleNumber7"
+                },
+            ),
+            "group4": RoleAuthorizations(
+                authorized_roles={"arn:aws:iam::123456789012:role/RoleNumber4"},
+                authorized_roles_cli_only=set(),
+            ),
+            "group4@example.com": RoleAuthorizations(
+                authorized_roles={"arn:aws:iam::123456789012:role/RoleNumber4"},
+                authorized_roles_cli_only=set(),
+            ),
+            "group4-cli": RoleAuthorizations(
+                authorized_roles=set(),
+                authorized_roles_cli_only={
+                    "arn:aws:iam::123456789012:role/RoleNumber4"
+                },
+            ),
+            "group4-cli@example.com": RoleAuthorizations(
+                authorized_roles=set(),
+                authorized_roles_cli_only={
+                    "arn:aws:iam::123456789012:role/RoleNumber4"
+                },
+            ),
+            "group0": RoleAuthorizations(
+                authorized_roles={"arn:aws:iam::123456789012:role/RoleNumber0"},
+                authorized_roles_cli_only=set(),
+            ),
+            "group0@example.com": RoleAuthorizations(
+                authorized_roles={"arn:aws:iam::123456789012:role/RoleNumber0"},
+                authorized_roles_cli_only=set(),
+            ),
+            "group0-cli": RoleAuthorizations(
+                authorized_roles=set(),
+                authorized_roles_cli_only={
+                    "arn:aws:iam::123456789012:role/RoleNumber0"
+                },
+            ),
+            "group0-cli@example.com": RoleAuthorizations(
+                authorized_roles=set(),
+                authorized_roles_cli_only={
+                    "arn:aws:iam::123456789012:role/RoleNumber0"
+                },
+            ),
+            "someuser@example.com": RoleAuthorizations(
+                authorized_roles={"arn:aws:iam::123456789012:role/userrolename"},
+                authorized_roles_cli_only=set(),
+            ),
+            "groupa@example.com": RoleAuthorizations(
+                authorized_roles={
+                    "arn:aws:iam::123456789012:role/roleA",
+                    "arn:aws:iam::123456789012:role/roleB",
+                },
+                authorized_roles_cli_only=set(),
+            ),
+        }
+
+        reverse_mapping = await generate_and_store_reverse_authorization_mapping(
+            authorization_mapping
+        )
+
+        expected = {
+            "arn:aws:iam::123456789012:role/RoleNumber0": [
+                "group0",
+                "group0@example.com",
+                "group0-cli",
+                "group0-cli@example.com",
+            ],
+            "arn:aws:iam::123456789012:role/RoleNumber1": [
+                "group1",
+                "group1@example.com",
+                "group1-cli",
+                "group1-cli@example.com",
+            ],
+            "arn:aws:iam::123456789012:role/RoleNumber2": [
+                "group2",
+                "group2@example.com",
+                "group2-cli",
+                "group2-cli@example.com",
+            ],
+            "arn:aws:iam::123456789012:role/RoleNumber3": [
+                "group3",
+                "group3@example.com",
+                "group3-cli",
+                "group3-cli@example.com",
+            ],
+            "arn:aws:iam::123456789012:role/RoleNumber4": [
+                "group4",
+                "group4@example.com",
+                "group4-cli",
+                "group4-cli@example.com",
+            ],
+            "arn:aws:iam::123456789012:role/RoleNumber5": [
+                "group5",
+                "group5@example.com",
+                "group5-cli",
+                "group5-cli@example.com",
+            ],
+            "arn:aws:iam::123456789012:role/RoleNumber6": [
+                "group6",
+                "group6@example.com",
+                "group6-cli",
+                "group6-cli@example.com",
+            ],
+            "arn:aws:iam::123456789012:role/RoleNumber7": [
+                "group7",
+                "group7@example.com",
+                "group7-cli",
+                "group7-cli@example.com",
+            ],
+            "arn:aws:iam::123456789012:role/RoleNumber8": [
+                "group8",
+                "group8@example.com",
+                "group8-cli",
+                "group8-cli@example.com",
+            ],
+            "arn:aws:iam::123456789012:role/RoleNumber9": [
+                "group9",
+                "group9@example.com",
+                "group9-cli",
+                "group9-cli@example.com",
+            ],
+            "arn:aws:iam::123456789012:role/roleA": ["groupa@example.com"],
+            "arn:aws:iam::123456789012:role/roleB": ["groupa@example.com"],
+            "arn:aws:iam::123456789012:role/rolename": ["group1@example.com"],
+            "arn:aws:iam::123456789012:role/rolename2": ["group1@example.com"],
+            "arn:aws:iam::123456789012:role/userrolename": ["someuser@example.com"],
+        }
+
+        self.assertDictEqual(reverse_mapping, expected)
+
     async def test_RoleTagAuthorizationMappingGenerator(self):
         from consoleme.lib.cloud_credential_authorization_mapping import (
             RoleAuthorizations,


### PR DESCRIPTION
This PR adds a new path to the V2 API, `/api/v2/audit/`. The initial endpoint included is `/api/v2/audit/roles/{accountNumber}/{roleName}/access`, which can be used to retrieve a list of groups which have access to the role specified in the request path. This endpoint uses mTLS auth.

To support this change, the `cache_credential_authorization_mapping` Celery task has been updated to call `generate_and_store_reverse_authorization_mapping()`. This function iterates through the authorization mapping and creates a mapping of role ARN -> groups. Additionally, the `CredentialAuthorizationMapping` singleton got some new methods: `retrieve_reverse_authorization_mapping()` and `determine_role_authorized_groups()`. `determine_role_authorized_groups()` is the heavy-lifter in the handler for the new endpoint.

The request/response look like this:
```json
GET /api/v2/audit/roles/012345678901/theDopestRole/access
{
    "status": "success",
    "status_code": 200,
    "data": [
        "group1@company.com",
        "coolergroup@company.com"
    ]
}
```