### PR TITLE
Fix self-service "Other Services" not expanding

### DIFF
--- a/consoleme/lib/change_request.py
+++ b/consoleme/lib/change_request.py
@@ -319,9 +319,12 @@ async def _generate_inline_iam_policy_statement_from_change_generator(
     :param change: ChangeGeneratorModel
     :return: policy_statement: A dictionary representing an inline policy statement.
     """
-    if change.generator_type == "s3":
+    generator_type = change.generator_type
+    if not isinstance(generator_type, str):
+        generator_type = change.generator_type.value
+    if generator_type == "s3":
         policy = await _generate_s3_inline_policy_statement_from_mapping(change)
-    elif change.generator_type == "crud_lookup":
+    elif generator_type == "crud_lookup":
         policy = await _generate_inline_policy_statement_from_policy_sentry(change)
     else:
         policy = await _generate_inline_policy_statement_from_mapping(change)

--- a/consoleme/lib/defaults.py
+++ b/consoleme/lib/defaults.py
@@ -208,7 +208,7 @@ permissions_map:
       permissions you need, use "Advanced Mode" from the dropdown instead.
     inputs:
       - name: service_name
-        type: typeahead_input
+        type: single_typeahead_input
         text: Service (s3, sqs, sns, rekognition, etc)
         required: true
         typeahead_endpoint: /api/v1/policyuniverse/autocomplete/?only_filter_services=true&prefix={query}

--- a/tests/handlers/v2/test_generate_changes.py
+++ b/tests/handlers/v2/test_generate_changes.py
@@ -89,7 +89,7 @@ class TestGenerateChangesHandler(AsyncHTTPTestCase):
                     "generator_type": "crud_lookup",
                     "resource_arn": "*",
                     "effect": "Allow",
-                    "service": "ssm",
+                    "service_name": "ssm",
                     "action_groups": ["list", "read"],
                 },
             ]
@@ -149,7 +149,7 @@ class TestGenerateChangesHandler(AsyncHTTPTestCase):
                     "generator_type": "crud_lookup",
                     "resource_arn": "*",
                     "effect": "Allow",
-                    "service": "ssm",
+                    "service_name": "ssm",
                     "action_groups": ["list", "read"],
                 },
             ]

--- a/ui/src/components/blocks/SingleTypeaheadBlockComponent.js
+++ b/ui/src/components/blocks/SingleTypeaheadBlockComponent.js
@@ -1,0 +1,90 @@
+import _ from "lodash";
+import React, { Component } from "react";
+import { Form, Search } from "semantic-ui-react";
+
+class SingleTypeaheadBlockComponent extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      isLoading: false,
+      results: [],
+      value: "",
+    };
+  }
+
+  handleResultSelect(e, { result }) {
+    this.setState(
+      {
+        value: result.title,
+      },
+      () => {
+        this.props.handleInputUpdate(result.title);
+      }
+    );
+  }
+
+  handleSearchChange(e, { value }) {
+    const { typeahead } = this.props;
+    this.setState(
+      {
+        isLoading: true,
+        value,
+      },
+      () => {
+        this.props.handleInputUpdate(value);
+      }
+    );
+
+    setTimeout(() => {
+      if (this.state.value.length < 1) {
+        return this.setState(
+          {
+            isLoading: false,
+            results: [],
+            value: "",
+          },
+          () => {
+            this.props.handleInputUpdate("");
+          }
+        );
+      }
+
+      const re = new RegExp(_.escapeRegExp(value), "i");
+      const isMatch = (result) => re.test(result.title);
+
+      const TYPEAHEAD_API = typeahead.replace("{query}", value);
+      this.props
+        .sendRequestCommon(null, TYPEAHEAD_API, "get")
+        .then((source) => {
+          this.setState({
+            isLoading: false,
+            results: _.filter(source, isMatch),
+          });
+        });
+    }, 300);
+  }
+
+  render() {
+    const { isLoading, results, value } = this.state;
+    const { defaultValue, required, label } = this.props;
+
+    return (
+      <Form.Field required={required || false}>
+        <label>{label || "Enter Value"}</label>
+        <Search
+          fluid
+          defaultValue={defaultValue || ""}
+          loading={isLoading}
+          onResultSelect={this.handleResultSelect.bind(this)}
+          onSearchChange={_.debounce(this.handleSearchChange.bind(this), 500, {
+            leading: true,
+          })}
+          results={results}
+          value={value}
+        />
+      </Form.Field>
+    );
+  }
+}
+
+export default SingleTypeaheadBlockComponent;

--- a/ui/src/components/selfservice/SelfServiceComponent.js
+++ b/ui/src/components/selfservice/SelfServiceComponent.js
@@ -13,6 +13,7 @@ import {
 import DropDownBlockComponent from "../blocks/DropDownBlockComponent";
 import TextInputBlockComponent from "../blocks/TextInputBlockComponent";
 import TypeaheadBlockComponent from "../blocks/TypeaheadBlockComponent";
+import SingleTypeaheadBlockComponent from "../blocks/SingleTypeaheadBlockComponent";
 
 class SelfServiceComponent extends Component {
   constructor(props) {
@@ -185,6 +186,17 @@ class SelfServiceComponent extends Component {
                 sendRequestCommon={this.props.sendRequestCommon}
               />
             </>
+          );
+        case "single_typeahead_input":
+          return (
+            <SingleTypeaheadBlockComponent
+              defaultValue={defaultValue + 1}
+              handleInputUpdate={this.handleInputUpdate.bind(this, input.name)}
+              required={input.required || false}
+              typeahead={input.typeahead_endpoint}
+              label={input.text}
+              sendRequestCommon={this.props.sendRequestCommon}
+            />
           );
         default:
           return <div />;


### PR DESCRIPTION
Currently, when users select the "Other Services" option in self-service, the actions aren't being correctly expanded by ConsoleMe. This PR fixes that issue.