### PR TITLE
Optimized dockerfile build speed and cache usage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,7 @@ RUN yarn --cwd ui build:prod
 
 # Run ConsoleMe tornado server using configuration
 COPY consoleme /apps/consoleme/consoleme/
+COPY scripts /apps/consoleme/scripts/
 CMD python scripts/retrieve_or_decode_configuration.py ; python /apps/consoleme/consoleme/__main__.py
 
 EXPOSE 8081

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,31 +1,39 @@
 # Dockerfile should instantiate AWS Project with configurable plugins
 FROM python:3.8
 MAINTAINER Curtis Castrapel
-COPY . /apps/consoleme
 WORKDIR /apps/consoleme
 # NODE_OPTIONS meeded to increase memory size of Node for the `yarn build` step. The Monaco Editor
 # appears to be the culprit requiring this.
 ENV NODE_OPTIONS="--max-old-space-size=20000"
 ENV SETUPTOOLS_USE_DISTUTILS=stdlib
-# Install dependencies
+
+# Install OS dependencies
 RUN curl -sL https://deb.nodesource.com/setup_14.x | bash
 RUN apt-get clean
 RUN apt-get update
 RUN apt-get install build-essential libxml2-dev libxmlsec1-dev libxmlsec1-openssl musl-dev libcurl4-nss-dev python3-dev nodejs -y
+
+# Install python dependencies
+COPY requirements.txt requirements-test.txt setup.py /apps/consoleme/
+COPY default_plugins /apps/consoleme/default_plugins/
+
 RUN pip install -U setuptools pip cython
 RUN pip install --no-cache-dir -r requirements.txt
 RUN pip install --no-cache-dir -r requirements-test.txt
 RUN pip install -e .
 RUN pip install -e default_plugins
 # Install watchdog. Used to automatically restart ConsoleMe in Docker, for development.
-RUN pip install watchdog
-# Required by watchdog
-RUN pip install argh
+RUN pip install watchdog argh
 
 # Install SPA frontend
+COPY ui /apps/consoleme/ui/
+RUN mkdir /apps/consoleme/consoleme
 RUN npm install yarn -g
 RUN yarn --cwd ui
 RUN yarn --cwd ui build:prod
+
+# Run ConsoleMe tornado server using configuration
+COPY consoleme /apps/consoleme/consoleme/
 CMD python scripts/retrieve_or_decode_configuration.py ; python /apps/consoleme/consoleme/__main__.py
 
 EXPOSE 8081


### PR DESCRIPTION
Currently, probably for simplicity the first command on the `Dockerfile` is `COPY . /apps/consoleme`.
Because of it, every file change causes rebuilding the whole docker image.
Especially in CDK deployments, when we want to test new python code, it could take around 15 minutes only to build the Docker image and test the updated code.
This PR splits the file copying and using the Docker build cache in an optimal way to reduce rebuilding time.