### PR TITLE
Self Service Step 3 Writable ; Reset advanced settings

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -7,6 +7,7 @@ boto3
 cchardet
 celery[redis]
 cloudaux
+cryptography # Dilbwag needed this
 datamodel-code-generator
 decorator<5 # Internal requirement has decorator pinned to <5.
 deepdiff

--- a/requirements.in
+++ b/requirements.in
@@ -7,7 +7,7 @@ boto3
 cchardet
 celery[redis]
 cloudaux
-cryptography # Dilbwag needed this
+cryptography
 datamodel-code-generator
 decorator<5 # Internal requirement has decorator pinned to <5.
 deepdiff

--- a/requirements.txt
+++ b/requirements.txt
@@ -64,6 +64,7 @@ certifi==2020.12.5
 cffi==1.14.5
     # via
     #   bcrypt
+    #   cryptography
     #   google-crc32c
 chardet==4.0.0
     # via
@@ -89,6 +90,8 @@ cloudaux==1.9.5
     # via -r requirements.in
 contextlib2==0.6.0.post1
     # via schema
+cryptography==3.4.7
+    # via -r requirements.in
 datamodel-code-generator==0.11.5
     # via -r requirements.in
 decorator==4.4.2

--- a/ui/src/components/selfservice/SelfService.js
+++ b/ui/src/components/selfservice/SelfService.js
@@ -176,6 +176,18 @@ class SelfService extends Component {
     this.setState({ permissions });
   }
 
+  handleResetUserChoices() {
+    // This function is called after a user has added a permission set
+    // to their "shopping cart". It will reset advanced settings so they
+    // are not carried over to additional permission sets they add to their
+    // "shopping cart".
+    this.setState({
+      extraActions: [],
+      includeAccounts: [],
+      excludeAccounts: [],
+    });
+  }
+
   getCurrentSelfServiceStep() {
     const {
       admin_bypass_approval_enabled,
@@ -218,6 +230,7 @@ class SelfService extends Component {
             handleStepClick={this.handleStepClick.bind(this)}
             updatePolicy={this.updatePolicy.bind(this)}
             handlePermissionsUpdate={this.handlePermissionsUpdate.bind(this)}
+            handleResetUserChoices={this.handleResetUserChoices.bind(this)}
             handleExtraActionsUpdate={this.handleExtraActionsUpdate.bind(this)}
             handleIncludeAccountsUpdate={this.handleIncludeAccountsUpdate.bind(
               this

--- a/ui/src/components/selfservice/SelfServiceStep2.js
+++ b/ui/src/components/selfservice/SelfServiceStep2.js
@@ -164,6 +164,8 @@ class SelfServiceStep2 extends Component {
           this.props.handlePermissionsUpdate(permissions);
         }
       );
+      // Reset extraActions, includeAccounts, and excludeAccounts
+      this.props.handleResetUserChoices();
     }
   }
 

--- a/ui/src/components/selfservice/SelfServiceStep3.js
+++ b/ui/src/components/selfservice/SelfServiceStep3.js
@@ -43,6 +43,7 @@ class SelfServiceStep3 extends Component {
     this.handleJustificationChange = this.handleJustificationChange.bind(this);
     this.handleSubmit = this.handleSubmit.bind(this);
     this.handleAdminSubmit = this.handleAdminSubmit.bind(this);
+    this.onValueChange = this.onValueChange.bind(this);
   }
 
   async componentDidMount() {
@@ -441,7 +442,6 @@ class SelfServiceStep3 extends Component {
           <MonacoDiffComponent
             oldValue={old_policy}
             newValue={new_policy}
-            readOnly={true}
             onLintError={this.onLintError}
             onValueChange={this.onValueChange}
           />

--- a/ui/src/components/selfservice/SelfServiceStep3.js
+++ b/ui/src/components/selfservice/SelfServiceStep3.js
@@ -122,7 +122,11 @@ class SelfServiceStep3 extends Component {
     });
   }
 
-  onValueChange() {}
+  onValueChange(newValue, e) {
+    this.setState({
+      new_policy: newValue,
+    });
+  }
 
   buildMonacoEditor() {
     const { old_policy, new_policy } = this.state;
@@ -131,7 +135,6 @@ class SelfServiceStep3 extends Component {
       <MonacoDiffComponent
         oldValue={old_policy}
         newValue={new_policy}
-        readOnly={true}
         onLintError={this.onLintError}
         onValueChange={this.onValueChange}
       />
@@ -150,8 +153,8 @@ class SelfServiceStep3 extends Component {
   }
 
   handleSubmit() {
-    const { role, updated_policy } = this.props;
-    const { justification, admin_auto_approve } = this.state;
+    const { role } = this.props;
+    const { justification, admin_auto_approve, new_policy } = this.state;
     if (!justification) {
       return this.setState((state) => ({
         messages: ["No Justification is Given"],
@@ -168,7 +171,7 @@ class SelfServiceStep3 extends Component {
             change_type: "inline_policy",
             action: "attach",
             policy: {
-              policy_document: JSON.parse(updated_policy),
+              policy_document: JSON.parse(new_policy),
             },
           },
         ],


### PR DESCRIPTION
This PR modifies Step 3 of the Self Service IAM wizard by making it writable. This will allow users to fix mistakes easier before submitting their request through the auto-approval / review process.

This PR also fixes a bug where "advanced settings" such as extraActions are carried over to additional permission sets when the user adds more than one permission set to their "shopping cart". 

Lastly, cryptography is required by ConsoleMe but was not properly listed in the requirements file. 

TODO: The action/resource typeahead in the MonacoDiffComponent is not working properly in Step 3. 