### PR TITLE
Allow overriding landing url

### DIFF
--- a/consoleme/handlers/v2/user_profile.py
+++ b/consoleme/handlers/v2/user_profile.py
@@ -39,6 +39,9 @@ class UserProfileHandler(BaseAPIV1Handler):
             ),
             "security_logo": config.get("security_logo.image"),
             "security_url": config.get("security_logo.url"),
+            # If site_config.landing_url is set, users will be redirected to the landing URL after authenticating
+            # on the frontend.
+            "landing_url": config.get("site_config.landing_url"),
         }
 
         custom_page_header: Dict[str, str] = await get_custom_page_header(

--- a/tests/handlers/v2/test_user_profile.py
+++ b/tests/handlers/v2/test_user_profile.py
@@ -39,6 +39,7 @@ class TestUserProfile(AsyncHTTPTestCase):
                     "support_chat_url": "https://www.example.com/slack/channel",
                     "security_logo": None,
                     "security_url": None,
+                    "landing_url": None,
                 },
                 "user": "user@example.com",
                 "is_contractor": False,

--- a/ui/src/auth/AuthProviderDefault.js
+++ b/ui/src/auth/AuthProviderDefault.js
@@ -42,7 +42,7 @@ const reducer = (state, action) => {
 export const AuthProvider = ({ children }) => {
   const [state, dispatch] = useReducer(reducer, initialAuthState);
 
-  const login = async () => {
+  const login = async (history) => {
     try {
       // First check whether user is currently authenticated by using the backend auth endpoint.
       const auth = await fetch("/auth?redirect_url=" + window.location.href, {
@@ -79,6 +79,11 @@ export const AuthProvider = ({ children }) => {
         type: "LOGIN",
         user,
       });
+
+      // Cloud administrators can override the initial landing URL for users by providing a configuration on the backend
+      if (user?.site_config?.landing_url) {
+        history.push(user.site_config.landing_url);
+      }
     } catch (error) {
       // If session expires, fetch will return the error page showing re-authentication is required and raise an
       // exception from handling the html file instead of application/json type.

--- a/ui/src/auth/ProtectedRoute.js
+++ b/ui/src/auth/ProtectedRoute.js
@@ -1,6 +1,11 @@
 import React, { useEffect } from "react";
 import { useAuth } from "./AuthProviderDefault";
-import { Route, useLocation, useRouteMatch } from "react-router-dom";
+import {
+  Route,
+  useHistory,
+  useLocation,
+  useRouteMatch,
+} from "react-router-dom";
 import { Segment } from "semantic-ui-react";
 import ConsoleMeHeader from "../components/Header";
 import ConsoleMeSidebar from "../components/Sidebar";
@@ -8,6 +13,7 @@ import ReactGA from "react-ga";
 
 const ProtectedRoute = (props) => {
   const auth = useAuth();
+  let history = useHistory();
   const location = useLocation();
   const { login, user, isSessionExpired } = auth;
   const match = useRouteMatch(props);
@@ -27,10 +33,10 @@ const ProtectedRoute = (props) => {
 
     if (!user) {
       (async () => {
-        await login();
+        await login(history);
       })();
     }
-  }, [match, user, isSessionExpired, login]);
+  }, [match, user, isSessionExpired, login, history]);
 
   if (!user) {
     return null;


### PR DESCRIPTION
Addresses #9188

This PR allows a ConsoleMe administrator to configure a landing page for their users in the UI, instead of the default index page. This can be accomplished by setting the `site_config.landing_url` configuration value. For example:

```
site_config:
  landing_url: /policies
```