### PR TITLE
Perform a case insensitive search on the eligible roles table

### DIFF
--- a/ui/src/components/blocks/datatable/useDataTable.js
+++ b/ui/src/components/blocks/datatable/useDataTable.js
@@ -64,7 +64,7 @@ const useDataTable = (config) => {
           let isMatched = true;
           Object.keys(filters).forEach((key) => {
             const filter = filters[key];
-            const re = new RegExp(filter, "g");
+            const re = new RegExp(filter, "gi");
             if (item[key] && !re.test(item[key])) {
               isMatched = false;
             }


### PR DESCRIPTION
This PR achieves the following-
1. A case insensitive search for the eligible roles table
2. Fixes a bug that causes no roles to show up on the eligible roles page when more than one matching role is present while trying to login to the AWS console using the URL-based login method in consoleme