### PR TITLE
Ensure all roles are returned by /api/v2/audit/roles

### DIFF
--- a/consoleme/handlers/v2/audit.py
+++ b/consoleme/handlers/v2/audit.py
@@ -13,7 +13,7 @@ stats = get_plugin_by_name(config.get("plugins.metrics", "default_metrics"))()
 credential_mapping = CredentialAuthorizationMapping()
 
 
-def get_last_page(total, page_size):
+def _get_last_page(total, page_size):
     pages = total / page_size
     if not total % page_size:
         pages += 1
@@ -88,7 +88,7 @@ class AuditRolesHandler(BaseMtlsHandler):
                 page=page,
                 total=total_roles,
                 count=len(roles),
-                last_page=get_last_page(total_roles, count),
+                last_page=_get_last_page(total_roles, count),
             ).json(exclude_unset=True)
         )
 

--- a/consoleme/handlers/v2/audit.py
+++ b/consoleme/handlers/v2/audit.py
@@ -13,6 +13,13 @@ stats = get_plugin_by_name(config.get("plugins.metrics", "default_metrics"))()
 credential_mapping = CredentialAuthorizationMapping()
 
 
+def get_last_page(total, page_size):
+    pages = total / page_size
+    if not total % page_size:
+        pages += 1
+    return pages
+
+
 class AuditRolesHandler(BaseMtlsHandler):
     """Handler for /api/v2/audit/roles
 
@@ -28,6 +35,28 @@ class AuditRolesHandler(BaseMtlsHandler):
         """
         GET /api/v2/audit/roles
         """
+        log_data = {
+            "function": f"{__name__}.{self.__class__.__name__}.{sys._getframe().f_code.co_name}",
+            "user-agent": self.request.headers.get("User-Agent"),
+            "request_id": self.request_uuid,
+        }
+
+        page = self.get_argument("page", "0")
+        try:
+            page = int(page)
+        except ValueError:
+            log_data["message"] = f"invalid value for page: {page}"
+            log.warning(log_data)
+            page = 0
+
+        count = self.get_argument("count", "1000")
+        try:
+            count = int(count)
+        except ValueError:
+            log_data["message"] = f"invalid value for count: {count}"
+            log.warning(log_data)
+            count = 100
+
         app_name = self.requester.get("name") or self.requester.get("username")
         stats.count(
             "AuditRoleHandler.get",
@@ -36,12 +65,26 @@ class AuditRolesHandler(BaseMtlsHandler):
             },
         )
 
-        roles = await credential_mapping.all_roles()
+        roles = await credential_mapping.all_roles(
+            paginate=True, page=page, count=count
+        )
+        total_roles = await credential_mapping.number_roles()
+        start = page * count
+        end = start + count
+        if end >= total_roles:
+            end = total_roles - 1
+        roles = roles[start:end]
 
         self.write(
-            WebResponse(status=Status2.success, status_code=200, data=roles).json(
-                exclude_unset=True
-            )
+            WebResponse(
+                status=Status2.success,
+                status_code=200,
+                data=roles,
+                page=page,
+                total=total_roles,
+                count=len(roles),
+                last_page=get_last_page(total_roles, count),
+            ).json(exclude_unset=True)
         )
 
 

--- a/consoleme/handlers/v2/audit.py
+++ b/consoleme/handlers/v2/audit.py
@@ -13,8 +13,8 @@ stats = get_plugin_by_name(config.get("plugins.metrics", "default_metrics"))()
 credential_mapping = CredentialAuthorizationMapping()
 
 
-def _get_last_page(total, page_size):
-    pages = total / page_size
+def _get_last_page(total: int, page_size: int) -> int:
+    pages = int(total / page_size)
     if not total % page_size:
         pages += 1
     return pages

--- a/consoleme/handlers/v2/audit.py
+++ b/consoleme/handlers/v2/audit.py
@@ -55,7 +55,12 @@ class AuditRolesHandler(BaseMtlsHandler):
         except ValueError:
             log_data["message"] = f"invalid value for count: {count}"
             log.warning(log_data)
-            count = 100
+            count = 1000
+
+        if page < 0:
+            page = 0
+        if count < 0:
+            count = 1000
 
         app_name = self.requester.get("name") or self.requester.get("username")
         stats.count(

--- a/consoleme/handlers/v2/user.py
+++ b/consoleme/handlers/v2/user.py
@@ -116,7 +116,7 @@ class UserRegistrationHandler(TornadoRequestHandler):
             status_code=200,
             message=f"Successfully created user {registration_attempt.username}.",
         )
-        self.write(res.json())
+        self.write(res.json(exclude_unset=True))
 
 
 class LoginConfigurationHandler(TornadoRequestHandler):
@@ -224,7 +224,7 @@ class LoginHandler(TornadoRequestHandler):
             reason="authenticated_redirect",
             message="User has successfully authenticated. Redirecting to their intended destination.",
         )
-        self.write(res.json())
+        self.write(res.json(exclude_unset=True))
 
 
 class UserManagementHandler(BaseAPIV2Handler):
@@ -288,7 +288,7 @@ class UserManagementHandler(BaseAPIV2Handler):
                 status_code=200,
                 message=f"Successfully created user {request.username}.",
             )
-            self.write(res.json())
+            self.write(res.json(exclude_unset=True))
             return
         elif request.user_management_action.value == "update":
             log.debug(
@@ -325,7 +325,7 @@ class UserManagementHandler(BaseAPIV2Handler):
                 status_code=200,
                 message=f"Successfully updated user {request.username}.",
             )
-            self.write(res.json())
+            self.write(res.json(exclude_unset=True))
             return
         elif request.user_management_action.value == "delete":
             log.debug(
@@ -343,7 +343,7 @@ class UserManagementHandler(BaseAPIV2Handler):
                 status_code=200,
                 message=f"Successfully deleted user {request.username}.",
             )
-            self.write(res.json())
+            self.write(res.json(exclude_unset=True))
             return
         else:
             errors = ["Change type is not supported by this endpoint."]

--- a/consoleme/handlers/v2/user.py
+++ b/consoleme/handlers/v2/user.py
@@ -116,7 +116,7 @@ class UserRegistrationHandler(TornadoRequestHandler):
             status_code=200,
             message=f"Successfully created user {registration_attempt.username}.",
         )
-        self.write(res.json(exclude_unset=True))
+        self.write(res.json(exclude_unset=True, exclude_none=True))
 
 
 class LoginConfigurationHandler(TornadoRequestHandler):
@@ -224,7 +224,7 @@ class LoginHandler(TornadoRequestHandler):
             reason="authenticated_redirect",
             message="User has successfully authenticated. Redirecting to their intended destination.",
         )
-        self.write(res.json(exclude_unset=True))
+        self.write(res.json(exclude_unset=True, exclude_none=True))
 
 
 class UserManagementHandler(BaseAPIV2Handler):
@@ -288,7 +288,7 @@ class UserManagementHandler(BaseAPIV2Handler):
                 status_code=200,
                 message=f"Successfully created user {request.username}.",
             )
-            self.write(res.json(exclude_unset=True))
+            self.write(res.json(exclude_unset=True, exclude_none=True))
             return
         elif request.user_management_action.value == "update":
             log.debug(
@@ -325,7 +325,7 @@ class UserManagementHandler(BaseAPIV2Handler):
                 status_code=200,
                 message=f"Successfully updated user {request.username}.",
             )
-            self.write(res.json(exclude_unset=True))
+            self.write(res.json(exclude_unset=True, exclude_none=True))
             return
         elif request.user_management_action.value == "delete":
             log.debug(
@@ -343,7 +343,7 @@ class UserManagementHandler(BaseAPIV2Handler):
                 status_code=200,
                 message=f"Successfully deleted user {request.username}.",
             )
-            self.write(res.json(exclude_unset=True))
+            self.write(res.json(exclude_unset=True, exclude_none=True))
             return
         else:
             errors = ["Change type is not supported by this endpoint."]

--- a/consoleme/handlers/v2/user.py
+++ b/consoleme/handlers/v2/user.py
@@ -116,7 +116,7 @@ class UserRegistrationHandler(TornadoRequestHandler):
             status_code=200,
             message=f"Successfully created user {registration_attempt.username}.",
         )
-        self.write(res.json(exclude_unset=True, exclude_none=True))
+        self.write(res.json(exclude_unset=True))
 
 
 class LoginConfigurationHandler(TornadoRequestHandler):

--- a/consoleme/lib/cloud_credential_authorization_mapping/__init__.py
+++ b/consoleme/lib/cloud_credential_authorization_mapping/__init__.py
@@ -33,6 +33,8 @@ log = config.get_logger("consoleme")
 class CredentialAuthorizationMapping(metaclass=Singleton):
     def __init__(self) -> None:
         self._all_roles = []
+        self._all_roles_count = 0
+        self._all_roles_last_update = 0
         self.authorization_mapping = {}
         self.authorization_mapping_last_update = 0
         self.reverse_mapping = {}
@@ -132,12 +134,47 @@ class CredentialAuthorizationMapping(metaclass=Singleton):
                 return {}
         return self.reverse_mapping
 
-    async def all_roles(self):
-        if self._all_roles:
-            return self._all_roles
-        reverse_mapping = await self.retrieve_reverse_authorization_mapping()
-        self._all_roles = list(reverse_mapping.keys())
+    async def retrieve_all_roles(self, max_age: Optional[int] = None):
+        if not self._all_roles or int(time.time()) - self._all_roles_last_update > 600:
+            redis_topic = config.get("aws.iamroles_redis_key", "IAM_ROLE_CACHE")
+            s3_bucket = config.get(
+                "cache_iam_resources_across_accounts.all_roles_combined.s3.bucket"
+            )
+            s3_key = config.get(
+                "cache_iam_resources_across_accounts.all_roles_combined.s3.file",
+                "account_resource_cache/cache_all_roles_v1.json.gz",
+            )
+            try:
+                all_roles = await retrieve_json_data_from_redis_or_s3(
+                    redis_topic,
+                    s3_bucket=s3_bucket,
+                    s3_key=s3_key,
+                    json_object_hook=RoleAuthorizationsDecoder,
+                    json_encoder=pydantic_encoder,
+                    max_age=max_age,
+                )
+            except Exception as e:
+                sentry_sdk.capture_exception()
+                log.error(
+                    {
+                        "function": f"{self.__class__.__name__}.{sys._getframe().f_code.co_name}",
+                        "error": f"Error loading IAM roles. Returning empty list: {e}",
+                    },
+                    exc_info=True,
+                )
+                return []
+            self._all_roles = list(all_roles.keys())
+            self._all_roles_count = len(self._all_roles)
+            self._all_roles_last_update = int(time.time())
         return self._all_roles
+
+    async def all_roles(self, paginate=False, page=None, count=None):
+        all_roles = await self.retrieve_all_roles()
+        return all_roles
+
+    async def number_roles(self) -> int:
+        _ = await self.retrieve_all_roles()
+        return self._all_roles_count
 
     async def determine_role_authorized_groups(self, account_id: str, role_name: str):
         arn = f"arn:aws:iam::{account_id}:role/{role_name.lower()}"

--- a/consoleme/lib/web.py
+++ b/consoleme/lib/web.py
@@ -33,6 +33,6 @@ async def handle_generic_error_response(
         status="error", status_code=status_code, errors=errors, reason=reason
     )
     request.set_status(status_code)
-    request.write(res.json())
+    request.write(res.json(exclude_unset=True))
     await request.finish()
     return True

--- a/consoleme/models.py
+++ b/consoleme/models.py
@@ -504,6 +504,10 @@ class WebResponse(BaseModel):
     status_code: Optional[int] = None
     message: Optional[str] = None
     errors: Optional[List[str]] = None
+    count: Optional[int] = None
+    total: Optional[int] = None
+    page: Optional[int] = None
+    last_page: Optional[int] = None
     data: Optional[Union[Dict[str, Any], List]] = None
 
 

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -167,7 +167,7 @@ paths:
                 $ref: "#/components/schemas/CreateCloneRequestResponse"
         default:
           $ref: "#/components/responses/DefaultErrorResponse"
-  /managed_policies_on_role/{accountNumber}/{roleName}:
+  /managed_policies_on_role/{account_id}/{role_name}:
     get:
       summary: get details about managed policies attached to a role
       tags:
@@ -182,7 +182,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/WebResponse"
-  /service_control_policies/{accountNumberOrOuId}:
+  /service_control_policies/{account_or_ou_id}:
     get:
       summary: get details about service control policies targeting an account or organizational unit
       tags:
@@ -403,6 +403,9 @@ paths:
       summary: retrieve a list of IAM roles
       tags:
         - audit
+      parameters:
+        - $ref: "#/components/parameters/PageQueryString"
+        - $ref: "#/components/parameters/CountQueryString"
       responses:
         "200":
           description: OK
@@ -493,6 +496,18 @@ components:
       name: limit
       in: query
       example: 20
+      schema:
+        type: integer
+    PageQueryString:
+      name: page
+      in: query
+      example: 0
+      schema:
+        type: integer
+    CountQueryString:
+      name: count
+      in: query
+      example: 1000
       schema:
         type: integer
   schemas:

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -1824,6 +1824,14 @@ components:
           type: array
           items:
             type: string
+        count:
+          type: integer
+        total:
+          type: integer
+        page:
+          type: integer
+        last_page:
+          type: integer
         data:
           oneOf:
             - type: object

--- a/tests/handlers/v2/test_user.py
+++ b/tests/handlers/v2/test_user.py
@@ -34,13 +34,10 @@ class TestUserRegistrationApi(AsyncHTTPTestCase):
             {
                 "status": "error",
                 "reason": "invalid_request",
-                "redirect_url": None,
                 "status_code": 403,
-                "message": None,
                 "errors": [
                     "The email address is not valid. It must have exactly one @-sign."
                 ],
-                "data": None,
             },
         )
 
@@ -56,12 +53,8 @@ class TestUserRegistrationApi(AsyncHTTPTestCase):
             json.loads(response.body),
             {
                 "status": "success",
-                "reason": None,
-                "redirect_url": None,
                 "status_code": 200,
                 "message": "Successfully created user testuser5@example.com.",
-                "errors": None,
-                "data": None,
             },
         )
 
@@ -93,14 +86,11 @@ class TestLoginApi(AsyncHTTPTestCase):
             {
                 "status": "error",
                 "reason": "authentication_failure",
-                "redirect_url": None,
                 "status_code": 403,
-                "message": None,
                 "errors": [
                     "User doesn't exist, or password is incorrect. ",
                     "Your next authentication failure will result in a 1 second wait. This wait time will expire after 60 seconds of no authentication failures.",
                 ],
-                "data": None,
             },
         )
 
@@ -119,14 +109,11 @@ class TestLoginApi(AsyncHTTPTestCase):
             {
                 "status": "error",
                 "reason": "authentication_failure",
-                "redirect_url": None,
                 "status_code": 403,
-                "message": None,
                 "errors": [
                     "User doesn't exist, or password is incorrect. ",
                     "Your next authentication failure will result in a 1 second wait. This wait time will expire after 60 seconds of no authentication failures.",
                 ],
-                "data": None,
             },
         )
 
@@ -154,8 +141,6 @@ class TestLoginApi(AsyncHTTPTestCase):
                 "redirect_url": "/",
                 "status_code": 200,
                 "message": "User has successfully authenticated. Redirecting to their intended destination.",
-                "errors": None,
-                "data": None,
             },
         )
 
@@ -188,12 +173,8 @@ class TestUserApi(AsyncHTTPTestCase):
             json.loads(response.body),
             {
                 "status": "success",
-                "reason": None,
-                "redirect_url": None,
                 "status_code": 200,
                 "message": "Successfully created user testuser3.",
-                "errors": None,
-                "data": None,
             },
         )
 
@@ -231,8 +212,8 @@ class TestUserApi(AsyncHTTPTestCase):
                     "Your next authentication failure will result in a 1 second wait. "
                     "This wait time will expire after 60 seconds of no authentication failures.",
                 ],
-                "username": None,
                 "groups": None,
+                "username": None,
             },
         )
 
@@ -250,12 +231,8 @@ class TestUserApi(AsyncHTTPTestCase):
             json.loads(response.body),
             {
                 "status": "success",
-                "reason": None,
-                "redirect_url": None,
                 "status_code": 200,
                 "message": "Successfully updated user testuser3.",
-                "errors": None,
-                "data": None,
             },
         )
 
@@ -273,12 +250,8 @@ class TestUserApi(AsyncHTTPTestCase):
             json.loads(response.body),
             {
                 "status": "success",
-                "reason": None,
-                "redirect_url": None,
                 "status_code": 200,
                 "message": "Successfully updated user testuser3.",
-                "errors": None,
-                "data": None,
             },
         )
         # Update groups and password AT THE SAME TIME!!1
@@ -296,12 +269,8 @@ class TestUserApi(AsyncHTTPTestCase):
             json.loads(response.body),
             {
                 "status": "success",
-                "reason": None,
-                "redirect_url": None,
                 "status_code": 200,
                 "message": "Successfully updated user testuser3.",
-                "errors": None,
-                "data": None,
             },
         )
 
@@ -320,11 +289,7 @@ class TestUserApi(AsyncHTTPTestCase):
             json.loads(response.body),
             {
                 "status": "success",
-                "reason": None,
-                "redirect_url": None,
                 "status_code": 200,
                 "message": "Successfully deleted user testuser3.",
-                "errors": None,
-                "data": None,
             },
         )


### PR DESCRIPTION
This PR gets a comprehensive list of roles from `cache_iam_resources_across_accounts` as opposed to using roles available in the credential mapping. However, this is still handled by the `CredentialAuthorizationMapping` singleton.

Since the list of roles can be quite large, I also added some optional fields to the WebResponse model to support pagination. The updated endpoint has pagination implemented in-line, but this could be moved to the base handler(s) if it's useful for other endpoints.