### PR TITLE
Added support for listing policy templates from dynamic config

### DIFF
--- a/consoleme/handlers/v2/self_service.py
+++ b/consoleme/handlers/v2/self_service.py
@@ -32,8 +32,17 @@ class PermissionTemplatesHandler(BaseAPIV2Handler):
     allowed_methods = ["GET"]
 
     async def get(self):
+        permission_templates_dynamic_config: dict = [
+            config.get("dynamic_config.permission_templates")
+        ]
+
         permission_templates_config: dict = config.get(
             "permission_templates", PERMISSION_TEMPLATE_DEFAULTS
         )
+        temp = [*permission_templates_config, *permission_templates_dynamic_config]
 
-        self.write({"permission_templates": permission_templates_config})
+        permission_templates = [
+            dict(t) for t in {tuple(sorted(p.items())) for p in temp}
+        ]
+
+        self.write({"permission_templates": permission_templates})

--- a/consoleme/handlers/v2/self_service.py
+++ b/consoleme/handlers/v2/self_service.py
@@ -1,3 +1,5 @@
+from typing import Any, Dict, List
+
 from consoleme.config import config
 from consoleme.handlers.base import BaseAPIV2Handler
 from consoleme.lib.auth import can_admin_policies
@@ -32,21 +34,32 @@ class PermissionTemplatesHandler(BaseAPIV2Handler):
     allowed_methods = ["GET"]
 
     async def get(self):
-        permission_templates_dynamic_config_raw: dict = config.get(
-            "dynamic_config.permission_templates"
+        """
+        Returns permission templates.
+
+        Combines permission templates from dynamic configuration to the ones discovered in static configuration, with a
+        priority to the templates defined in dynamic configuration.
+
+        If no permission_templates are defined in static configuration, this function will substitute the static
+        configuration templates with PERMISSION_TEMPLATE_DEFAULTS.
+        """
+        permission_templates_dynamic_config: List[Dict[str, Any]] = config.get(
+            "dynamic_config.permission_templates", []
         )
 
-        permission_templates_dynamic_config: dict = [
-            value for _, value in permission_templates_dynamic_config_raw.items()
-        ]
-
-        permission_templates_config: dict = config.get(
+        permission_templates_config: List[Dict[str, Any]] = config.get(
             "permission_templates", PERMISSION_TEMPLATE_DEFAULTS
         )
-        temp = [*permission_templates_config, *permission_templates_dynamic_config]
 
-        permission_templates = [
-            dict(t) for t in {tuple(sorted(p.items())) for p in temp}
-        ]
+        seen = set()
+        compiled_permission_templates = []
+        for item in [
+            *permission_templates_dynamic_config,
+            *permission_templates_config,
+        ]:
+            if item["key"] in seen:
+                continue
+            compiled_permission_templates.append(item)
+            seen.add(item["key"])
 
-        self.write({"permission_templates": permission_templates})
+        self.write({"permission_templates": compiled_permission_templates})

--- a/consoleme/handlers/v2/self_service.py
+++ b/consoleme/handlers/v2/self_service.py
@@ -32,8 +32,12 @@ class PermissionTemplatesHandler(BaseAPIV2Handler):
     allowed_methods = ["GET"]
 
     async def get(self):
+        permission_templates_dynamic_config_raw: dict = config.get(
+            "dynamic_config.permission_templates"
+        )
+
         permission_templates_dynamic_config: dict = [
-            config.get("dynamic_config.permission_templates")
+            value for _, value in permission_templates_dynamic_config_raw.items()
         ]
 
         permission_templates_config: dict = config.get(


### PR DESCRIPTION
This PR enables us to define our own generic/templated policies in the dynamic config and select them from the inline policy template dropdown box.
The syntax for adding the policies in the dynamic config is shown below-
```yaml
permission_templates: 
    dynamodb:
        key: dynamodb
        text: dynamodb ReadWrite
        value: |-
            {
                "Version": "2012-10-17",
                "Statement": [
                    {
                        "Sid": "DynamodbReadTable",
                        "Effect": "Allow",
                        "Action": [
                            "dynamodb:BatchGetItem"
                        ],
                        "Resource": [
                            ""
                        ]
                    }
                ]
            }
    updated:
        key: updated
        text: updated
        value: |-
            {
                "Version": "2012-10-17",
                "Statement": [
                    {
                        "Sid": "updated",
                        "Effect": "Allow",
                        "Action": [
                            "updated:something"
                        ],
                        "Resource": [
                            "updated"
                        ]
                    }
                ]
            }
```