### PR TITLE
chore: Fix paste bug in Self Service IAM Wizard

### DIFF
--- a/consoleme/handlers/v2/typeahead.py
+++ b/consoleme/handlers/v2/typeahead.py
@@ -151,8 +151,15 @@ class SelfServiceStep1ResourceTypeahead(BaseAPIV2Handler):
                 matching.append(entry)
                 continue
             if (
-                entry.get("resource_identifier")
-                and type_ahead.lower() in entry["resource_identifier"].lower()
+                entry.get("principal", {}).get("resource_identifier")
+                and type_ahead.lower()
+                in entry["principal"]["resource_identifier"].lower()
+            ):
+                matching.append(entry)
+                continue
+            if (
+                entry.get("principal", {}).get("principal_arn")
+                and type_ahead.lower() in entry["principal"]["principal_arn"].lower()
             ):
                 matching.append(entry)
                 continue


### PR DESCRIPTION
This PR improves the self-service typeahead by making it compatible with our newer Aws Principal Model. We also remove complexity from the frontend search typeahead. it will no longer try to match an ARN regex and fetch a role directly. Instead, if a user pastes in a query, it will make the backend do the heavy lifting to identify and return valid principals regardless of whether it matches an arn regex.

Addresses #9200