### PR TITLE
refactor: only redirect to landing_url if current pathname is `/`

### DIFF
--- a/ui/src/auth/AuthProviderDefault.js
+++ b/ui/src/auth/AuthProviderDefault.js
@@ -81,7 +81,7 @@ export const AuthProvider = ({ children }) => {
       });
 
       // Cloud administrators can override the initial landing URL for users by providing a configuration on the backend
-      if (user?.site_config?.landing_url) {
+      if (user?.site_config?.landing_url && window.location.pathname === "/") {
         history.push(user.site_config.landing_url);
       }
     } catch (error) {


### PR DESCRIPTION
Fix the issued I mentioned earlier on discord. Should stop redirecting to `landing_url` when clicking on a notification link.