### PR TITLE
Detect language updates

### DIFF
--- a/ui/src/components/blocks/MonacoDiffComponent.js
+++ b/ui/src/components/blocks/MonacoDiffComponent.js
@@ -14,6 +14,7 @@ const MonacoDiffComponent = (props) => {
   const onValueChange = props.onValueChange;
   const modifiedEditorRef = useRef();
   const [language, setLanguage] = useState("json");
+  const [languageDetected, setLanguageDetected] = useState(false);
 
   const onChange = (newValue) => {
     onValueChange(newValue);
@@ -32,10 +33,11 @@ const MonacoDiffComponent = (props) => {
   useEffect(
     () => {
       const { newValue } = props;
-      if (!newValue) return;
+      if (!newValue || languageDetected) return;
       setLanguage(getStringFormat(newValue));
+      setLanguageDetected(true);
     },
-    [] // eslint-disable-line
+    [props.newValue] // eslint-disable-line
   );
 
   const editorDidMount = (editor, monaco) => {


### PR DESCRIPTION
Currently, for YAML the newValue doesn't load fast enough in the backend to correctly detect the language. Since this only runs once, it doesn't work as expected and prevents YAML requests from being submitted.
This PR ensures that we run the language detection once after `newValue` has loaded properly.