### PR TITLE
Adds configurable support for Google Analytics pageviews

### DIFF
--- a/consoleme/handlers/v2/user_profile.py
+++ b/consoleme/handlers/v2/user_profile.py
@@ -26,7 +26,10 @@ class UserProfileHandler(BaseAPIV1Handler):
         is_contractor = config.config_plugin().is_contractor(self.user)
         site_config = {
             "consoleme_logo": await get_random_security_logo(),
-            "google_tracking_uri": config.get("google_analytics.tracking_url"),
+            "google_analytics": {
+                "tracking_id": config.get("google_analytics.tracking_id"),
+                "options": config.get("google_analytics.options", {}),
+            },
             "documentation_url": config.get(
                 "documentation_page", "https://hawkins.gitbook.io/consoleme/"
             ),

--- a/tests/handlers/v2/test_user_profile.py
+++ b/tests/handlers/v2/test_user_profile.py
@@ -33,7 +33,7 @@ class TestUserProfile(AsyncHTTPTestCase):
             response_j,
             {
                 "site_config": {
-                    "google_tracking_uri": None,
+                    "google_analytics": {"tracking_id": None, "options": {}},
                     "documentation_url": "https://github.com/Netflix/consoleme/",
                     "support_contact": "consoleme-support@example.com",
                     "support_chat_url": "https://www.example.com/slack/channel",

--- a/ui/package.json
+++ b/ui/package.json
@@ -17,6 +17,7 @@
     "react": "^17.0.2",
     "react-app-rewired": "^2.1.8",
     "react-dom": "^17.0.2",
+    "react-ga": "^3.3.0",
     "react-json-view": "^1.21.3",
     "react-markdown": "5.0.3",
     "react-monaco-editor": "^0.43.0",

--- a/ui/src/auth/AuthProviderDefault.js
+++ b/ui/src/auth/AuthProviderDefault.js
@@ -1,5 +1,6 @@
 import React, { createContext, useContext, useReducer } from "react";
 import { getCookie } from "../helpers/utils";
+import ReactGA from "react-ga";
 
 const initialAuthState = {
   user: null, // user profile data
@@ -62,6 +63,18 @@ export const AuthProvider = ({ children }) => {
 
       // User is now authenticated so retrieve user profile.
       const user = await sendRequestCommon(null, "/api/v2/user_profile", "get");
+
+      // If backend Consoleme is configured with google analytics, let's set it up here
+      if (user?.site_config?.google_analytics?.tracking_id) {
+        ReactGA.initialize(
+          user.site_config.google_analytics.tracking_id,
+          user.site_config.google_analytics.options
+        );
+        user.google_analytics_initialized = true;
+      } else {
+        user.google_analytics_initialized = false;
+      }
+
       dispatch({
         type: "LOGIN",
         user,

--- a/ui/src/auth/ProtectedRoute.js
+++ b/ui/src/auth/ProtectedRoute.js
@@ -1,12 +1,14 @@
 import React, { useEffect } from "react";
 import { useAuth } from "./AuthProviderDefault";
-import { Route, useRouteMatch } from "react-router-dom";
+import { Route, useLocation, useRouteMatch } from "react-router-dom";
 import { Segment } from "semantic-ui-react";
 import ConsoleMeHeader from "../components/Header";
 import ConsoleMeSidebar from "../components/Sidebar";
+import ReactGA from "react-ga";
 
 const ProtectedRoute = (props) => {
   const auth = useAuth();
+  const location = useLocation();
   const { login, user, isSessionExpired } = auth;
   const match = useRouteMatch(props);
   const { component: Component, ...rest } = props;
@@ -52,6 +54,11 @@ const ProtectedRoute = (props) => {
     }
   }
 
+  if (user?.google_analytics_initialized) {
+    const currentPath = location.pathname + location.search;
+    ReactGA.set({ page: currentPath });
+    ReactGA.pageview(currentPath);
+  }
   return (
     <>
       <ConsoleMeHeader />

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -10956,6 +10956,11 @@ react-fast-compare@3.2.0, react-fast-compare@^3.0.1:
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.0.tgz#641a9da81b6a6320f270e89724fb45a0b39e43bb"
   integrity sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==
 
+react-ga@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/react-ga/-/react-ga-3.3.0.tgz#c91f407198adcb3b49e2bc5c12b3fe460039b3ca"
+  integrity sha512-o8RScHj6Lb8cwy3GMrVH6NJvL+y0zpJvKtc0+wmH7Bt23rszJmnqEQxRbyrqUzk9DTJIHoP42bfO5rswC9SWBQ==
+
 react-is@^16.6.0, react-is@^16.6.3, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.6:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"


### PR DESCRIPTION
This PR adds configurable support for Google Analytics to ConsoleMe. Google Analytics is DISABLED by default and can only be configured by the admin of your ConsoleMe cluster. To use Google Analytics, set your backend consoleme configuration as follows:

```
google_analytics:
  tracking_id: REPLACE_WITH_YOUR_TRACKING_ID
```