### PR TITLE
Prevent cross-account resource policy creation for role that doesn't exist

### DIFF
--- a/consoleme/lib/v2/requests.py
+++ b/consoleme/lib/v2/requests.py
@@ -1517,6 +1517,16 @@ async def populate_cross_account_resource_policy_for_change(
                     extended=True,
                     force_refresh=True,
                 )
+                if not role:
+                    log.error(
+                        {
+                            **log_data,
+                            "message": (
+                                "Unable to retrieve role. Won't attempt to make cross-account policy."
+                            ),
+                        }
+                    )
+                    return
                 old_policy = role.assume_role_policy_document
 
         old_policy_sha256 = sha256(


### PR DESCRIPTION
This PR handles an edge case where we may attempt to create a cross-account resource policy for a role that no longer exists