### PR TITLE
Quicker dynamic configuration refresh in Celery worker child processes

### DIFF
--- a/consoleme/celery_tasks/celery_tasks.py
+++ b/consoleme/celery_tasks/celery_tasks.py
@@ -242,30 +242,8 @@ def get_celery_request_tags(**kwargs):
 @task_prerun.connect
 def refresh_dynamic_config_in_worker(**kwargs):
     tags = get_celery_request_tags(**kwargs)
-    log_data = {"function": f"{__name__}.{sys._getframe().f_code.co_name}"}
-
-    dynamic_config = red.get("DYNAMIC_CONFIG_CACHE")
-    if not dynamic_config:
-        log.warn(
-            {
-                **log_data,
-                "error": (
-                    "Unable to retrieve Dynamic Config from Redis. "
-                    "This can be safely ignored if your dynamic config is empty."
-                ),
-            }
-        )
-        return
-    dynamic_config_j = json.loads(dynamic_config)
-    if config.CONFIG.config.get("dynamic_config", {}) != dynamic_config_j:
-        log.debug(
-            {
-                **log_data,
-                **tags,
-                "message": "Refreshing dynamic configuration on Celery Worker",
-            }
-        )
-        config.CONFIG.config["dynamic_config"] = dynamic_config_j
+    log_data = {"function": f"{__name__}.{sys._getframe().f_code.co_name}", **tags}
+    config.CONFIG.load_dynamic_config_from_redis(log_data, red)
 
 
 @task_received.connect
@@ -2165,7 +2143,6 @@ schedule = {
         "schedule": schedule_minute,
     },
 }
-
 
 if internal_celery_tasks and isinstance(internal_celery_tasks, dict):
     schedule = {**schedule, **internal_celery_tasks}

--- a/consoleme/handlers/v2/dynamic_config.py
+++ b/consoleme/handlers/v2/dynamic_config.py
@@ -6,20 +6,34 @@ import sentry_sdk
 import tornado.escape
 import tornado.web
 
+from consoleme.celery_tasks.celery_tasks import app as celery_app
 from consoleme.config import config
 from consoleme.handlers.base import BaseHandler
 from consoleme.lib.auth import can_edit_dynamic_config
 from consoleme.lib.dynamo import UserDynamoHandler
 from consoleme.lib.json_encoder import SetEncoder
 from consoleme.lib.plugins import get_plugin_by_name
+from consoleme.lib.redis import RedisHandler
 
 ddb = UserDynamoHandler()
 log = config.get_logger()
 stats = get_plugin_by_name(config.get("plugins.metrics", "default_metrics"))()
 aws = get_plugin_by_name(config.get("plugins.aws", "default_aws"))()
+red = RedisHandler().redis_sync()
 
 
 class DynamicConfigApiHandler(BaseHandler):
+    def on_finish(self) -> None:
+        if self.request.method != "POST":
+            return
+        # Force a refresh of credential authorization mapping in current region
+        # TODO: Trigger this to run cross-region
+        # TODO: Delete server-side user-role cache intelligently so users get immediate access
+        celery_app.send_task(
+            "consoleme.celery_tasks.celery_tasks.cache_credential_authorization_mapping",
+            countdown=10,
+        )
+
     async def get(self) -> None:
         """
         Get the dynamic configuration endpoint.
@@ -110,4 +124,7 @@ class DynamicConfigApiHandler(BaseHandler):
         result["newsha56"] = new_sha256
         self.write(result)
         await self.finish()
+        # Force a refresh of dynamic configuration in the current region. Other regions will need to wait until the
+        # next background thread refreshes it automatically. By default, this happens every 60 seconds.
+        config.CONFIG.load_config_from_dynamo(ddb=ddb, red=red)
         return

--- a/consoleme/lib/cloud_credential_authorization_mapping/dynamic_config.py
+++ b/consoleme/lib/cloud_credential_authorization_mapping/dynamic_config.py
@@ -1,3 +1,4 @@
+import sys
 from typing import Dict
 
 from consoleme.config import config
@@ -6,6 +7,9 @@ from consoleme.lib.cloud_credential_authorization_mapping.models import (
     RoleAuthorizations,
     user_or_group,
 )
+from consoleme.lib.redis import RedisHandler
+
+red = RedisHandler().redis_sync()
 
 
 class DynamicConfigAuthorizationMappingGenerator(CredentialAuthzMappingGenerator):
@@ -13,6 +17,11 @@ class DynamicConfigAuthorizationMappingGenerator(CredentialAuthzMappingGenerator
         self, authorization_mapping: Dict[user_or_group, RoleAuthorizations]
     ) -> Dict[user_or_group, RoleAuthorizations]:
         """This will list accounts that meet the account attribute search criteria."""
+        function = f"{__name__}.{sys._getframe().f_code.co_name}"
+        log_data = {
+            "function": function,
+        }
+        config.CONFIG.load_dynamic_config_from_redis(log_data, red)
         group_mapping_configuration = config.get("dynamic_config.group_mapping")
 
         if not group_mapping_configuration:


### PR DESCRIPTION
This PR migrates Celery Worker dynamic refresh capability to config.py. In some cases, child processes executing tasks on a worker may not receive updated dynamic configuration in memory, despite a `task_prerun` that is supposed to keep it updated. Having an updated dynamic configuration is important for generating an updated credential authorization mapping file (let users get access to roles quicker). Therefore, we're forcing a dynamic config refresh in `DynamicConfigAuthorizationMappingGenerator`.

- [X] Migrates core dynamic configuration Redis loading capability from `celery_tasks.refresh_dynamic_config_in_worker` to `config.load_dynamic_config_from_redis`
- [X] Upon dynamic config update via Web UI, Force an immediate refresh of dynamic configuration in current running web host, and update shared Redis cluster with latest version. Also spawn a `cache_credential_authorization_mapping` celery task in the current region
- [X] Force `DynamicConfigAuthorizationMappingGenerator` to always check for new dynamic configuration in Redis.

Future releases:
* Force cross-region deletion of server-side user "authorized role mapping" cache
* Run `cache_credential_authorization_mapping` across all regions after successful cache update

