### PR TITLE
Update helm values to work when merging with other values files

### DIFF
--- a/helm/consoleme/templates/configmap-base.yaml
+++ b/helm/consoleme/templates/configmap-base.yaml
@@ -8,6 +8,10 @@ data:
   config_base.yaml: |-
     application_admin: {{ .Values.consoleme.application_admin }}
 
+    {{- with .Values.consoleme_s3_bucket }}
+    consoleme_s3_bucket: {{ . }}
+    {{- end }}
+
     environment: {{ .Values.consoleme.environment }}
 
     {{- with .Values.tornado }}

--- a/helm/consoleme/templates/deployment-celery-worker.yaml
+++ b/helm/consoleme/templates/deployment-celery-worker.yaml
@@ -44,7 +44,11 @@ spec:
         - name: {{ .Chart.Name }}-celery-worker
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
+          {{- if .Values.image.digest }}
+          image: "{{ .Values.image.repository }}@{{ .Values.image.digest}}"
+          {{- else }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["/bin/bash","-c", {{ .Values.consoleme.celery_worker.command }}]
           resources:

--- a/helm/consoleme/templates/deployment-celery.yaml
+++ b/helm/consoleme/templates/deployment-celery.yaml
@@ -44,7 +44,11 @@ spec:
         - name: {{ .Chart.Name }}-celery
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
+          {{- if .Values.image.digest }}
+          image: "{{ .Values.image.repository }}@{{ .Values.image.digest}}"
+          {{- else }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["/bin/bash","-c", {{ .Values.consoleme.celery.command }}]
           resources:

--- a/helm/consoleme/templates/deployment-consoleme.yaml
+++ b/helm/consoleme/templates/deployment-consoleme.yaml
@@ -47,7 +47,11 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
+          {{- if .Values.image.digest }}
+          image: "{{ .Values.image.repository }}@{{ .Values.image.digest}}"
+          {{- else }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["/bin/bash","-c", {{ .Values.consoleme.web.command }}]
           ports:

--- a/helm/consoleme/templates/ingress.yaml
+++ b/helm/consoleme/templates/ingress.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "consoleme.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-apiVersion: extensions/v1beta1
+apiVersion: {{ .Values.ingress.apiVersion }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}

--- a/helm/consoleme/values.yaml
+++ b/helm/consoleme/values.yaml
@@ -210,9 +210,9 @@ aws:
 #   required_headers:
 #     - RequiredMTLSHeader: RequiredMTLSHeaderValue
 
-challenge_url:
-  enabled: true
-  request_ip_must_match_challenge_creation_ip: false
+# challenge_url:
+#   enabled: true
+#   request_ip_must_match_challenge_creation_ip: false
 
 consoleme:
   # Whether to show terraform exporter tab or not

--- a/helm/consoleme/values.yaml
+++ b/helm/consoleme/values.yaml
@@ -22,7 +22,7 @@ serviceAccount:
   name: ""
 
 # If you're using Kube2iam: Role to be assumed by the pods
-# podAnnotations:
+podAnnotations: {}
 #   iam.amazonaws.com/role: arn:aws:iam::<AWS account number>:role/ConsoleMeInstanceProfile
 
 podSecurityContext:
@@ -196,7 +196,7 @@ cloud_credential_authorization_mapping:
     internal_plugin:
       enabled: false
 
-# account_ids_to_name:
+account_ids_to_name: {}
 #   "<First AWS account number>": <First AWS account name>
 #   "<Second AWS account number>": <Second AWS account name>
 
@@ -205,12 +205,12 @@ aws:
   account_number: "<Main AWS account number>"
   region: us-east-1
 
-# cli_auth:
+cli_auth: {}
 #   certificate_header: certificate_header
 #   required_headers:
 #     - RequiredMTLSHeader: RequiredMTLSHeaderValue
 
-# challenge_url:
+challenge_url: {}
 #   enabled: true
 #   request_ip_must_match_challenge_creation_ip: false
 

--- a/helm/consoleme/values.yaml
+++ b/helm/consoleme/values.yaml
@@ -363,6 +363,7 @@ service:
 
 ingress:
   enabled: false
+  apiVersion: extensions/v1beta1
   annotations: {}
   hosts:
     - host: <ConsoleMe URL>

--- a/helm/consoleme/values.yaml
+++ b/helm/consoleme/values.yaml
@@ -22,8 +22,8 @@ serviceAccount:
   name: ""
 
 # If you're using Kube2iam: Role to be assumed by the pods
-podAnnotations:
-  iam.amazonaws.com/role: arn:aws:iam::<AWS account number>:role/ConsoleMeInstanceProfile
+# podAnnotations:
+#   iam.amazonaws.com/role: arn:aws:iam::<AWS account number>:role/ConsoleMeInstanceProfile
 
 podSecurityContext:
   {}
@@ -38,8 +38,8 @@ securityContext:
   # runAsNonRoot: true
   # runAsUser: 1000
 
-sentry:
-  dsn: <Sentry project DSN>
+# sentry:
+#   dsn: <Sentry project DSN>
 
 tornado:
   debug: false
@@ -184,8 +184,8 @@ documentation_page: https://github.com/Netflix/consoleme/
 # consoleme-authorized-cli-only=group3@example.com
 cloud_credential_authorization_mapping:
   role_tags:
-    enabled: True
-    required_trust_policy_entity: "arn:aws:iam::<AWS account number>:role/ConsoleMeInstanceProfile"
+    enabled: true
+    # required_trust_policy_entity: "arn:aws:iam::<AWS account number>:role/ConsoleMeInstanceProfile"
     authorized_groups_tags:
       - consoleme-authorized
     authorized_groups_cli_only_tags:
@@ -196,19 +196,19 @@ cloud_credential_authorization_mapping:
     internal_plugin:
       enabled: false
 
-account_ids_to_name:
-  "<First AWS account number>": <First AWS account name>
-  "<Second AWS account number>": <Second AWS account name>
+# account_ids_to_name:
+#   "<First AWS account number>": <First AWS account name>
+#   "<Second AWS account number>": <Second AWS account name>
 
 aws:
   issuer: YourCompany
   account_number: "<Main AWS account number>"
   region: us-east-1
 
-cli_auth:
-  certificate_header: certificate_header
-  required_headers:
-    - RequiredMTLSHeader: RequiredMTLSHeaderValue
+# cli_auth:
+#   certificate_header: certificate_header
+#   required_headers:
+#     - RequiredMTLSHeader: RequiredMTLSHeaderValue
 
 challenge_url:
   enabled: true
@@ -225,8 +225,7 @@ consoleme:
   web:
     replicaCount: 1
     # Not using the script retrieve_or_decode_configuration
-    command: >
-      "python consoleme/__main__.py"
+    command: "python consoleme/__main__.py"
     containerPort: 8081
     livenessProbe:
       path: /
@@ -290,8 +289,7 @@ consoleme:
     # In case you're deploying DynamoDB in this chart you should add this command at the beginning:
     #     python scripts/initialize_dynamodb_oss.py;
     # It'll create the necessary tables
-    command: >
-      "celery -A consoleme.celery_tasks.celery_tasks worker -l DEBUG -E --pidfile /tmp/celery.pid --max-memory-per-child=1000000 --max-tasks-per-child 50 --soft-time-limit 3600 --concurrency=10 -O fair"
+    command: "celery -A consoleme.celery_tasks.celery_tasks worker -l DEBUG -E --pidfile /tmp/celery.pid --max-memory-per-child=1000000 --max-tasks-per-child 50 --soft-time-limit 3600 --concurrency=10 -O fair"
     env:
       - name: EC2_REGION
         value: us-east-1

--- a/helm/consoleme/values.yaml
+++ b/helm/consoleme/values.yaml
@@ -38,7 +38,7 @@ securityContext:
   # runAsNonRoot: true
   # runAsUser: 1000
 
-# sentry:
+sentry: {}
 #   dsn: <Sentry project DSN>
 
 tornado:


### PR DESCRIPTION
## High Level Problem

With helm, objects merge together as additional keys are set within a parent object. In the screenshot below, I get bogus values added to my helm deployment with the current `values.yaml` files. 

<img width="770" alt="Screen Shot 2021-07-23 at 3 13 20 PM" src="https://user-images.githubusercontent.com/11354884/126847613-e662a57e-3f6a-46e4-ba7d-c066b34fb476.png">

This PR comments out those values so helm value merging succeeds.

## Other Changes

- Added `consoleme_s3_bucket` to the `config_base.yaml` (Since I thought I needed to backup the cache to s3 also)
- Added optional override for `image.digest` (Since there's only 1 `latest` tagged docker image, I wanted to lock it in to a digest)
- Added optional override for `ingress.apiVersion` (Since we have different versions of k8s)