### PR TITLE
make group extraction handle string

### DIFF
--- a/consoleme/lib/alb_auth.py
+++ b/consoleme/lib/alb_auth.py
@@ -146,6 +146,10 @@ async def authenticate_user_by_alb_auth(request):
             groups = token.get(
                 config.get("get_user_by_aws_alb_auth_settings.jwt_groups_key", "groups")
             )
+            
+            if isinstance(groups, str):
+                groups = [groups]
+            
             if groups:
                 break
 


### PR DESCRIPTION
currently some IDP providers pass group membership information as a string instead of a list but the alb_auth code here will only accepts a list.