### PR TITLE
CDK - add the missing pyyaml depdency

### DIFF
--- a/cdk/Pipfile
+++ b/cdk/Pipfile
@@ -8,6 +8,7 @@ pytest = "*"
 
 [packages]
 boto3 = "*"
+pyyaml = "*"
 
 [requires]
 python_version = "3"

--- a/cdk/Pipfile.lock
+++ b/cdk/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "f937cd06a56b4485501ff200f5dc601307045d6679c35af91f286c68f86e5735"
+            "sha256": "d51eb6aaf82f846fc2d5763c43365052f69c0cf9d8d97bce30702d83d65d175b"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -17,23 +17,25 @@
     "default": {
         "boto3": {
             "hashes": [
-                "sha256:a6399df957bfc7944fbd97e9fb0755cba29b1cb135b91d7e43fd298b268ab804",
-                "sha256:ddfe4a78f04cd2d3a7a37d5cdfa07b4889b24296508786969bc968bee6b8b003"
+                "sha256:a03ab82efcbf457c36dab4afc545d0ddb72b5140c9993cffc78bc23b8d8baa40",
+                "sha256:fa686e8e0a0559124aa9f19dcc25e6cc428f18ff11f779bb7346b883b353fdc2"
             ],
-            "version": "==1.18.1"
+            "version": "==1.20.25"
         },
         "botocore": {
             "hashes": [
-                "sha256:200887ce5f3b47d7499b7ded75dc65c4649abdaaddd06cebc118a3a954d6fd73",
-                "sha256:b845220eb580d10f7714798a96e380eb8f94dca89905a41d8a3c35119c757b01"
+                "sha256:98f8a23ca035edfbd8a8028e624eaf08ba22452dd78ad62eeb03fcd0bbd5f58d",
+                "sha256:9eb71d5ee1ea335b3968751346601e923c66a7b324b1dc58e360d14e0d2ac136"
             ],
-            "version": "==1.21.1"
+            "markers": "python_version >= '3.6'",
+            "version": "==1.23.25"
         },
         "jmespath": {
             "hashes": [
                 "sha256:b85d0567b8666149a93172712e68920734333c0ce7e89b78b3e987f71e5ed4f9",
                 "sha256:cdf6525904cc597730141d61b36f2e4b8ecc257c420fa2f4549bac2c2d0cb72f"
             ],
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==0.10.0"
         },
         "python-dateutil": {
@@ -41,13 +43,53 @@
                 "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86",
                 "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.8.2"
+        },
+        "pyyaml": {
+            "hashes": [
+                "sha256:0283c35a6a9fbf047493e3a0ce8d79ef5030852c51e9d911a27badfde0605293",
+                "sha256:055d937d65826939cb044fc8c9b08889e8c743fdc6a32b33e2390f66013e449b",
+                "sha256:07751360502caac1c067a8132d150cf3d61339af5691fe9e87803040dbc5db57",
+                "sha256:0b4624f379dab24d3725ffde76559cff63d9ec94e1736b556dacdfebe5ab6d4b",
+                "sha256:0ce82d761c532fe4ec3f87fc45688bdd3a4c1dc5e0b4a19814b9009a29baefd4",
+                "sha256:1e4747bc279b4f613a09eb64bba2ba602d8a6664c6ce6396a4d0cd413a50ce07",
+                "sha256:213c60cd50106436cc818accf5baa1aba61c0189ff610f64f4a3e8c6726218ba",
+                "sha256:231710d57adfd809ef5d34183b8ed1eeae3f76459c18fb4a0b373ad56bedcdd9",
+                "sha256:277a0ef2981ca40581a47093e9e2d13b3f1fbbeffae064c1d21bfceba2030287",
+                "sha256:2cd5df3de48857ed0544b34e2d40e9fac445930039f3cfe4bcc592a1f836d513",
+                "sha256:40527857252b61eacd1d9af500c3337ba8deb8fc298940291486c465c8b46ec0",
+                "sha256:473f9edb243cb1935ab5a084eb238d842fb8f404ed2193a915d1784b5a6b5fc0",
+                "sha256:48c346915c114f5fdb3ead70312bd042a953a8ce5c7106d5bfb1a5254e47da92",
+                "sha256:50602afada6d6cbfad699b0c7bb50d5ccffa7e46a3d738092afddc1f9758427f",
+                "sha256:68fb519c14306fec9720a2a5b45bc9f0c8d1b9c72adf45c37baedfcd949c35a2",
+                "sha256:77f396e6ef4c73fdc33a9157446466f1cff553d979bd00ecb64385760c6babdc",
+                "sha256:819b3830a1543db06c4d4b865e70ded25be52a2e0631ccd2f6a47a2822f2fd7c",
+                "sha256:897b80890765f037df3403d22bab41627ca8811ae55e9a722fd0392850ec4d86",
+                "sha256:98c4d36e99714e55cfbaaee6dd5badbc9a1ec339ebfc3b1f52e293aee6bb71a4",
+                "sha256:9df7ed3b3d2e0ecfe09e14741b857df43adb5a3ddadc919a2d94fbdf78fea53c",
+                "sha256:9fa600030013c4de8165339db93d182b9431076eb98eb40ee068700c9c813e34",
+                "sha256:a80a78046a72361de73f8f395f1f1e49f956c6be882eed58505a15f3e430962b",
+                "sha256:b3d267842bf12586ba6c734f89d1f5b871df0273157918b0ccefa29deb05c21c",
+                "sha256:b5b9eccad747aabaaffbc6064800670f0c297e52c12754eb1d976c57e4f74dcb",
+                "sha256:c5687b8d43cf58545ade1fe3e055f70eac7a5a1a0bf42824308d868289a95737",
+                "sha256:cba8c411ef271aa037d7357a2bc8f9ee8b58b9965831d9e51baf703280dc73d3",
+                "sha256:d15a181d1ecd0d4270dc32edb46f7cb7733c7c508857278d3d378d14d606db2d",
+                "sha256:d4db7c7aef085872ef65a8fd7d6d09a14ae91f691dec3e87ee5ee0539d516f53",
+                "sha256:d4eccecf9adf6fbcc6861a38015c2a64f38b9d94838ac1810a9023a0609e1b78",
+                "sha256:d67d839ede4ed1b28a4e8909735fc992a923cdb84e618544973d7dfc71540803",
+                "sha256:daf496c58a8c52083df09b80c860005194014c3698698d1a57cbcfa182142a3a",
+                "sha256:e61ceaab6f49fb8bdfaa0f92c4b57bcfbea54c09277b1b4f7ac376bfb7a7c174",
+                "sha256:f84fbc98b019fef2ee9a1cb3ce93e3187a6df0b2538a651bfb890254ba9f90b5"
+            ],
+            "version": "==6.0"
         },
         "s3transfer": {
             "hashes": [
                 "sha256:50ed823e1dc5868ad40c8dc92072f757aa0e653a192845c94a3b676f4a62da4c",
                 "sha256:9c1dc369814391a6bda20ebbf4b70a0f34630592c9aa520856bf384916af2803"
             ],
+            "markers": "python_version >= '3.6'",
             "version": "==0.5.0"
         },
         "six": {
@@ -55,442 +97,509 @@
                 "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
                 "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.16.0"
         },
         "urllib3": {
             "hashes": [
-                "sha256:39fb8672126159acb139a7718dd10806104dec1e2f0f6c88aab05d17df10c8d4",
-                "sha256:f57b4c16c62fa2760b7e3d97c35b255512fb6b59a259730f36ba32ce9f8e342f"
+                "sha256:4987c65554f7a2dbf30c18fd48778ef124af6fab771a377103da0585e2336ece",
+                "sha256:c4fdf4019605b6e5423637e01bc9fe4daef873709a7973e195ceba0a62bbc844"
             ],
-            "version": "==1.26.6"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
+            "version": "==1.26.7"
         }
     },
     "develop": {
         "attrs": {
             "hashes": [
-                "sha256:31b2eced602aa8423c2aea9c76a724617ed67cf9513173fd3a4f03e3a929c7e6",
-                "sha256:832aa3cde19744e49938b91fea06d69ecb9e649c93ba974535d08ad92164f700"
+                "sha256:149e90d6d8ac20db7a955ad60cf0e6881a3f20d37096140088356da6c716b0b1",
+                "sha256:ef6aaac3ca6cd92904cdd0d83f629a15f18053ec84e6432106f7a4d04ae4f5fb"
             ],
-            "version": "==20.3.0"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==21.2.0"
         },
         "aws-cdk.assets": {
             "hashes": [
-                "sha256:17fad128ab390604ae7527ea98571d06590119941f5b0b45167f8a9231e421e6",
-                "sha256:193130f4962c23b896f5ccb6846baf6090a095d0a2d0b79e1ba9325a9d1ef1c2"
+                "sha256:13bf0cfc42d4d753b7369ddfbaf9bcfb5036f179e8f4e64508717cf74edd7227",
+                "sha256:57cd7852e6b740d08c7607693fde47b034aeef92d4426aba2f2910c08cf94b39"
             ],
-            "version": "==1.114.0"
+            "markers": "python_version >= '3.6'",
+            "version": "==1.136.0"
+        },
+        "aws-cdk.aws-acmpca": {
+            "hashes": [
+                "sha256:0476932c51e3cf1f6bcc9686dbd96719eec2aa732088403122227d8e122adaa3",
+                "sha256:82153ff523f578a2038c258f01244768b012f23d8a5f376f164dc8aa8cf80922"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==1.136.0"
         },
         "aws-cdk.aws-apigateway": {
             "hashes": [
-                "sha256:306bf406bc8e91c033e61af8d251ad09bf48c130638e187b014543837c239abf",
-                "sha256:6a840c14844f606cf08e6f2bdf3d5c27e8541bbd07935c732718353412116a45"
+                "sha256:07d188b0fd4ec9ce230209f45238e39f53f5fb89b3f681f160215adde06bff7d",
+                "sha256:6f72ea0b8eec2440672e3c9f8db42a12a0a5e5fb51f8db40a886c26c5a5fc1b9"
             ],
-            "version": "==1.114.0"
+            "markers": "python_version >= '3.6'",
+            "version": "==1.136.0"
         },
         "aws-cdk.aws-applicationautoscaling": {
             "hashes": [
-                "sha256:20ff9e22c5e2e7d1bd850ed1d53cc3228816fd9a6aa6b067155017eeac7d0eae",
-                "sha256:40c2cd1e2c37bf6b548e3444659cffa55408d586b00e38eaaff4669858077ddd"
+                "sha256:2c8396b7232fe1fb61bb28520c1a05ac37f7f4a3035c30b6ae8012b6d5d22bfc",
+                "sha256:45ba786f12c4bfb9c82b932ab743a3a158521436fed55ed9070b0678a14473ac"
             ],
-            "version": "==1.114.0"
+            "markers": "python_version >= '3.6'",
+            "version": "==1.136.0"
         },
         "aws-cdk.aws-autoscaling": {
             "hashes": [
-                "sha256:92333caebc5bb27a9454f6383c14d5444760b93e7b0ef524820ba70c82bbfcb3",
-                "sha256:9aae81286aaffcfcfabbdb8af6625b382562c0f380bd90ccdc609ae624bd59b9"
+                "sha256:371bd8baea3d99e22b2282ee4cc06f5600753ad2b7762d1cf433772d7694b22d",
+                "sha256:cec93c0bce50836a8f1f9a770c258f934da9d490dd865c3a1b96a025d1b02096"
             ],
-            "version": "==1.114.0"
+            "markers": "python_version >= '3.6'",
+            "version": "==1.136.0"
         },
         "aws-cdk.aws-autoscaling-common": {
             "hashes": [
-                "sha256:65c200553a62463b56004743c007bf6c7c29b1db2bb95f5415e60df090d92afc",
-                "sha256:c4bab400a22ee0adf93887fba2c09ce14b6d40a139cb4341962f83d74bf40236"
+                "sha256:8641be3866d9071f2bba7a901883d1aff170ab4fe61f8affb5c0327cb0ce7b69",
+                "sha256:ffed7f6ac30cd89ef8a9a415639004834cf9d43b759c81aad9554774d7d126fd"
             ],
-            "version": "==1.114.0"
+            "markers": "python_version >= '3.6'",
+            "version": "==1.136.0"
         },
         "aws-cdk.aws-autoscaling-hooktargets": {
             "hashes": [
-                "sha256:dda878cf671fea0f61941ab9102ccb0af6e91c0855a6bfe3456eb20a435e8931",
-                "sha256:e83fba3d1f18030db56da5ee63e46fc24937f5d841983c15a22086760350e76a"
+                "sha256:869b4dea5ffc7c4b9017d03657f8c1a1d8fe60ee417546c0e4111a18785200b8",
+                "sha256:cc6bd5830edd2ad4c673560143a113ec12d3f504211a9eab41d7e441dd8e711d"
             ],
-            "version": "==1.114.0"
+            "markers": "python_version >= '3.6'",
+            "version": "==1.136.0"
         },
         "aws-cdk.aws-certificatemanager": {
             "hashes": [
-                "sha256:7b2852a899cf3aa92e10fe4ed8257996997463acfa0b757aeebbebc8c640e606",
-                "sha256:dfc7d04d56f6ec679db0b3a47429c3397dbf985990203675ba3c7a10327f8427"
+                "sha256:4fa5760ff57e30ad0c0aac6156c0302ae7cc7051d28a87c31b7e9942d2a72a96",
+                "sha256:fae2e6a7f70d2e7ecaf083752205a82f29f6379d51b4a54bb104bcc056f640a3"
             ],
-            "version": "==1.114.0"
+            "markers": "python_version >= '3.6'",
+            "version": "==1.136.0"
         },
         "aws-cdk.aws-cloudformation": {
             "hashes": [
-                "sha256:7e638c721589429e1bf6c9f085b3a354a49e82e4923fdb81c80a67abb1c59153",
-                "sha256:96773ea6990106b637169da30da99cdd001bd9bc4533bf432a4c5fd08a2f980d"
+                "sha256:58670f518f60275ad10e4522d62ca774d02d4021750efaa6481274c100deca3a",
+                "sha256:e4ae4a5cf5c54fb0532e247e4330b79e88a00aad0d70176773f1747ad60eab18"
             ],
-            "version": "==1.114.0"
+            "markers": "python_version >= '3.6'",
+            "version": "==1.136.0"
         },
         "aws-cdk.aws-cloudfront": {
             "hashes": [
-                "sha256:6bb4460ac8298dab0680d906e5f0b13c90346c5ddd94ee4cb7296175479b21d7",
-                "sha256:77ace19cc75450ba679a0e6d54d33b30e8ef1e7f3921f4ab920e630c5a796cb0"
+                "sha256:321ca6cfa914d66d508a660b334af902519a483e7eb5633386e32a9f63056879",
+                "sha256:657fdf3fa36d7673343194b9f1328f6258f02beb7714d6f09783012ff292e53b"
             ],
-            "version": "==1.114.0"
+            "markers": "python_version >= '3.6'",
+            "version": "==1.136.0"
         },
         "aws-cdk.aws-cloudwatch": {
             "hashes": [
-                "sha256:c04ab0b6b7fbcd478336b89dfd7a6014f4ec1a804803e98ba3fb71f635ff3914",
-                "sha256:c898a1aaeaa16929bdd9fe21fd49ce04205774c8767641e5fb80099c9f159451"
+                "sha256:78def813951d2551853b0d81a2022dd35f38f079549d22c65165f35b2ab9f770",
+                "sha256:ed4064fdd7d85f628241b91ee548969efe3191e07f029af286d6818fde9ed707"
             ],
-            "version": "==1.114.0"
+            "markers": "python_version >= '3.6'",
+            "version": "==1.136.0"
         },
         "aws-cdk.aws-codebuild": {
             "hashes": [
-                "sha256:0f3531f76c972cd91b64023cec058a250553c8b508c6cf93c1780a5c8d8a992a",
-                "sha256:7a6f740e4a7cadbee79d830d3902dcf07c48102b4def6ebbca0e7148cc59ca94"
+                "sha256:03489eba8dac5c6e26c1c365d877ed7052e16bd742c868aae26480374ec8439b",
+                "sha256:0552f5876eacd7d6ee6963bfc2b7b60e9a5078b6ca495aa8f683fd89cbb4b04a"
             ],
-            "version": "==1.114.0"
+            "markers": "python_version >= '3.6'",
+            "version": "==1.136.0"
         },
         "aws-cdk.aws-codecommit": {
             "hashes": [
-                "sha256:395848fd00a371cfb90b62997f93d0d997421182355609cda9bba850125189ff",
-                "sha256:434b226f753800161d3283d1bda6094d3a770692c1895529be681273327247fd"
+                "sha256:2c9be0e6ac17d4928cd0a413feb8ed6a018eeeb1e3a4bdeb20f5658098a7c7ac",
+                "sha256:44950e5693c6157e10ff0470fcf07214da38cdbf68643fe6555f777ee02cf3f7"
             ],
-            "version": "==1.114.0"
+            "markers": "python_version >= '3.6'",
+            "version": "==1.136.0"
         },
         "aws-cdk.aws-codeguruprofiler": {
             "hashes": [
-                "sha256:152cab0b62cb80a2305a8c01f436a07013d53fecb497223d34f40c1e69b23c40",
-                "sha256:20372148130f774b9f3fbffcb63a5ea78c50847113e3dfa9a686005b514276d2"
+                "sha256:4f2858b59b96db00a846975ed7703b2867029157d82d46aff248710b80980a61",
+                "sha256:95458b53e0351373d747bc3f4eb6b424dbb8dee9471ff6867e4fcd9a0486d60b"
             ],
-            "version": "==1.114.0"
+            "markers": "python_version >= '3.6'",
+            "version": "==1.136.0"
         },
         "aws-cdk.aws-codepipeline": {
             "hashes": [
-                "sha256:1fde4f487c36c0c4b2e9e6a60167ceee653e855da9886ab0c86212d58dc3df17",
-                "sha256:5c21c4c254cbd4db5fa9fe4ecf6224fea9c4be35be3b5a7bf17664feda56c623"
+                "sha256:b918197295a7d2c4e5fc9864cedabfdd29d4127ab8389800357fdaa28beeb44b",
+                "sha256:e48e552e52fae857a4dbb51eb7cfe749e8e83c3a0645a2a52e91f3a1e3908d07"
             ],
-            "version": "==1.114.0"
+            "markers": "python_version >= '3.6'",
+            "version": "==1.136.0"
         },
         "aws-cdk.aws-codestarnotifications": {
             "hashes": [
-                "sha256:488db18ec1789064b78db1a8f9dd02a69bc9bc4b9af8010113ff8ca6718bac7a",
-                "sha256:c2726b7d657bf98611df31765a80bf0bbee2054fcde104fcf4179bd22a9aa972"
+                "sha256:a20e140e432d01df01fafe436e31824dece8c8b3380773686ab1dcab111190db",
+                "sha256:eec94991144a8b8430e5d24d8f8c67ff2020097f47130e9c32acea14967c0991"
             ],
-            "version": "==1.114.0"
+            "markers": "python_version >= '3.6'",
+            "version": "==1.136.0"
         },
         "aws-cdk.aws-cognito": {
             "hashes": [
-                "sha256:16a423c9c37cda7bce33ca6edf0213b73c053bcfcb0b969a43b1a9d5cf6c5ceb",
-                "sha256:1a6407ff7dc8aa24e28c98ffdbb9fcadf7931782a2c5721a1fd12eae5423e76c"
+                "sha256:400569731c6fe50bad44a2640231985ceb9ec58ab4b0d9284689ac748e67ad05",
+                "sha256:acdbad5cbee2f82aaf7e4517643bbee1920ab2dd28622fe457ca126417e2862a"
             ],
-            "version": "==1.114.0"
+            "markers": "python_version >= '3.6'",
+            "version": "==1.136.0"
         },
         "aws-cdk.aws-dynamodb": {
             "hashes": [
-                "sha256:4f9aacdd7af48d54caca92754603fbbf2f6d23345cc7f747e41382b09ea9cbd0",
-                "sha256:b05bcb1079356a35afbbd5f0bd6692aa42dac3ce1d1025e7a002a6a1d7234ed2"
+                "sha256:04f464acce63da41b7323e037e3b6014ff6799123f0e05406b95d3716e3eba68",
+                "sha256:f2b78b5118fa60ff9d85677381a07e8e646059d5083652909934264c7550a269"
             ],
-            "version": "==1.114.0"
+            "markers": "python_version >= '3.6'",
+            "version": "==1.136.0"
         },
         "aws-cdk.aws-ec2": {
             "hashes": [
-                "sha256:1d366020fad2d279c107452b0f51cff9d633cdb408c8148b9d586d285fdced10",
-                "sha256:4fd352665be4cc6e8a2757378d7a66976d179185bb456b11d1af88eefecec2f3"
+                "sha256:09bca32a8989ec19f073e8add3115043eb76d872199cdea877ad3b23319628f5",
+                "sha256:722cabea1ab7085fd97a3a0c31d27b6732cc3ceb5d23e7d3827b343a4c5936c8"
             ],
-            "version": "==1.114.0"
+            "markers": "python_version >= '3.6'",
+            "version": "==1.136.0"
         },
         "aws-cdk.aws-ecr": {
             "hashes": [
-                "sha256:3c3e621c4b2dc822e7836c6a07eda68c61428ef1b759652248b88a49d87daa0f",
-                "sha256:bad45188c02c197f228091bea2204d3ec7e74e24af7bc90e3bd0b2103ffdefb2"
+                "sha256:9de72455569d1ae39b1b7b489c0970d4192708beca0b3b98197174c22ba90392",
+                "sha256:b10372a1e6b3b7bd66cd857dfca6ce53465901a6f692d08c82ff914349ae28d1"
             ],
-            "version": "==1.114.0"
+            "markers": "python_version >= '3.6'",
+            "version": "==1.136.0"
         },
         "aws-cdk.aws-ecr-assets": {
             "hashes": [
-                "sha256:3e022aac921a2f6e65617ba56d817f955a82da6c4ee9862dbc10a022b9470490",
-                "sha256:a7ef95fbe5ca5e2672a582e0685bba8656200a82750262eeb61adc6d08323f27"
+                "sha256:8283ff01e834dc0c912a41230dc757cbbfdb2464bdd226adfa4713e01cfc43a9",
+                "sha256:be75fde2c9dfddacaff627e5005b82a35b5c9af54f2d133a8d848fc2d809b1b1"
             ],
-            "version": "==1.114.0"
+            "markers": "python_version >= '3.6'",
+            "version": "==1.136.0"
         },
         "aws-cdk.aws-ecs": {
             "hashes": [
-                "sha256:14ba25ea2b685d8a34a6ad9843efde206cf2b458e6d7c313fe7f96b1c9d387bc",
-                "sha256:ab2250d0147cd7c9b222182f7e391059461a21217e5ac4dccf46238e2d17a975"
+                "sha256:0fb1a6affde636575d7821fb16e756b3b561a88f6d41acfce7385f38ef3f6b21",
+                "sha256:94c45e00a4379049a4664a1af266253963089e6b275f417c974720bb75c714b6"
             ],
-            "version": "==1.114.0"
+            "markers": "python_version >= '3.6'",
+            "version": "==1.136.0"
         },
         "aws-cdk.aws-ecs-patterns": {
             "hashes": [
-                "sha256:16337d92b7a0f9edfa64ba4f8b211e089ecaa3e6fca9e16ffbc96d8beeb99a61",
-                "sha256:8deff8b460dc277a122292d0975d954a29c8bb81d0483b487e18c865b897b9c9"
+                "sha256:18bb6af8a53e821a2e4e9c3075e43723e4e64a4da68966e2923bc07e6119a6a6",
+                "sha256:cee68de1e4820bca38291dbebe4aba3da176ee9e5b34989a75d7e7076b804af8"
             ],
-            "version": "==1.114.0"
+            "markers": "python_version >= '3.6'",
+            "version": "==1.136.0"
         },
         "aws-cdk.aws-efs": {
             "hashes": [
-                "sha256:6eaaa396b37bdb502a9c556b76e6dad60dc7993f87c387abdef61bf8437c867c",
-                "sha256:a97808189d68d2c87b31619a532da1476c512e60e0de791dc58ce01d24161b66"
+                "sha256:0fc9baf715dce28bbb58cd57eab89471728b984598336cef5499023cddf832ef",
+                "sha256:19d707e4b296f414e5eacb64940f71b09faf05383cae78fc72f4407008f7d62a"
             ],
-            "version": "==1.114.0"
+            "markers": "python_version >= '3.6'",
+            "version": "==1.136.0"
         },
         "aws-cdk.aws-elasticache": {
             "hashes": [
-                "sha256:9a6daacf8f8573b6334d503ee401b19cdaa104acd72147c41fdc49cceeed4ae0",
-                "sha256:b97c1fcfa26c44b7737e20a323c8363f61541130aaa49d511b5bd04a7ba324aa"
+                "sha256:5dc6accca41624d3a666db70d428c1c0c7580e4caf80fab46b4bfbbb334f3664",
+                "sha256:7e5ea32d1b674dc6e762e2d3463582568168a2a77039db7d95c5859a0c0a5fcc"
             ],
-            "version": "==1.114.0"
+            "markers": "python_version >= '3.6'",
+            "version": "==1.136.0"
         },
         "aws-cdk.aws-elasticloadbalancing": {
             "hashes": [
-                "sha256:26106d7967e700c2ea3b4be14d481d1c3781468404ff91b2af9b717e63fb815c",
-                "sha256:5370283f19c47483f725e6814b1e7e66852972ea2585750e9aa725c75e731578"
+                "sha256:6f8c620a21d412a49a7b8abaedab066b15d07db9b0efb34a8eaaa882804c1eb0",
+                "sha256:ccebb90dadf535bb9bd473b4c3c975b76ba19b8561351b1a2ea2e8b63caa36c6"
             ],
-            "version": "==1.114.0"
+            "markers": "python_version >= '3.6'",
+            "version": "==1.136.0"
         },
         "aws-cdk.aws-elasticloadbalancingv2": {
             "hashes": [
-                "sha256:2427012df7730399f2740877e8f92c80031d51a8117b3f6e7f69567d186de08b",
-                "sha256:67dca6aa18dfec91f342f2399b34ccdefc7a343199215bb73f056ffbab2b992b"
+                "sha256:a192201882ce2d6600a097dc3dace897b41b2feb3cec40a9a826565198442b81",
+                "sha256:d0f359a004816851b6f1237ce50481a774d3f1a5fc13acefd8fda93316cfda3b"
             ],
-            "version": "==1.114.0"
+            "markers": "python_version >= '3.6'",
+            "version": "==1.136.0"
         },
         "aws-cdk.aws-events": {
             "hashes": [
-                "sha256:1f46990365709509304c5c02e16d28c853e06a9801b8beafbc7634429f77bc3e",
-                "sha256:f7cad2fec385fc00183b96ef0b50b2c54dccb44dc4ad50c10d28a40952e3af4e"
+                "sha256:26b11912e7ed3963c6518de9e8a84cf984c9f3539859ac366354ed63d753455f",
+                "sha256:9a04090dcf2864359e9e088c0507c548b757ea2549b93d4616f66604c4a4d2c3"
             ],
-            "version": "==1.114.0"
+            "markers": "python_version >= '3.6'",
+            "version": "==1.136.0"
         },
         "aws-cdk.aws-events-targets": {
             "hashes": [
-                "sha256:8b3bd923c2859ea1b3ca4f59c29c7b6fb85837ba010aa75f585541d05af1f024",
-                "sha256:c65688b5e47ca65653002a161d91ebb2a623c5f831f6b105823d3c051ca6cb11"
+                "sha256:6fa4e113f817b76316743c43cd3c1e2f7be9fa1997f8a07ded46773d2af59835",
+                "sha256:d73d6cdf50f0e1b45a49cdf8ce12c0bf0d5b64194d0f96ff6cd70a6fffe8edcb"
             ],
-            "version": "==1.114.0"
+            "markers": "python_version >= '3.6'",
+            "version": "==1.136.0"
         },
         "aws-cdk.aws-globalaccelerator": {
             "hashes": [
-                "sha256:8a54745e64b6dafa343bc104ad43f8b620b73b31ec5d1cb20ad04b04a702b3cd",
-                "sha256:e786be38ac4e691658a5e818ced7370e25d31354821d351333fdc851966a68c1"
+                "sha256:2442cb54707a1352c4fd8d558f76fc8a4d600c99b57fc0a24eec980443fc338f",
+                "sha256:f665fea3817a18834a9d855c9397eebbc933c98415a32d96c32832624c4c1365"
             ],
-            "version": "==1.114.0"
+            "markers": "python_version >= '3.6'",
+            "version": "==1.136.0"
         },
         "aws-cdk.aws-iam": {
             "hashes": [
-                "sha256:173095fa5ea5cc017ad85cb9f6d377a5b8272c913f46e801bd49aa50a2418f1a",
-                "sha256:9661944cdb045471afa4b4bf579bc84d999b080afdc187d15ac2c63c608c4e3a"
+                "sha256:2755debe9f5f8583a518e77067d27a9a13dd76f2af9ffb06d2488c8593b2ac82",
+                "sha256:ba876c97287fd84ee2281582e7abeda7d67284ec651caca9251ea84db11f449d"
             ],
-            "version": "==1.114.0"
+            "markers": "python_version >= '3.6'",
+            "version": "==1.136.0"
         },
         "aws-cdk.aws-kinesis": {
             "hashes": [
-                "sha256:8d568a7ec5bcfb27666a40e586432202507cea8c62e2e736ae131e502fbf70f3",
-                "sha256:d8cdca622c575cbe36472c92735add1bab24dcb14e7d340caeb2e128578aee7b"
+                "sha256:1d3fc9d576ec4e86dd7e8929dc3e2ed32286443f47e448c15e13434215a26454",
+                "sha256:e125b42b1c30032b61f9832609db9de318a7d8f75c2f13c71bd93b066954e823"
             ],
-            "version": "==1.114.0"
+            "markers": "python_version >= '3.6'",
+            "version": "==1.136.0"
         },
         "aws-cdk.aws-kinesisfirehose": {
             "hashes": [
-                "sha256:2d306f74d6d5496a33001e247de6747a0f589ffb614f0a1cae449f5efb220945",
-                "sha256:8d0dfe33ca9c6d28a00b0f08b37700cfd469ee312a6b1033d8ce00a5621c4ee1"
+                "sha256:7302401b3e1a1e01d4e2be4437b07eb8d2c071684400580c635c50a941b2452d",
+                "sha256:75daffedef9342839289fd7963bab5d7cf46a9bd0b5985676cff9d8a5b629462"
             ],
-            "version": "==1.114.0"
+            "markers": "python_version >= '3.6'",
+            "version": "==1.136.0"
         },
         "aws-cdk.aws-kms": {
             "hashes": [
-                "sha256:7126b7026036ba6fcd9840a098ae46a176e987c7b3306e3bc4c2152d3da479c4",
-                "sha256:b379cd5d16c4ed0d7fdea61305d6e2a75e2415354617a2f0044f241c76d7a5ab"
+                "sha256:1e0304ed3e0c882d1de759d53942b1eb8cb9330268d8eb4a91274a9d393e19bc",
+                "sha256:7453cf9c76b35b94aa0ff0df4539112eb53d54af9825650bedeb5eec2eaec9e5"
             ],
-            "version": "==1.114.0"
+            "markers": "python_version >= '3.6'",
+            "version": "==1.136.0"
         },
         "aws-cdk.aws-lambda": {
             "hashes": [
-                "sha256:73b81984f271465e4b78302997b57db9dc1d56f86c8a5a55b352535afa4c841c",
-                "sha256:93c0ba6a98141c4e9a29a98abb0fdbb6828a5975a83c6981d22528131545ff42"
+                "sha256:728b0e64040eddab75d2d4818fb3d4d0972c0b0378ed1288f5341060c939a071",
+                "sha256:9ade08ad771145da7d2b7ee52244ad678d2895f6830f15e2eb1d0688285d15e2"
             ],
-            "version": "==1.114.0"
+            "markers": "python_version >= '3.6'",
+            "version": "==1.136.0"
         },
         "aws-cdk.aws-logs": {
             "hashes": [
-                "sha256:62000ee99c212c98bb889b674ef74b0df45d4ba54cc1c13684e99f79ec453684",
-                "sha256:c2a000b0666be5947b928384785e9f413f72867f1846d2d52c256b2fdc8751f3"
+                "sha256:23b3d3df2c6a2b2df41a6688d64e10ca2cc57b629f4ef84e0afec883701ceecb",
+                "sha256:8f940efcb3545fcfa4ca3ac245d7b60105384f999488c7571a49c6413ccbd7e2"
             ],
-            "version": "==1.114.0"
+            "markers": "python_version >= '3.6'",
+            "version": "==1.136.0"
         },
         "aws-cdk.aws-route53": {
             "hashes": [
-                "sha256:8853c9c684e83635bfa18f9e1e4532f355cff2d7bf496fe3fc4d489e349d8f0b",
-                "sha256:df9888c91cd0062be2636d0a5760ef652d4cfb7a8ae5a680773ad2f601cbd694"
+                "sha256:74da6dbf860f6a93be6ea7bf0d85c8a500eae55530fbc8230d3b4d0237d63446",
+                "sha256:eccd9613c5620c3db8db25e4affcbbcdfad659c45110ffed4960651096b06922"
             ],
-            "version": "==1.114.0"
+            "markers": "python_version >= '3.6'",
+            "version": "==1.136.0"
         },
         "aws-cdk.aws-route53-targets": {
             "hashes": [
-                "sha256:0eaeddd0f7934adb85769a61cc743628f371e5f2cc1b979a0ba97b68250ca231",
-                "sha256:74e42b8e7e3cfe56acecfcd6291c7a3cefa66083d7a229cca6170cdf384ae928"
+                "sha256:0edfccc18b223a97a54a272923c18f33ff649647dc16fd99fcc210cbabe090da",
+                "sha256:4c4be226a307bd0b4dbd67937d60cde9c36f924745c0842a8fbbcf75d4378a10"
             ],
-            "version": "==1.114.0"
+            "markers": "python_version >= '3.6'",
+            "version": "==1.136.0"
         },
         "aws-cdk.aws-s3": {
             "hashes": [
-                "sha256:267cb0dbacee761948eeef26f50f26bc68ebce57c6154a23305197237d9d55ea",
-                "sha256:98f4f6b32798c310fc201c2b2dd8fe2f8a09ff669d88ac2fe5e8ce88714f7b9f"
+                "sha256:7743896dcf33a2961d5da84c093aa5fe6a29bd2800f2cdd29a2be0fe498519bd",
+                "sha256:de0ce4dec441437a3d4db661bc5b22c66228d8d16b6379316c0e34f444f54cc4"
             ],
-            "version": "==1.114.0"
+            "markers": "python_version >= '3.6'",
+            "version": "==1.136.0"
         },
         "aws-cdk.aws-s3-assets": {
             "hashes": [
-                "sha256:045a18ba6c8c6d2173c47388dc909f9692b5ac7912ce153b8646b4d4ac7a8ac2",
-                "sha256:22f85f9ab009a775fb96445ce6feb754e8adc768014dc720bff7d570c239e367"
+                "sha256:4c3ace120d5b7fc8805c62b8f676dd9067676d7af3268065a8a06469b7243d3d",
+                "sha256:ce10f01596a9129aa606f0c7edf88a0e5d347c88f1c7f6d88c4c7c18388ce7aa"
             ],
-            "version": "==1.114.0"
+            "markers": "python_version >= '3.6'",
+            "version": "==1.136.0"
         },
         "aws-cdk.aws-s3-deployment": {
             "hashes": [
-                "sha256:78805d18ec6b06f8f9260b7bdf71e3ca0f74cd261e8a82dfa0e77bff0bab4da8",
-                "sha256:d74ec4057ed7410fa29c0cb6bb6913023f31890302454c6d6475070ef2de7e7c"
+                "sha256:74dae1909abc095f914e4a3db665e8765c12412ab1f6bccdbf70b3290397054a",
+                "sha256:fa1b7518b4b865d72e1c8e4c83de5a3cda4927c54548e1494e699eeaadc3afd3"
             ],
-            "version": "==1.114.0"
+            "markers": "python_version >= '3.6'",
+            "version": "==1.136.0"
         },
         "aws-cdk.aws-sam": {
             "hashes": [
-                "sha256:4b0084b015dea4f64160307071458a10e72dbe2c2b9f3d806e7ed4c75a420dd5",
-                "sha256:5b3e62815a977786efc251995d3e4bd08b89250a373388f68c3c468a05a8a89c"
+                "sha256:2f328d948dd98570914baf89c14daa42fe2b07d024ee831a50f2a64669ec8a89",
+                "sha256:9d0d81f43f5262854e797d57b3331a61325ea0a50b37f36e4c53557bec5bbc67"
             ],
-            "version": "==1.114.0"
+            "markers": "python_version >= '3.6'",
+            "version": "==1.136.0"
         },
         "aws-cdk.aws-secretsmanager": {
             "hashes": [
-                "sha256:065a51aa770ebe4b8e4d7c5055c7d5a1de15e3ef83e5da83433d7387355e775d",
-                "sha256:ed4bc56e6ba13815f6757d48ad09345a44a2a1fbc211a88180dcc8d475408c39"
+                "sha256:35a9a78fda6e4f95a49e449be3fb145dfd1832a46f11b4c7658e7d609d2aa598",
+                "sha256:c40c9ea1f01e843259ae56bf8d535b85658714308e7b9e2703cfeb40b95faa0c"
             ],
-            "version": "==1.114.0"
+            "markers": "python_version >= '3.6'",
+            "version": "==1.136.0"
         },
         "aws-cdk.aws-servicediscovery": {
             "hashes": [
-                "sha256:7731f57973b2b5c6ea8a42f00ccb9539532f6c2842602f074005f871ff512cc9",
-                "sha256:e6ee6974fe467aab94e3580b9699973634827be483a1653c30548fbd9c08cb0f"
+                "sha256:10da145d384cce83404f39c86cb9cc24d8f930d93046f63dc3a98d91fbbb8afa",
+                "sha256:dbcd6a2224338a69d875e82838c5cea820e90ef4856fedb24e88aa0142825bc3"
             ],
-            "version": "==1.114.0"
+            "markers": "python_version >= '3.6'",
+            "version": "==1.136.0"
         },
         "aws-cdk.aws-signer": {
             "hashes": [
-                "sha256:3907714183befebace0f94990ddfe019ba9222fdbb2c9bd85b9d14368be9a750",
-                "sha256:b71542d3725243e36620b55dffbdf22ff0bcb9a0e56c05dee9b8aea459add6e3"
+                "sha256:1540f05af708ceec05014c4961d4cf22562916dadc6366d58175d60652253a71",
+                "sha256:48796d4f423ee2f5eb7b67539485b8c4237e2c4ea9631985dc72df3b5d54e504"
             ],
-            "version": "==1.114.0"
+            "markers": "python_version >= '3.6'",
+            "version": "==1.136.0"
         },
         "aws-cdk.aws-sns": {
             "hashes": [
-                "sha256:364eff643256c43dad7fe0f9f837a9c74d2d0bc13348a035b0b5e6e8677aaa48",
-                "sha256:dc981a9b6c96cf3a7a4914081743a400424ee807a2984f6bcb8411e72ec38852"
+                "sha256:c6b017ecf2fc2d9e8b103df51eed308231d67f109b3750a6f3ee38df9ac6c4ad",
+                "sha256:f45f05fd254f0e71ca3536cadcfebc660423cb39b807ee4d32ade5db209a9b14"
             ],
-            "version": "==1.114.0"
+            "markers": "python_version >= '3.6'",
+            "version": "==1.136.0"
         },
         "aws-cdk.aws-sns-subscriptions": {
             "hashes": [
-                "sha256:ad24e938cd2f2bef89b073db3a032c550632fa5fa114d3ba63dfb267da887048",
-                "sha256:c67569a4917b940fff1b701dc8c69b82d47249801e064ffadc7bcf822fbb9886"
+                "sha256:dc23f96051055745d051142d4f1db14d6557280fb80fc674cae2c9c6ca3c17f0",
+                "sha256:dcc97abd6462f9deb3cab41c6083bcdce4b971ed2b56be0e0a5455baa1cd9557"
             ],
-            "version": "==1.114.0"
+            "markers": "python_version >= '3.6'",
+            "version": "==1.136.0"
         },
         "aws-cdk.aws-sqs": {
             "hashes": [
-                "sha256:88cbe09062ff48ce0f597013c7597e8ea05a355feba939a9c9257267db28ac0d",
-                "sha256:d5403e5158d3dc982f5846387a8fa2f1e3b3bddca0673f019bb45b8e7fe62c23"
+                "sha256:acb8c4c4c8b73eaca1250d61e6a397d3a89914d32468b1c80f9387404402528f",
+                "sha256:c8e8fde1e57e6d2e4ec6126a746c6c20c86b98d455bb66173cca5508bf74b6d8"
             ],
-            "version": "==1.114.0"
+            "markers": "python_version >= '3.6'",
+            "version": "==1.136.0"
         },
         "aws-cdk.aws-ssm": {
             "hashes": [
-                "sha256:397f26c994031bfc624b2cca99f2d8a2eeb8fc28581161ceeca6405621a2f222",
-                "sha256:60afe25d9c23803c667e02898bcadf33d405b4a0d224e83a37b173dc0849a17c"
+                "sha256:2229adb30919c3b63295dacb7597691799ffbacd2c399f82a245e7d1c709cea7",
+                "sha256:87c145604c2b9425ba3806d9ab5952e9687db9470913084e8fd3333e989d02b5"
             ],
-            "version": "==1.114.0"
+            "markers": "python_version >= '3.6'",
+            "version": "==1.136.0"
         },
         "aws-cdk.aws-stepfunctions": {
             "hashes": [
-                "sha256:937b6f4780e71c904063d80f1428aa269912c6c19bed31ecc50bd4c912c5b1e4",
-                "sha256:ca4b9a046b88785c3090002203932389b27c935e78bffe7673d08946c44d09ac"
+                "sha256:816c7e3667c42f98f971fefe41d41e3a5b416aa7a689f808172e36ad1ea4703b",
+                "sha256:a9d9b20bb691cfa25deac2a249e4f27fd2955ff9449f519fa63185547c19ad70"
             ],
-            "version": "==1.114.0"
+            "markers": "python_version >= '3.6'",
+            "version": "==1.136.0"
         },
         "aws-cdk.cloud-assembly-schema": {
             "hashes": [
-                "sha256:26cf344dc699fb4de4d6524a47a26748d6c616aea180be943cc374082a621652",
-                "sha256:4a62be285bd458601725f92f5158f38dc3b3e42bcaaa483e30723d64d29ea569"
+                "sha256:0cc6c399663f85050f7edd629c32775dede7a52f0292f1ca38a8548c6e1a9204",
+                "sha256:6409c9530a5e538c22badea4a2b10eae0195dbbffbbaf4f669dff378925a0a76"
             ],
-            "version": "==1.114.0"
+            "markers": "python_version >= '3.6'",
+            "version": "==1.136.0"
         },
         "aws-cdk.core": {
             "hashes": [
-                "sha256:23c838bdea601084f46a820c351ec62a1973b46f7cf8c3628958c40fd490c5e7",
-                "sha256:d89203de39d7ef21797c2b5470743e86d12f3b1c78eee966a81553691597c4d1"
+                "sha256:80e599298bee58316d68e794b40283dc7452ffe9b670bbbc3a96175ca18fd964",
+                "sha256:b8dddcab8ea0f6f2edbf64ed9cdd71e46b236922fba757c9ba1cee820c0106c5"
             ],
-            "version": "==1.114.0"
+            "markers": "python_version >= '3.6'",
+            "version": "==1.136.0"
         },
         "aws-cdk.custom-resources": {
             "hashes": [
-                "sha256:4e18032ded356ca5e9fbb1fae0a2f4829eea97bc3c1080baa59f79d2d5fc01b1",
-                "sha256:d05f373983acca6ed2f67abf664ad1243b98458d51f569917a9ab8ecd910d11d"
+                "sha256:5edeb0e90109af1009b977baf9d5bd1d66562a2d9d051c3410f0d73e318236b9",
+                "sha256:8c5e1c6261570f933c7853bd4c866b9534c4606f2fba68b6b2f324c95739fa37"
             ],
-            "version": "==1.114.0"
+            "markers": "python_version >= '3.6'",
+            "version": "==1.136.0"
         },
         "aws-cdk.cx-api": {
             "hashes": [
-                "sha256:09011eace2c513e995a7944b9548f94eab97a0721b44e4319cafb50d62f049a0",
-                "sha256:8b15eb5c1ea532943f40defeb22ba95af9417ac3c17ba2946f8adb7ddd0c7e08"
+                "sha256:c11812fb329b48b464dd1dbc26be048d0cda6df5e88c3f16c547524690ad23c1",
+                "sha256:e94eb85c9c9e120e771c88f22f2e4d0a4fdac710f6e189f5652f5d19ed7d88b9"
             ],
-            "version": "==1.114.0"
+            "markers": "python_version >= '3.6'",
+            "version": "==1.136.0"
         },
         "aws-cdk.lambda-layer-awscli": {
             "hashes": [
-                "sha256:5993fc9067c79d2145a79bd0421f4af216595c3af62b21ac5936602ed7db1e6d",
-                "sha256:a7d4be74edb9fd16b152e3a8cbab94257bae6b48c9089d9638d404d919325f7e"
+                "sha256:30753bbe744af2fbe54349b4fe9238cf34b632557cc294c578a747f8f81d7d13",
+                "sha256:e73bb6d1617f3f40678518ad4fc3628e4f2ed23b752240c7c595de4cb13198fe"
             ],
-            "version": "==1.114.0"
+            "markers": "python_version >= '3.6'",
+            "version": "==1.136.0"
         },
         "aws-cdk.region-info": {
             "hashes": [
-                "sha256:19b71a6e1596999b52698939f31c7de70eca70f7b47576ccfc9e5a6ca0e601d1",
-                "sha256:cf3190f8169943eb3e897c2e6e02fb332fbc4a1edfbbbe815dec920d7edbd104"
+                "sha256:a42d33f0f228d216cf5011f8da0c3dc8086740f28060844d01d3bb932c5d7075",
+                "sha256:c24c30ebbc58b6e4d774d6e1cb2ae43c7583bb5301e07f787ece2bcfd78cdd33"
             ],
-            "version": "==1.114.0"
+            "markers": "python_version >= '3.6'",
+            "version": "==1.136.0"
         },
         "cattrs": {
             "hashes": [
-                "sha256:277d12740b45e46318b41c3b2e4a3bc067a7b9971cf61f0e96497598ad83f282",
-                "sha256:a6233d0ce33d48ac71ef818f8e0b9309a89496b359994c4dfe9ad211c1f6d0a3"
+                "sha256:5c121ab06a7cac494813c228721a7feb5a6423b17316eeaebf13f5a03e5b0d53",
+                "sha256:901fb2040529ae8fc9d93f48a2cdf7de3e983312ffb2a164ffa4e9847f253af1"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==1.5.0"
+            "version": "==1.8.0"
         },
         "certifi": {
             "hashes": [
-                "sha256:2bbf76fd432960138b3ef6dda3dde0544f27cbf8546c458e60baf371917ba9ee",
-                "sha256:50b1e4f8446b06f41be7dd6338db18e0990601dce795c2b1686458aa7e8fa7d8"
+                "sha256:78884e7c1d4b00ce3cea67b44566851c4343c120abd683433ce934a68ea58872",
+                "sha256:d62a0163eb4c2344ac042ab2bdf75399a71a2d8c7d47eac2e2ee91b9d6339569"
             ],
-            "version": "==2021.5.30"
+            "version": "==2021.10.8"
         },
         "charset-normalizer": {
             "hashes": [
-                "sha256:88fce3fa5b1a84fdcb3f603d889f723d1dd89b26059d0123ca435570e848d5e1",
-                "sha256:c46c3ace2d744cfbdebceaa3c19ae691f53ae621b39fd7570f59d14fb7f2fd12"
+                "sha256:1eecaa09422db5be9e29d7fc65664e6c33bd06f9ced7838578ba40d58bdf3721",
+                "sha256:b0b883e8e874edfdece9c28f314e3dd5badf067342e42fb162203335ae61aa2c"
             ],
             "markers": "python_version >= '3'",
-            "version": "==2.0.3"
+            "version": "==2.0.9"
         },
         "consoleme-ecs-cdk": {
             "editable": true,
-            "path": "consoleme_ecs_cdk"
+            "path": "./consoleme_ecs_cdk"
         },
         "constructs": {
             "hashes": [
-                "sha256:372902f796bc135017571bad737a71530e4c354479c077c4e67fed6bf7a4df37",
-                "sha256:482d31b08fe7ae036d3ed41b7e51ff3b683a55957765fe418ce037b3fa62f6a7"
+                "sha256:17f8d11375c801f6c88073014c9da61b157897540a985f08798ba60d40a92d23",
+                "sha256:2a65607090947284afa5c43a78b0f0604fe9e564c41a7ba4a8cfe2634b001516"
             ],
-            "version": "==3.3.97"
+            "markers": "python_version >= '3.6'",
+            "version": "==3.3.168"
         },
         "docopt": {
             "hashes": [
@@ -500,11 +609,11 @@
         },
         "idna": {
             "hashes": [
-                "sha256:14475042e284991034cb48e06f6851428fb14c4dc953acd9be9a5e95c7b6dd7a",
-                "sha256:467fbad99067910785144ce333826c71fb0e63a425657295239737f7ecd125f3"
+                "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff",
+                "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"
             ],
             "markers": "python_version >= '3'",
-            "version": "==3.2"
+            "version": "==3.3"
         },
         "iniconfig": {
             "hashes": [
@@ -515,31 +624,34 @@
         },
         "jsii": {
             "hashes": [
-                "sha256:0e166a334dc96aa10b30b531fbd5c2079b1be3d03a7a5fb53db9d6a4f20ddba0",
-                "sha256:511d535f8d02912b92b7d405b3610161a2acd485991791fd793a45f3262d14f0"
+                "sha256:0d8fb7f6d8f520325a871eba2deeb0f138b2642e15d06a74fe095f9a90ab43f9",
+                "sha256:403947d1b459957d98683681334a1928810aab4e85c98db773be01b3d536888e"
             ],
-            "version": "==1.31.0"
+            "markers": "python_version ~= '3.6'",
+            "version": "==1.49.0"
         },
         "packaging": {
             "hashes": [
-                "sha256:7dc96269f53a4ccec5c0670940a4281106dd0bb343f47b7471f779df49c2fbe7",
-                "sha256:c86254f9220d55e31cc94d69bade760f0847da8000def4dfe1c6b872fd14ff14"
+                "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb",
+                "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"
             ],
-            "version": "==21.0"
+            "markers": "python_version >= '3.6'",
+            "version": "==21.3"
         },
         "pipreqs": {
             "hashes": [
-                "sha256:9e351d644b28b98d7386b046a73806cbb3bb66b23a30e74feeb95ed9571db939",
-                "sha256:cafe42ab70628d408c147fb8944bc303355ea8f91fddca4a98d273e572e39905"
+                "sha256:1510a91ae73ef6a8e2f24ffc8751132251cd61a01296d61538f37d1491841640",
+                "sha256:c793b4e147ac437871b3a962c5ce467e129c859ece5ba79aca83c20f4d9c3aef"
             ],
-            "version": "==0.4.10"
+            "version": "==0.4.11"
         },
         "pluggy": {
             "hashes": [
-                "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0",
-                "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"
+                "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159",
+                "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"
             ],
-            "version": "==0.13.1"
+            "markers": "python_version >= '3.6'",
+            "version": "==1.0.0"
         },
         "publication": {
             "hashes": [
@@ -550,71 +662,79 @@
         },
         "py": {
             "hashes": [
-                "sha256:21b81bda15b66ef5e1a777a21c4dcd9c20ad3efd0b3f817e7a809035269e1bd3",
-                "sha256:3b80836aa6d1feeaa108e046da6423ab8f6ceda6468545ae8d02d9d58d18818a"
+                "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719",
+                "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378"
             ],
-            "version": "==1.10.0"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==1.11.0"
         },
         "pyparsing": {
             "hashes": [
-                "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1",
-                "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"
+                "sha256:04ff808a5b90911829c55c4e26f75fa5ca8a2f5f36aa3a51f68e27033341d3e4",
+                "sha256:d9bdec0013ef1eb5a84ab39a3b3868911598afa494f5faa038647101504e2b81"
             ],
-            "version": "==2.4.7"
+            "markers": "python_version >= '3.6'",
+            "version": "==3.0.6"
         },
         "pytest": {
             "hashes": [
-                "sha256:50bcad0a0b9c5a72c8e4e7c9855a3ad496ca6a881a3641b4260605450772c54b",
-                "sha256:91ef2131a9bd6be8f76f1f08eac5c5317221d6ad1e143ae03894b862e8976890"
+                "sha256:131b36680866a76e6781d13f101efb86cf674ebb9762eb70d3082b6f29889e89",
+                "sha256:7310f8d27bc79ced999e760ca304d69f6ba6c6649c0b60fb0e04a4a77cacc134"
             ],
-            "version": "==6.2.4"
+            "version": "==6.2.5"
         },
         "python-dateutil": {
             "hashes": [
                 "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86",
                 "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.8.2"
         },
         "pyyaml": {
             "hashes": [
-                "sha256:08682f6b72c722394747bddaf0aa62277e02557c0fd1c42cb853016a38f8dedf",
-                "sha256:0f5f5786c0e09baddcd8b4b45f20a7b5d61a7e7e99846e3c799b05c7c53fa696",
-                "sha256:129def1b7c1bf22faffd67b8f3724645203b79d8f4cc81f674654d9902cb4393",
-                "sha256:294db365efa064d00b8d1ef65d8ea2c3426ac366c0c4368d930bf1c5fb497f77",
-                "sha256:3b2b1824fe7112845700f815ff6a489360226a5609b96ec2190a45e62a9fc922",
-                "sha256:3bd0e463264cf257d1ffd2e40223b197271046d09dadf73a0fe82b9c1fc385a5",
-                "sha256:4465124ef1b18d9ace298060f4eccc64b0850899ac4ac53294547536533800c8",
-                "sha256:49d4cdd9065b9b6e206d0595fee27a96b5dd22618e7520c33204a4a3239d5b10",
-                "sha256:4e0583d24c881e14342eaf4ec5fbc97f934b999a6828693a99157fde912540cc",
-                "sha256:5accb17103e43963b80e6f837831f38d314a0495500067cb25afab2e8d7a4018",
-                "sha256:607774cbba28732bfa802b54baa7484215f530991055bb562efbed5b2f20a45e",
-                "sha256:6c78645d400265a062508ae399b60b8c167bf003db364ecb26dcab2bda048253",
-                "sha256:72a01f726a9c7851ca9bfad6fd09ca4e090a023c00945ea05ba1638c09dc3347",
-                "sha256:74c1485f7707cf707a7aef42ef6322b8f97921bd89be2ab6317fd782c2d53183",
-                "sha256:895f61ef02e8fed38159bb70f7e100e00f471eae2bc838cd0f4ebb21e28f8541",
-                "sha256:8c1be557ee92a20f184922c7b6424e8ab6691788e6d86137c5d93c1a6ec1b8fb",
-                "sha256:bb4191dfc9306777bc594117aee052446b3fa88737cd13b7188d0e7aa8162185",
-                "sha256:bfb51918d4ff3d77c1c856a9699f8492c612cde32fd3bcd344af9be34999bfdc",
-                "sha256:c20cfa2d49991c8b4147af39859b167664f2ad4561704ee74c1de03318e898db",
-                "sha256:cb333c16912324fd5f769fff6bc5de372e9e7a202247b48870bc251ed40239aa",
-                "sha256:d2d9808ea7b4af864f35ea216be506ecec180628aced0704e34aca0b040ffe46",
-                "sha256:d483ad4e639292c90170eb6f7783ad19490e7a8defb3e46f97dfe4bacae89122",
-                "sha256:dd5de0646207f053eb0d6c74ae45ba98c3395a571a2891858e87df7c9b9bd51b",
-                "sha256:e1d4970ea66be07ae37a3c2e48b5ec63f7ba6804bdddfdbd3cfd954d25a82e63",
-                "sha256:e4fac90784481d221a8e4b1162afa7c47ed953be40d31ab4629ae917510051df",
-                "sha256:fa5ae20527d8e831e8230cbffd9f8fe952815b2b7dae6ffec25318803a7528fc",
-                "sha256:fd7f6999a8070df521b6384004ef42833b9bd62cfee11a09bda1079b4b704247",
-                "sha256:fdc842473cd33f45ff6bce46aea678a54e3d21f1b61a7750ce3c498eedfe25d6",
-                "sha256:fe69978f3f768926cfa37b867e3843918e012cf83f680806599ddce33c2c68b0"
+                "sha256:0283c35a6a9fbf047493e3a0ce8d79ef5030852c51e9d911a27badfde0605293",
+                "sha256:055d937d65826939cb044fc8c9b08889e8c743fdc6a32b33e2390f66013e449b",
+                "sha256:07751360502caac1c067a8132d150cf3d61339af5691fe9e87803040dbc5db57",
+                "sha256:0b4624f379dab24d3725ffde76559cff63d9ec94e1736b556dacdfebe5ab6d4b",
+                "sha256:0ce82d761c532fe4ec3f87fc45688bdd3a4c1dc5e0b4a19814b9009a29baefd4",
+                "sha256:1e4747bc279b4f613a09eb64bba2ba602d8a6664c6ce6396a4d0cd413a50ce07",
+                "sha256:213c60cd50106436cc818accf5baa1aba61c0189ff610f64f4a3e8c6726218ba",
+                "sha256:231710d57adfd809ef5d34183b8ed1eeae3f76459c18fb4a0b373ad56bedcdd9",
+                "sha256:277a0ef2981ca40581a47093e9e2d13b3f1fbbeffae064c1d21bfceba2030287",
+                "sha256:2cd5df3de48857ed0544b34e2d40e9fac445930039f3cfe4bcc592a1f836d513",
+                "sha256:40527857252b61eacd1d9af500c3337ba8deb8fc298940291486c465c8b46ec0",
+                "sha256:473f9edb243cb1935ab5a084eb238d842fb8f404ed2193a915d1784b5a6b5fc0",
+                "sha256:48c346915c114f5fdb3ead70312bd042a953a8ce5c7106d5bfb1a5254e47da92",
+                "sha256:50602afada6d6cbfad699b0c7bb50d5ccffa7e46a3d738092afddc1f9758427f",
+                "sha256:68fb519c14306fec9720a2a5b45bc9f0c8d1b9c72adf45c37baedfcd949c35a2",
+                "sha256:77f396e6ef4c73fdc33a9157446466f1cff553d979bd00ecb64385760c6babdc",
+                "sha256:819b3830a1543db06c4d4b865e70ded25be52a2e0631ccd2f6a47a2822f2fd7c",
+                "sha256:897b80890765f037df3403d22bab41627ca8811ae55e9a722fd0392850ec4d86",
+                "sha256:98c4d36e99714e55cfbaaee6dd5badbc9a1ec339ebfc3b1f52e293aee6bb71a4",
+                "sha256:9df7ed3b3d2e0ecfe09e14741b857df43adb5a3ddadc919a2d94fbdf78fea53c",
+                "sha256:9fa600030013c4de8165339db93d182b9431076eb98eb40ee068700c9c813e34",
+                "sha256:a80a78046a72361de73f8f395f1f1e49f956c6be882eed58505a15f3e430962b",
+                "sha256:b3d267842bf12586ba6c734f89d1f5b871df0273157918b0ccefa29deb05c21c",
+                "sha256:b5b9eccad747aabaaffbc6064800670f0c297e52c12754eb1d976c57e4f74dcb",
+                "sha256:c5687b8d43cf58545ade1fe3e055f70eac7a5a1a0bf42824308d868289a95737",
+                "sha256:cba8c411ef271aa037d7357a2bc8f9ee8b58b9965831d9e51baf703280dc73d3",
+                "sha256:d15a181d1ecd0d4270dc32edb46f7cb7733c7c508857278d3d378d14d606db2d",
+                "sha256:d4db7c7aef085872ef65a8fd7d6d09a14ae91f691dec3e87ee5ee0539d516f53",
+                "sha256:d4eccecf9adf6fbcc6861a38015c2a64f38b9d94838ac1810a9023a0609e1b78",
+                "sha256:d67d839ede4ed1b28a4e8909735fc992a923cdb84e618544973d7dfc71540803",
+                "sha256:daf496c58a8c52083df09b80c860005194014c3698698d1a57cbcfa182142a3a",
+                "sha256:e61ceaab6f49fb8bdfaa0f92c4b57bcfbea54c09277b1b4f7ac376bfb7a7c174",
+                "sha256:f84fbc98b019fef2ee9a1cb3ce93e3187a6df0b2538a651bfb890254ba9f90b5"
             ],
-            "version": "==5.4.1"
+            "version": "==6.0"
         },
         "requests": {
             "hashes": [
                 "sha256:6c1246513ecd5ecd4528a0906f910e8f0f9c6b8ec72030dc9fd154dc1a6efd24",
                 "sha256:b8aa58f8cf793ffd8782d3d8cb19e66ef36f7aba4353eec859e74678b01b07a7"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
             "version": "==2.26.0"
         },
         "six": {
@@ -622,6 +742,7 @@
                 "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
                 "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.16.0"
         },
         "toml": {
@@ -629,22 +750,24 @@
                 "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b",
                 "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
             ],
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==0.10.2"
         },
         "typing-extensions": {
             "hashes": [
-                "sha256:0ac0f89795dd19de6b97debb0c6af1c70987fd80a2d62d1958f7e56fcc31b497",
-                "sha256:50b6f157849174217d0656f99dc82fe932884fb250826c18350e159ec6cdf342",
-                "sha256:779383f6086d90c99ae41cf0ff39aac8a7937a9283ce0a414e5dd782f4c94a84"
+                "sha256:4ca091dea149f945ec56afb48dae714f21e8692ef22a395223bcd328961b6a0e",
+                "sha256:7f001e5ac290a0c0401508864c7ec868be4e701886d5b573a9528ed3973d9d3b"
             ],
-            "version": "==3.10.0.0"
+            "markers": "python_version >= '3.6'",
+            "version": "==4.0.1"
         },
         "urllib3": {
             "hashes": [
-                "sha256:39fb8672126159acb139a7718dd10806104dec1e2f0f6c88aab05d17df10c8d4",
-                "sha256:f57b4c16c62fa2760b7e3d97c35b255512fb6b59a259730f36ba32ce9f8e342f"
+                "sha256:4987c65554f7a2dbf30c18fd48778ef124af6fab771a377103da0585e2336ece",
+                "sha256:c4fdf4019605b6e5423637e01bc9fe4daef873709a7973e195ceba0a62bbc844"
             ],
-            "version": "==1.26.6"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
+            "version": "==1.26.7"
         },
         "yarg": {
             "hashes": [


### PR DESCRIPTION
`cdk ls` complains about the missing `yaml` dependency:

```
Traceback (most recent call last):
  File "/Users/xxxx/github/consoleme/cdk/app.py", line 10, in <module>
    import yaml
ModuleNotFoundError: No module named 'yaml'
```