### PR TITLE
Add user specific settings on UI

### DIFF
--- a/ui/src/components/DynamicConfig.js
+++ b/ui/src/components/DynamicConfig.js
@@ -10,12 +10,14 @@ import {
   Divider,
 } from "semantic-ui-react";
 import { useAuth } from "../auth/AuthProviderDefault";
+import { getLocalStorageSettings } from "../helpers/utils";
 
 function ConsoleMeDynamicConfig() {
   const [config, setConfig] = useState("");
   const [configSha256, setConfigSha256] = useState("");
   const [statusMessage, setStatusMessage] = useState(null);
   const { sendRequestCommon } = useAuth();
+  const editorTheme = getLocalStorageSettings("editorTheme");
 
   useEffect(() => {
     async function fetchDynamicConfig() {
@@ -93,7 +95,7 @@ function ConsoleMeDynamicConfig() {
           <MonacoEditor
             height="1000"
             language="yaml"
-            theme="vs-light"
+            theme={editorTheme}
             value={config}
             onChange={onChange}
             options={options}

--- a/ui/src/components/Header.js
+++ b/ui/src/components/Header.js
@@ -1,11 +1,13 @@
-import React from "react";
+import React, { useState } from "react";
 import { Dropdown, Menu, Image, Message } from "semantic-ui-react";
 import { NavLink } from "react-router-dom";
 import { useAuth } from "../auth/AuthProviderDefault";
 import ReactMarkdown from "react-markdown";
+import SettingsModal from "./SettingsModal";
 
 const ConsoleMeHeader = () => {
   const { user } = useAuth();
+  const [settingsOpen, setSettingsOpen] = useState(false);
 
   const generatePoliciesDropDown = () => {
     const canCreateRoles = user?.authorization?.can_create_roles;
@@ -49,6 +51,14 @@ const ConsoleMeHeader = () => {
     return null;
   };
 
+  const openSettings = () => {
+    setSettingsOpen(true);
+  };
+
+  const closeSettings = () => {
+    setSettingsOpen(false);
+  };
+
   const getAvatarImage = () => {
     let dropdownOptions = [
       {
@@ -56,6 +66,11 @@ const ConsoleMeHeader = () => {
         text: user.user,
         value: user.user,
         image: { avatar: true, src: user?.employee_photo_url },
+      },
+      {
+        key: "settings",
+        text: "Settings",
+        onClick: openSettings,
       },
     ];
     if (user?.can_logout) {
@@ -104,6 +119,13 @@ const ConsoleMeHeader = () => {
     return null;
   };
 
+  // const settingsModal = () => {
+  //   if(settingsOpen){
+  //     return <SettingsModal />;
+  //   }
+  //   return null;
+  // }
+
   return (
     <>
       <Menu
@@ -145,6 +167,7 @@ const ConsoleMeHeader = () => {
         </Menu.Menu>
       </Menu>
       {headerMessage()}
+      <SettingsModal isOpen={settingsOpen} closeSettings={closeSettings} />
     </>
   );
 };

--- a/ui/src/components/Header.js
+++ b/ui/src/components/Header.js
@@ -119,13 +119,6 @@ const ConsoleMeHeader = () => {
     return null;
   };
 
-  // const settingsModal = () => {
-  //   if(settingsOpen){
-  //     return <SettingsModal />;
-  //   }
-  //   return null;
-  // }
-
   return (
     <>
       <Menu

--- a/ui/src/components/SettingsModal.js
+++ b/ui/src/components/SettingsModal.js
@@ -77,12 +77,7 @@ const SettingsModal = (props) => {
           onClick={saveSettings}
           positive
         />
-        <Button
-          content="Cancel"
-          onClick={closeSettings}
-          icon="cancel"
-          negative
-        />
+        <Button content="Close" onClick={closeSettings} icon="cancel" />
       </Modal.Actions>
     </Modal>
   );

--- a/ui/src/components/SettingsModal.js
+++ b/ui/src/components/SettingsModal.js
@@ -1,23 +1,31 @@
 import React, { useState } from "react";
-import { Button, Modal, Dropdown, Grid } from "semantic-ui-react";
-import { editor_themes, getLocalStorageSettings } from "../helpers/utils";
+import { Button, Modal, Dropdown, Grid, Message } from "semantic-ui-react";
+import {
+  editor_themes,
+  getLocalStorageSettings,
+  setLocalStorageSettings,
+} from "../helpers/utils";
 
 const SettingsModal = (props) => {
   const [currentSettings, setCurrentSettings] = useState(
     JSON.parse(JSON.stringify(getLocalStorageSettings()))
   );
+  const [messages, setMessages] = useState([]);
 
   const saveSettings = () => {
-    console.log("Save");
+    setLocalStorageSettings(currentSettings);
+    setMessages(["Settings have been successfully updated!"]);
   };
   const closeSettings = () => {
     setCurrentSettings(JSON.parse(JSON.stringify(getLocalStorageSettings())));
+    setMessages([]);
     props.closeSettings();
   };
 
   const updateEditorTheme = (e, data) => {
     const oldSettings = currentSettings;
     oldSettings.editorTheme = data.value;
+    setMessages([]);
     setCurrentSettings(oldSettings);
   };
 
@@ -42,12 +50,24 @@ const SettingsModal = (props) => {
       </Grid>
     );
   };
+  const getMessages = () => {
+    if (messages.length > 0) {
+      return (
+        <Message positive>
+          <Message.Header>Success</Message.Header>
+          <Message.Content>{messages[0]}</Message.Content>
+        </Message>
+      );
+    }
+    return null;
+  };
 
   return (
-    <Modal open={props.isOpen}>
+    <Modal open={props.isOpen} onClose={closeSettings}>
       <Modal.Header>Settings</Modal.Header>
       <Modal.Content>
         <Modal.Description>{editorThemeSettings()}</Modal.Description>
+        {getMessages()}
       </Modal.Content>
       <Modal.Actions>
         <Button

--- a/ui/src/components/SettingsModal.js
+++ b/ui/src/components/SettingsModal.js
@@ -1,0 +1,71 @@
+import React, { useState } from "react";
+import { Button, Modal, Dropdown, Grid } from "semantic-ui-react";
+import { editor_themes, getLocalStorageSettings } from "../helpers/utils";
+
+const SettingsModal = (props) => {
+  const [currentSettings, setCurrentSettings] = useState(
+    JSON.parse(JSON.stringify(getLocalStorageSettings()))
+  );
+
+  const saveSettings = () => {
+    console.log("Save");
+  };
+  const closeSettings = () => {
+    setCurrentSettings(JSON.parse(JSON.stringify(getLocalStorageSettings())));
+    props.closeSettings();
+  };
+
+  const updateEditorTheme = (e, data) => {
+    const oldSettings = currentSettings;
+    oldSettings.editorTheme = data.value;
+    setCurrentSettings(oldSettings);
+  };
+
+  const editorThemeSettings = () => {
+    return (
+      <Grid verticalAlign="middle">
+        <Grid.Row>
+          <Grid.Column width={4} floated="left">
+            Editor Theme
+          </Grid.Column>
+          <Grid.Column width={8}>
+            <Dropdown
+              fluid
+              placeholder="Select Theme"
+              selection
+              onChange={updateEditorTheme}
+              defaultValue={currentSettings.editorTheme}
+              options={editor_themes}
+            />
+          </Grid.Column>
+        </Grid.Row>
+      </Grid>
+    );
+  };
+
+  return (
+    <Modal open={props.isOpen}>
+      <Modal.Header>Settings</Modal.Header>
+      <Modal.Content>
+        <Modal.Description>{editorThemeSettings()}</Modal.Description>
+      </Modal.Content>
+      <Modal.Actions>
+        <Button
+          content="Save Settings"
+          labelPosition="left"
+          icon="arrow right"
+          onClick={saveSettings}
+          positive
+        />
+        <Button
+          content="Cancel"
+          onClick={closeSettings}
+          icon="cancel"
+          negative
+        />
+      </Modal.Actions>
+    </Modal>
+  );
+};
+
+export default SettingsModal;

--- a/ui/src/components/blocks/MonacoDiffComponent.js
+++ b/ui/src/components/blocks/MonacoDiffComponent.js
@@ -4,6 +4,7 @@ import PropTypes from "prop-types";
 import {
   getMonacoTriggerCharacters,
   getStringFormat,
+  getLocalStorageSettings,
 } from "../../helpers/utils";
 import * as monaco from "monaco-editor/esm/vs/editor/editor.api.js";
 // This is a global setting, no need to do this multiple times - right now PolicyMonacoEditor.js already sets it
@@ -28,6 +29,7 @@ class MonacoDiffComponent extends React.Component {
       modifiedEditor: null,
       triggerCharacters: getMonacoTriggerCharacters(),
       language: "json",
+      theme: getLocalStorageSettings("editorTheme"),
     };
   }
 
@@ -90,7 +92,7 @@ class MonacoDiffComponent extends React.Component {
         editorDidMount={this.editorDidMount}
         options={options}
         onChange={this.onChange}
-        theme="vs-light"
+        theme={this.state.theme}
         alwaysConsumeMouseWheel={false}
       />
     );

--- a/ui/src/components/generate_config/GenerateConfig.js
+++ b/ui/src/components/generate_config/GenerateConfig.js
@@ -6,6 +6,7 @@ import MonacoEditor from "react-monaco-editor";
 import yaml from "js-yaml";
 import { Header, Icon, Message, Popup, Segment } from "semantic-ui-react";
 import "./GenerateConfig.css";
+import { getLocalStorageSettings } from "../../helpers/utils";
 
 const generated_config_editor_options = {
   selectOnLineNumbers: true,
@@ -21,6 +22,7 @@ function GenerateConfig() {
   const [complete, setComplete] = useState(false);
   const [results, setResults] = useState({});
   const [messages, setMessages] = useState([]);
+  const editorTheme = getLocalStorageSettings("editorTheme");
   const getSpecialTypes = (questions) => {
     const specialTypes = {};
     const formatTypes = {};
@@ -192,7 +194,7 @@ function GenerateConfig() {
           height="700px"
           language="yaml"
           width="100%"
-          theme="vs-light"
+          theme={editorTheme}
           value={yaml.dump(results, 4)}
           options={generated_config_editor_options}
           textAlign="center"

--- a/ui/src/components/policy/ManagedPolicy.js
+++ b/ui/src/components/policy/ManagedPolicy.js
@@ -14,6 +14,7 @@ import useManagedPolicy from "./hooks/useManagedPolicy";
 import { JustificationModal } from "./PolicyModals";
 import { useAuth } from "../../auth/AuthProviderDefault";
 import MonacoEditor from "react-monaco-editor";
+import { getLocalStorageSettings } from "../../helpers/utils";
 
 const ManagedPolicy = () => {
   const { user, sendRequestCommon } = useAuth();
@@ -34,6 +35,7 @@ const ManagedPolicy = () => {
     setAttachedManagedPolicyDetails,
   ] = useState(null);
   const editorRef = useRef();
+  const editorTheme = getLocalStorageSettings("editorTheme");
   // available managed policies are only used for rendering. so let's retrieve from here.
   useEffect(() => {
     (async () => {
@@ -190,7 +192,7 @@ const ManagedPolicy = () => {
                         ref={editorRef}
                         height="540px"
                         language="json"
-                        theme="vs-light"
+                        theme={editorTheme}
                         value={JSON.stringify(
                           attachedManagedPolicyDetails[policy?.PolicyName],
                           null,

--- a/ui/src/components/policy/PermissionsBoundary.js
+++ b/ui/src/components/policy/PermissionsBoundary.js
@@ -14,6 +14,7 @@ import usePermissionsBoundary from "./hooks/usePermissionsBoundary";
 import { JustificationModal } from "./PolicyModals";
 import { useAuth } from "../../auth/AuthProviderDefault";
 import MonacoEditor from "react-monaco-editor";
+import { getLocalStorageSettings } from "../../helpers/utils";
 
 const PermissionsBoundary = () => {
   const { user, sendRequestCommon } = useAuth();
@@ -34,6 +35,7 @@ const PermissionsBoundary = () => {
     setAttachedPermissionsBoundaryDetails,
   ] = useState(null);
   const editorRef = useRef();
+  const editorTheme = getLocalStorageSettings("editorTheme");
   // available managed policies are only used for rendering. so let's retrieve from here.
   useEffect(() => {
     (async () => {
@@ -223,7 +225,7 @@ const PermissionsBoundary = () => {
                     ref={editorRef}
                     height="540px"
                     language="json"
-                    theme="vs-light"
+                    theme={editorTheme}
                     value={JSON.stringify(
                       attachedPermissionsBoundaryDetails,
                       null,

--- a/ui/src/components/policy/PolicyMonacoEditor.js
+++ b/ui/src/components/policy/PolicyMonacoEditor.js
@@ -3,6 +3,7 @@ import { Button, Form, Icon, Message, Segment } from "semantic-ui-react";
 import MonacoEditor from "react-monaco-editor";
 import * as monaco from "monaco-editor/esm/vs/editor/editor.api.js";
 import {
+  getLocalStorageSettings,
   getMonacoCompletions,
   getMonacoTriggerCharacters,
 } from "../../helpers/utils";
@@ -105,6 +106,7 @@ export const PolicyMonacoEditor = ({
   const { user, sendRequestCommon } = useAuth();
   const { setModalWithAdminAutoApprove } = usePolicyContext();
   const editorRef = useRef();
+  const editorTheme = getLocalStorageSettings("editorTheme");
   const timeout = useRef(null);
 
   const policyDocumentOriginal = JSON.stringify(
@@ -206,7 +208,7 @@ export const PolicyMonacoEditor = ({
           ref={editorRef}
           height="540px"
           language="json"
-          theme="vs-light"
+          theme={editorTheme}
           value={policyDocument}
           onChange={onEditChange}
           options={editorOptions}
@@ -266,6 +268,7 @@ export const NewPolicyMonacoEditor = ({ addPolicy, setIsNewPolicy }) => {
   const { user, sendRequestCommon } = useAuth();
   const { setModalWithAdminAutoApprove } = usePolicyContext();
   const editorRef = useRef();
+  const editorTheme = getLocalStorageSettings("editorTheme");
   const timeout = useRef(null);
 
   const [newPolicyName, setNewPolicyName] = useState("");
@@ -405,7 +408,7 @@ export const NewPolicyMonacoEditor = ({ addPolicy, setIsNewPolicy }) => {
           ref={editorRef}
           height="540px"
           language="json"
-          theme="vs-light"
+          theme={editorTheme}
           value={policyDocument}
           onChange={onEditChange}
           options={editorOptions}
@@ -450,6 +453,7 @@ export const ReadOnlyPolicyMonacoEditor = ({ policy }) => {
     ...editorOptions,
     readOnly: true,
   };
+  const editorTheme = getLocalStorageSettings("editorTheme");
   return (
     <>
       <Segment
@@ -462,7 +466,7 @@ export const ReadOnlyPolicyMonacoEditor = ({ policy }) => {
         <MonacoEditor
           height="540px"
           language="json"
-          theme="vs-light"
+          theme={editorTheme}
           value={JSON.stringify(policy, null, "\t")}
           options={readOnlyEditorOptions}
           editorDidMount={editorDidMount}

--- a/ui/src/components/selfservice/SelfServiceModal.js
+++ b/ui/src/components/selfservice/SelfServiceModal.js
@@ -3,6 +3,7 @@ import { Button, Divider, Header, Message, Modal } from "semantic-ui-react";
 import React, { Component } from "react";
 import MonacoEditor from "react-monaco-editor";
 import * as monaco from "monaco-editor/esm/vs/editor/editor.api.js";
+import { getLocalStorageSettings } from "../../helpers/utils";
 
 const editor_options = {
   selectOnLineNumbers: true,
@@ -42,6 +43,7 @@ class SelfServiceModal extends Component {
       payloadPermissions: [],
       modal_statement: this.props.updated_policy,
       open: false,
+      editorTheme: getLocalStorageSettings("editorTheme"),
     };
     this.inlinePolicyEditorRef = React.createRef();
     this.onChange = this.onChange.bind(this);
@@ -86,7 +88,7 @@ class SelfServiceModal extends Component {
         height="500px"
         language="json"
         width="100%"
-        theme="vs-light"
+        theme={this.state.editorTheme}
         value={modal_statement}
         onChange={this.onChange}
         options={editor_options}

--- a/ui/src/helpers/utils.js
+++ b/ui/src/helpers/utils.js
@@ -198,10 +198,10 @@ export const getResourceEndpoint = (
   return endpoint;
 };
 
-export const parseLocalStorageCache = (key) => {
+export const parseLocalStorageCache = (key, default_return = []) => {
   const value = window.localStorage.getItem(key);
   if (value == null) {
-    return [];
+    return default_return;
   }
   try {
     return JSON.parse(value);
@@ -241,3 +241,50 @@ export function getStringFormat(str) {
 }
 
 export const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+// Editor theme support
+
+export const editor_themes = [
+  {
+    key: "vs-light",
+    text: "vs-light",
+    value: "vs-light",
+  },
+  {
+    key: "vs-dark",
+    text: "vs-dark",
+    value: "vs-dark",
+  },
+  {
+    key: "hc-black",
+    text: "hc-black",
+    value: "hc-black",
+  },
+];
+
+const default_user_settings = {
+  editorTheme: "vs-light",
+};
+
+export const getLocalStorageSettings = (specificSetting = "") => {
+  const localStorageSettingsKey = "consoleMeUserSettings";
+  let localSettings = parseLocalStorageCache(
+    localStorageSettingsKey,
+    default_user_settings
+  );
+  if (specificSetting === "") {
+    return localSettings;
+  }
+  if (localSettings.hasOwnProperty(specificSetting)) {
+    return localSettings[specificSetting];
+  }
+  return "";
+};
+
+// export const setLocalStorageSettings = (settings) => {
+//   const localStorageSettingsKey = "consoleMeUserSettings";
+//   window.localStorage.setItem(
+//     localStorageRecentRolesKey,
+//     JSON.stringify(recentRoles)
+//   );
+// }

--- a/ui/src/helpers/utils.js
+++ b/ui/src/helpers/utils.js
@@ -281,10 +281,10 @@ export const getLocalStorageSettings = (specificSetting = "") => {
   return "";
 };
 
-// export const setLocalStorageSettings = (settings) => {
-//   const localStorageSettingsKey = "consoleMeUserSettings";
-//   window.localStorage.setItem(
-//     localStorageRecentRolesKey,
-//     JSON.stringify(recentRoles)
-//   );
-// }
+export const setLocalStorageSettings = (settings) => {
+  const localStorageSettingsKey = "consoleMeUserSettings";
+  window.localStorage.setItem(
+    localStorageSettingsKey,
+    JSON.stringify(settings)
+  );
+};


### PR DESCRIPTION
This PR adds user-specific settings on the React side, using local storage. Currently, the only supported setting is the editor theme. By default, this is set to "vs-light", which is what the current setting is.

In the future, we can add support for other user-specific settings that are desirable, such as a default region for logging into the AWS Console. 

Here is a quick video demoing this:
https://www.loom.com/share/95808be39c55411690be9d46725c5d50