### PR TITLE
Turn off cloudtrail denies celery task, unless specified by config

### DIFF
--- a/consoleme/celery_tasks/celery_tasks.py
+++ b/consoleme/celery_tasks/celery_tasks.py
@@ -2180,11 +2180,6 @@ schedule = {
         "options": {"expires": 300},
         "schedule": schedule_24_hours,
     },
-    "cache_cloudtrail_errors_by_arn": {
-        "task": "consoleme.celery_tasks.celery_tasks.cache_cloudtrail_errors_by_arn",
-        "options": {"expires": 300},
-        "schedule": schedule_1_hour,
-    },
     "cache_resources_from_aws_config_across_accounts": {
         "task": "consoleme.celery_tasks.celery_tasks.cache_resources_from_aws_config_across_accounts",
         "options": {"expires": 300},
@@ -2239,6 +2234,11 @@ if config.get("celery.cache_cloudtrail_denies.enabled"):
         "task": "consoleme.celery_tasks.celery_tasks.cache_cloudtrail_denies",
         "options": {"expires": 300},
         "schedule": schedule_minute,
+    }
+    schedule["cache_cloudtrail_errors_by_arn"] = {
+        "task": "consoleme.celery_tasks.celery_tasks.cache_cloudtrail_errors_by_arn",
+        "options": {"expires": 300},
+        "schedule": schedule_1_hour,
     }
 
 


### PR DESCRIPTION
The task `cache_cloudtrail_errors_by_arn` relies on the caching done by `cache_cloudtrail_denies`. So, only run `cache_cloudtrail_errors_by_arn` if `cache_cloudtrail_denies` is going to be running as well