### PR TITLE
Add major,minor,patch versioning to our docker images

### DIFF
--- a/.github/workflows/docker-publish-dockerhub.yaml
+++ b/.github/workflows/docker-publish-dockerhub.yaml
@@ -11,20 +11,28 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v2
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v1.1.1
       - name: Login to DockerHub
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.CONSOLEME_DOCKERHUB_USERNAME }}
           password: ${{ secrets.CONSOLEME_DOCKERHUB_PASSWORD }}
-      - name: Build and push
-        id: docker_build
-        uses: docker/build-push-action@v2
-        with:
-          push: true
-          tags: consoleme/consoleme:latest
-      - name: Image digest
-        run: echo ${{ steps.docker_build.outputs.digest }}
+      - name: Build ConsoleMe
+        run: |
+          docker build -t consoleme .
+      - name: Tag, and push image to DockerHub
+        run: |
+          export CONSOLEME_VERSION=$(python setup.py -q --version)
+          export CONSOLEME_MAJOR=$(cut -d '.' -f 1 <<< "$CONSOLEME_VERSION")
+          export CONSOLEME_MINOR=$(cut -d '.' -f 1,2 <<< "$CONSOLEME_VERSION")
+          export CONSOLEME_PATCH=$(cut -d '.' -f 1,2,3 <<< "$CONSOLEME_VERSION")
+          docker tag consoleme:latest consoleme/consoleme:latest
+          docker tag consoleme:latest consoleme/consoleme:$CONSOLEME_VERSION
+          docker tag consoleme:latest consoleme/consoleme:$CONSOLEME_MAJOR
+          docker tag consoleme:latest consoleme/consoleme:$CONSOLEME_MINOR
+          docker tag consoleme:latest consoleme/consoleme:$CONSOLEME_PATCH
+          docker push consoleme/consoleme:latest
+          docker push consoleme/consoleme:$CONSOLEME_VERSION
   deploy_consoleme_demo_site:
     name: Deploy Demo Site
     if: github.repository == 'Netflix/consoleme'

--- a/.github/workflows/docker-publish-dockerhub.yaml
+++ b/.github/workflows/docker-publish-dockerhub.yaml
@@ -31,8 +31,7 @@ jobs:
           docker tag consoleme:latest consoleme/consoleme:$CONSOLEME_MAJOR
           docker tag consoleme:latest consoleme/consoleme:$CONSOLEME_MINOR
           docker tag consoleme:latest consoleme/consoleme:$CONSOLEME_PATCH
-          docker push consoleme/consoleme:latest
-          docker push consoleme/consoleme:$CONSOLEME_VERSION
+          docker push --all-tags consoleme/consoleme
   deploy_consoleme_demo_site:
     name: Deploy Demo Site
     if: github.repository == 'Netflix/consoleme'

--- a/.github/workflows/docker-publish-ecr.yml
+++ b/.github/workflows/docker-publish-ecr.yml
@@ -34,5 +34,14 @@ jobs:
           docker build -t consoleme .
       - name: Tag, and push image to Amazon ECR
         run: |
+          export CONSOLEME_VERSION=$(python setup.py -q --version)
+          export CONSOLEME_MAJOR=$(cut -d '.' -f 1 <<< "$CONSOLEME_VERSION")
+          export CONSOLEME_MINOR=$(cut -d '.' -f 1,2 <<< "$CONSOLEME_VERSION")
+          export CONSOLEME_PATCH=$(cut -d '.' -f 1,2,3 <<< "$CONSOLEME_VERSION")
           docker tag consoleme:latest public.ecr.aws/consoleme/consoleme:latest
+          docker tag consoleme:latest public.ecr.aws/consoleme/consoleme:$CONSOLEME_VERSION
+          docker tag consoleme:latest public.ecr.aws/consoleme/consoleme:$CONSOLEME_MAJOR
+          docker tag consoleme:latest public.ecr.aws/consoleme/consoleme:$CONSOLEME_MINOR
+          docker tag consoleme:latest public.ecr.aws/consoleme/consoleme:$CONSOLEME_PATCH
           docker push public.ecr.aws/consoleme/consoleme:latest
+          docker push public.ecr.aws/consoleme/consoleme:$CONSOLEME_VERSION

--- a/.github/workflows/docker-publish-ecr.yml
+++ b/.github/workflows/docker-publish-ecr.yml
@@ -43,5 +43,4 @@ jobs:
           docker tag consoleme:latest public.ecr.aws/consoleme/consoleme:$CONSOLEME_MAJOR
           docker tag consoleme:latest public.ecr.aws/consoleme/consoleme:$CONSOLEME_MINOR
           docker tag consoleme:latest public.ecr.aws/consoleme/consoleme:$CONSOLEME_PATCH
-          docker push public.ecr.aws/consoleme/consoleme:latest
-          docker push public.ecr.aws/consoleme/consoleme:$CONSOLEME_VERSION
+          docker push --all-tags public.ecr.aws/consoleme/consoleme


### PR DESCRIPTION
This PR is an attempt at adding appropriate version tags to Docker images that are built automatically by Github actions. This will tag the docker image with the full version, major, minor, and patch versions

Here's what this looks like when tagging a test image with a dirty commit:

![2021-07-30_06-41_1](https://user-images.githubusercontent.com/7538233/127661712-64a1ec51-66bd-4624-b112-063af1c7daab.png)


