### PR TITLE
Removed unnecesary setup steps

### DIFF
--- a/docs/gitbook/configuration/authentication-and-authorization/google-groups-support.md
+++ b/docs/gitbook/configuration/authentication-and-authorization/google-groups-support.md
@@ -9,7 +9,8 @@ ConsoleMe can retrieve your google groups information and use it to authorize ro
 1. Login to the google account in which the GCP app for consoleme was setup
 2. Go to the [service accounts](https://console.cloud.google.com/iam-admin/serviceaccounts) page and select your consoleme project
 3. Click on **create service account** option
-4. Fill in the details and click **Done**
+4. Fill in the details but skip the optional steps
+5. Click **Done**
 
 ## Enable Domain wide delegation for the service account
 
@@ -105,9 +106,8 @@ ConsoleMe should now be able to get groups info from Google IDP.
 
 ## Check if group info is properly retrieved
 
-One way to check is by decoding the JWT in the **consoleme\_auth** cookie.
+One way to check is by decoding the JWT in the **consoleme_auth** cookie.
 
-1. Copy the contents of the **consoleme\_auth** cookie from your consoleme domain
+1. Copy the contents of the **consoleme_auth** cookie from your consoleme domain
 2. Go to [jwt.io](https://github.com/Netflix/consoleme/tree/6423fcfc7f089b5f021608c48e7c04f9d1435221/docs/gitbook/configuration/authentication-and-authorization/jwt.io) and paste in the contents of the cookie
 3. It will decode the JWT and you can validate the groups information as seen by ConsoleMe
-

--- a/docs/gitbook/configuration/authentication-and-authorization/google-groups-support.md
+++ b/docs/gitbook/configuration/authentication-and-authorization/google-groups-support.md
@@ -9,9 +9,7 @@ ConsoleMe can retrieve your google groups information and use it to authorize ro
 1. Login to the google account in which the GCP app for consoleme was setup
 2. Go to the [service accounts](https://console.cloud.google.com/iam-admin/serviceaccounts) page and select your consoleme project
 3. Click on **create service account** option
-4. Fill in the details and click **create and continue**
-5. From the **Select a role** dropdown menu, choose the **owner** option
-6. Click **Done**
+4. Fill in the details and click **Done**
 
 ## Enable Domain wide delegation for the service account
 


### PR DESCRIPTION
This PR removes one unnecessary step while setting up google groups with ALB auth. This extra permission of giving the service account owner access is not required.