### PR TITLE
Fixes a bug that breaks the "Policy Wizard" button on roles

### DIFF
--- a/ui/src/components/selfservice/SelfService.js
+++ b/ui/src/components/selfservice/SelfService.js
@@ -58,7 +58,6 @@ class SelfService extends Component {
     if (arnRegex.test(paramSearch.arn)) {
       const match = arnRegex.exec(paramSearch.arn);
       const { accountId, roleName } = match.groups;
-
       this.setState({
         admin_bypass_approval_enabled: config.admin_bypass_approval_enabled,
         export_to_terraform_enabled: config.export_to_terraform_enabled,
@@ -72,6 +71,10 @@ class SelfService extends Component {
             app_details: [],
           },
           arn: `arn:aws:iam::${accountId}:role/${roleName}`,
+          principal: {
+            principal_type: "AwsResource",
+            principal_arn: `arn:aws:iam::${accountId}:role/${roleName}`,
+          },
           name: roleName,
           owner: "",
           tags: [],


### PR DESCRIPTION
With the Self-Service UI revamp, it seems that the "Policy Wizard" button is broken, if you try to add an action:

https://www.loom.com/share/974470723eb049cb81ec2a0b4f532c8f

This PR fixes that.