### PR TITLE
Allow end-users to override the default AWS region they are logged in to

### DIFF
--- a/consoleme/lib/v2/notifications.py
+++ b/consoleme/lib/v2/notifications.py
@@ -43,6 +43,7 @@ class RetrieveNotifications(metaclass=Singleton):
                 s3_key=config.get(
                     "notifications.s3.key", "notifications/all_notifications_v1.json.gz"
                 ),
+                default={},
             )
             self.last_update = int(time.time())
         return self.all_notifications

--- a/ui/src/components/ConsoleLogin.js
+++ b/ui/src/components/ConsoleLogin.js
@@ -1,7 +1,11 @@
 import React, { useCallback, useEffect, useState } from "react";
 import { useParams, useLocation } from "react-router-dom";
 import { Icon, Message } from "semantic-ui-react";
-import { delay, setRecentRoles } from "../helpers/utils";
+import {
+  delay,
+  getLocalStorageSettings,
+  setRecentRoles,
+} from "../helpers/utils";
 import { useAuth } from "../auth/AuthProviderDefault";
 
 const signOutUrl = "https://signin.aws.amazon.com/oauth?Action=logout";
@@ -11,11 +15,18 @@ const ConsoleLogin = () => {
   const { roleQuery } = useParams();
   const [errorMessage, setErrorMessage] = useState("");
   const { sendRequestCommon } = useAuth();
+  const userDefaultAwsRegionSetting = getLocalStorageSettings(
+    "defaultAwsConsoleRegion"
+  );
 
   const onSignIn = useCallback(async () => {
+    let extraArgs = "";
+    if (userDefaultAwsRegionSetting && !search) {
+      extraArgs = "?r=" + userDefaultAwsRegionSetting;
+    }
     const roleData = await sendRequestCommon(
       null,
-      "/api/v2/role_login/" + roleQuery + search,
+      "/api/v2/role_login/" + roleQuery + search + extraArgs,
       "get"
     );
 
@@ -31,7 +42,7 @@ const ConsoleLogin = () => {
     }
 
     setErrorMessage(roleData.message);
-  }, [roleQuery, search, sendRequestCommon]);
+  }, [roleQuery, search, sendRequestCommon, userDefaultAwsRegionSetting]);
 
   useEffect(() => {
     (async () => {

--- a/ui/src/components/SettingsModal.js
+++ b/ui/src/components/SettingsModal.js
@@ -1,5 +1,12 @@
 import React, { useState } from "react";
-import { Button, Modal, Dropdown, Grid, Message } from "semantic-ui-react";
+import {
+  Button,
+  Modal,
+  Dropdown,
+  Grid,
+  Message,
+  Input,
+} from "semantic-ui-react";
 import {
   editor_themes,
   getLocalStorageSettings,
@@ -29,6 +36,13 @@ const SettingsModal = (props) => {
     setCurrentSettings(oldSettings);
   };
 
+  const updateDefaultAwsConsoleRegion = (e, data) => {
+    const oldSettings = currentSettings;
+    oldSettings.defaultAwsConsoleRegion = data.value;
+    setMessages([]);
+    setCurrentSettings(oldSettings);
+  };
+
   const editorThemeSettings = () => {
     return (
       <Grid verticalAlign="middle">
@@ -44,6 +58,20 @@ const SettingsModal = (props) => {
               onChange={updateEditorTheme}
               defaultValue={currentSettings.editorTheme}
               options={editor_themes}
+            />
+          </Grid.Column>
+        </Grid.Row>
+        <Grid.Row>
+          <Grid.Column width={4} floated="left">
+            Default AWS Console Region
+          </Grid.Column>
+          <Grid.Column width={8}>
+            <Input
+              fluid
+              placeholder="Default AWS Console Region"
+              selection
+              onChange={updateDefaultAwsConsoleRegion}
+              defaultValue={currentSettings.defaultAwsConsoleRegion}
             />
           </Grid.Column>
         </Grid.Row>


### PR DESCRIPTION
This PR allows users to specify an additional configuration setting for the AWS region that they would like to be logged in to.

First, load your settings:

![2021-09-09_21-36](https://user-images.githubusercontent.com/7538233/132800453-46072bc7-402c-4990-9d3e-3ecf7c12c079.png)

Second, change your default region to one of your choosing:

![2021-09-09_21-38](https://user-images.githubusercontent.com/7538233/132800500-c9f6be1c-bc16-46fc-8fb7-f13a01282c9c.png)
