### PR TITLE
Fix division by zero exception

### DIFF
--- a/consoleme/handlers/v2/audit.py
+++ b/consoleme/handlers/v2/audit.py
@@ -59,7 +59,7 @@ class AuditRolesHandler(BaseMtlsHandler):
 
         if page < 0:
             page = 0
-        if count < 0:
+        if count <= 0:
             count = 1000
 
         app_name = self.requester.get("name") or self.requester.get("username")


### PR DESCRIPTION
If count = 0, this causes a division by zero exception. This PR fixes https://demo.consolemeoss.com/api/v2/audit/roles?count=0.