### PR TITLE
Make sure resource dump temp dir gets deleted

### DIFF
--- a/consoleme/lib/git.py
+++ b/consoleme/lib/git.py
@@ -95,4 +95,5 @@ def store_iam_resources_in_git(
             origin.push("master", force=True)
     except Exception:  # noqa
         sentry_sdk.capture_exception()
-    shutil.rmtree(tempdir)
+    finally:
+        shutil.rmtree(tempdir)


### PR DESCRIPTION
When ConsoleMe encounters an exception while storing the IAM resource dump in Git, the temporary directory does not get cleaned up. This PR moves the cleanup to the `finally` section of the try/except block for this operation.