### PR TITLE
Added EC2_REGION environment variable in relevant docker-compose files

### DIFF
--- a/docker-compose-deploy-dockerhub.yaml
+++ b/docker-compose-deploy-dockerhub.yaml
@@ -9,6 +9,7 @@ services:
     environment:
       - SETUPTOOLS_USE_DISTUTILS=stdlib
       - CONFIG_LOCATION=${CONFIG_LOCATION:-/apps/consoleme/example_config/example_config_docker_development.yaml}
+      - EC2_REGION=${EC2_REGION:-us-east-1}
     # Run commands to install Consoleme, run the service, and never exit in the event of failure (For dev debugging)
     command: >
       bash -c 'python consoleme/__main__.py'
@@ -17,6 +18,7 @@ services:
     environment:
       - SETUPTOOLS_USE_DISTUTILS=stdlib
       - CONFIG_LOCATION=${CONFIG_LOCATION:-/apps/consoleme/example_config/example_config_docker_development.yaml}
+      - EC2_REGION=${EC2_REGION:-us-east-1}
       - COLUMNS=80 # Needed for Celery: https://github.com/celery/celery/issues/5761
     # Run Redis with ConsoleMe configuration
     command: >

--- a/docker-compose-deploy.yaml
+++ b/docker-compose-deploy.yaml
@@ -9,6 +9,7 @@ services:
     environment:
       - SETUPTOOLS_USE_DISTUTILS=stdlib
       - CONFIG_LOCATION=${CONFIG_LOCATION:-/apps/consoleme/example_config/example_config_docker_development.yaml}
+      - EC2_REGION=${EC2_REGION:-us-east-1}
     # Run commands to install Consoleme, run the service, and never exit in the event of failure (For dev debugging)
     command: >
       bash -c 'python consoleme/__main__.py'
@@ -17,6 +18,7 @@ services:
     environment:
       - SETUPTOOLS_USE_DISTUTILS=stdlib
       - CONFIG_LOCATION=${CONFIG_LOCATION:-/apps/consoleme/example_config/example_config_docker_development.yaml}
+      - EC2_REGION=${EC2_REGION:-us-east-1}
       - COLUMNS=80 # Needed for Celery: https://github.com/celery/celery/issues/5761
     # Run Redis with ConsoleMe configuration
     command: >

--- a/docker-compose-dockerhub.yaml
+++ b/docker-compose-dockerhub.yaml
@@ -14,6 +14,7 @@ services:
       - ~/.config/consoleme:/etc/consoleme/
     environment:
       - CONFIG_LOCATION=${CONFIG_LOCATION:-/apps/consoleme/example_config/example_config_docker_development.yaml}
+      - EC2_REGION=${EC2_REGION:-us-east-1}
       - SETUPTOOLS_USE_DISTUTILS=stdlib
     # Run commands to install Consoleme, run the service, and never exit in the event of failure (For dev debugging)
     # We're running `FORCE_COLOR=true yarn --cwd /apps/consoleme/ui/ start | cat` instead of
@@ -42,6 +43,7 @@ services:
       - ~/.config/consoleme:/etc/consoleme/
     environment:
       - CONFIG_LOCATION=${CONFIG_LOCATION:-/apps/consoleme/example_config/example_config_docker_development.yaml}
+      - EC2_REGION=${EC2_REGION:-us-east-1}
       - SETUPTOOLS_USE_DISTUTILS=stdlib
       - COLUMNS=80 # Needed for Celery: https://github.com/celery/celery/issues/5761
     # Run Redis with ConsoleMe configuration

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -17,6 +17,7 @@ services:
       - /apps/consoleme/ui/node_modules/
     environment:
       - CONFIG_LOCATION=${CONFIG_LOCATION:-/apps/consoleme/example_config/example_config_docker_development.yaml}
+      - EC2_REGION=${EC2_REGION:-us-east-1}
       - SETUPTOOLS_USE_DISTUTILS=stdlib
     # Run commands to install Consoleme, run the service, and never exit in the event of failure (For dev debugging)
     # We're running `FORCE_COLOR=true yarn --cwd /apps/consoleme/ui/ start | cat` instead of
@@ -50,6 +51,7 @@ services:
       - /apps/consoleme/ui/node_modules/
     environment:
       - CONFIG_LOCATION=${CONFIG_LOCATION:-/apps/consoleme/example_config/example_config_docker_development.yaml}
+      - EC2_REGION=${EC2_REGION:-us-east-1}
       - SETUPTOOLS_USE_DISTUTILS=stdlib
       - COLUMNS=80 # Needed for Celery: https://github.com/celery/celery/issues/5761
     # Run Redis with ConsoleMe configuration

--- a/docs/gitbook/quick-start/docker.md
+++ b/docs/gitbook/quick-start/docker.md
@@ -49,7 +49,10 @@ redis:
 
 ```
 CONFIG_LOCATION=<S3-URI-of-the-config>
+EC2_REGION=<custom-AWS-region>
 ```
+
+> Note: EC2_REGION is an optional variable. This is only required if you want to use AWS managed dynamodb service and make the dynamodb tables in region other than us-east-1.
 
 {% hint style="info" %}
 **BEFORE RUNNING THE COMMAND BELOW**: We highly recommend that you put valid AWS credentials for your account in your `~/.aws/credentials` file under the `[default]` profile \([Instructions](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html#cli-configure-files-where)\). The role you use should have the permissions outlined under [Central Account IAM Permissions](../prerequisites/required-iam-permissions/central-account-consolemeinstanceprofile.md). These credentials will be shared with the container, and when you run the second command to populate your Redis cache \(`make redis`\) command using docker exec, the command will attempt to populate your redis cache with live resources from your account. This will only work if you have valid AWS credentials.


### PR DESCRIPTION
This change along with https://github.com/Netflix/consoleme/pull/9133 will give users the flexibility to make dynamodb tables in regions other than us-east-1. Alone https://github.com/Netflix/consoleme/pull/9133 is not sufficient to achieve this. Also updated the docs to reflect the same.