### PR TITLE
Improve CDK spoke account handling

### DIFF
--- a/cdk/README.md
+++ b/cdk/README.md
@@ -80,6 +80,8 @@ password for the `jwt_secret` key. You can use the following command to generate
   $ cdk bootstrap --cloudformation-execution-policies arn:aws:iam::aws:policy/AdministratorAccess
   ```
 
+  The CDK will attempt to bootstrap the main account and all spoke accounts: re-run the bootstrap for each account required with appropriate credentials.
+
 ### Preparing the CDK Environment
 
 At this point you can now synthesize the CloudFormation template for this code.
@@ -104,10 +106,10 @@ $ cdk deploy ConsoleMeECS
 ```
 
 Then, deploy the trust role to the spoke accounts.
-While logged in to each spoke account, deploy `ConsoleMeSpoke` stack:
+While logged in to each spoke account, deploy required `ConsoleMeSpoke-${SPOKE_ACCOUNT_ID}` stacks:
 
 ```
-$ cdk deploy ConsoleMeSpoke
+$ cdk deploy "ConsoleMeSpoke-${SPOKE_ACCOUNT_ID}"
 ```
 
 Don't forget to approve the template and security resources before the deployment.

--- a/cdk/app.py
+++ b/cdk/app.py
@@ -34,7 +34,7 @@ for spoke_account_id in spoke_accounts:
         account=spoke_account_id, region=os.getenv("AWS_REGION")
     )
     spoke_stack = ConsolemeSpokeAccountsStack(
-        app, SPOKE_BASE_NAME, env=spoke_environment
+        app, f"{SPOKE_BASE_NAME}-{spoke_account_id}", env=spoke_environment
     )  # Spoke account stack
 
 consoleme_ecs_service_stack = ConsolemeEcsServiceStack(


### PR DESCRIPTION
Fix #9248 - handle more than one "spoke" account in CDK. Added to documentation.

Reduced deployed IAM role permissions for safety: removed iam:* and other write-enabling permissions.