### PR TITLE
Allow role to be selected through app name

### DIFF
--- a/consoleme/lib/account_indexers/__init__.py
+++ b/consoleme/lib/account_indexers/__init__.py
@@ -85,6 +85,9 @@ async def get_cloud_account_model_array(
     for account in all_accounts.accounts:
         if status and account.status.value != status:
             continue
+        if environment and not account.environment:
+            # if we are looking to filter on environment, and account doesn't contain environment information
+            continue
         if environment and account.environment.value != environment:
             continue
         filtered_accounts.accounts.append(account)

--- a/default_plugins/consoleme_default_plugins/plugins/policies/policies.py
+++ b/default_plugins/consoleme_default_plugins/plugins/policies/policies.py
@@ -1,8 +1,10 @@
+from typing import List
+
 import sentry_sdk
 
 from consoleme.config import config
 from consoleme.lib.dynamo import UserDynamoHandler
-from consoleme.models import AppDetailsArray, AppDetailsModel
+from consoleme.models import AppDetailsArray, AppDetailsModel, AwsPrincipalModel
 
 
 class Policies:
@@ -45,6 +47,19 @@ class Policies:
                 )
             )
         return AppDetailsArray(app_details=apps_formatted)
+
+    async def get_roles_associated_with_app(
+        self, app_name: str
+    ) -> List[AwsPrincipalModel]:
+        """
+        This function returns roles associated with an app from configuration. You may want to override this
+        function to pull this information from an authoritative source.
+
+        :param app_name: Name of application
+        :return: List[AwsPrincipalModel]
+        """
+
+        return []
 
 
 def init():


### PR DESCRIPTION
Allows the user to request a role by specifying an app name. 
If an account name / number is specified, then it's used directly. If no account information is present, we will attempt to find an account designated as a "test" account. If multiple test accounts are present, or no test accounts are present, then it's an error.