### PR TITLE
feat: add roles.allowed_tag_keys configuration

### DIFF
--- a/consoleme/lib/aws.py
+++ b/consoleme/lib/aws.py
@@ -1849,7 +1849,7 @@ def allowed_to_sync_role(
     This function determines whether ConsoleMe is allowed to sync or otherwise manipulate an IAM role. By default,
     ConsoleMe will sync all roles that it can get its grubby little hands on. However, ConsoleMe administrators can tell
     ConsoleMe to only sync roles with either 1) Specific ARNs, or 2) Specific tag key/value pairs. All configured tags
-    must exist on the role for ConsoleMe to sync it.
+    must exist on the role for ConsoleMe to sync it., or 3) Specific tag keys
 
     Here's an example configuration for a tag-based restriction:
 
@@ -1872,6 +1872,15 @@ def allowed_to_sync_role(
         - arn:aws:iam::333333333333:role/role-name-here-1
     ```
 
+    And another one for an tag key based restriction:
+
+    ```
+    roles:
+      allowed_tag_keys:
+        - cosoleme-authorized
+        - consoleme-authorized-cli-only
+    ```
+
     :param
         arn: The AWS role arn
         role_tags: A dictionary of role tags
@@ -1880,10 +1889,22 @@ def allowed_to_sync_role(
     """
     allowed_tags = config.get("roles.allowed_tags", {})
     allowed_arns = config.get("roles.allowed_arns", [])
-    if not allowed_tags and not allowed_arns:
+    allowed_tag_keys = config.get("roles.allowed_tag_keys", [])
+    if not allowed_tags and not allowed_arns and not allowed_tag_keys:
         return True
 
     if role_arn in allowed_arns:
+        return True
+
+    # Convert list of role tag dicts to an array of tag keys
+    # ex:
+    # role_tags = [{'Key': 'consoleme-authorized', 'Value': 'consoleme_admins'},
+    # {'Key': 'Description', 'Value': 'ConsoleMe OSS Demo Role'}]
+    # so: actual_tag_keys = ['consoleme-authorized', 'Description']
+    actual_tag_keys = [d['Key'] for d in role_tags]
+
+    # If any allowed tag key exists in the role's actual_tags this condition will pass
+    if allowed_tag_keys and any(x in allowed_tag_keys for x in actual_tag_keys):
         return True
 
     # Convert list of role tag dicts to a single key/value dict of tags

--- a/consoleme/lib/aws.py
+++ b/consoleme/lib/aws.py
@@ -1901,7 +1901,7 @@ def allowed_to_sync_role(
     # role_tags = [{'Key': 'consoleme-authorized', 'Value': 'consoleme_admins'},
     # {'Key': 'Description', 'Value': 'ConsoleMe OSS Demo Role'}]
     # so: actual_tag_keys = ['consoleme-authorized', 'Description']
-    actual_tag_keys = [d['Key'] for d in role_tags]
+    actual_tag_keys = [d["Key"] for d in role_tags]
 
     # If any allowed tag key exists in the role's actual_tags this condition will pass
     if allowed_tag_keys and any(x in allowed_tag_keys for x in actual_tag_keys):

--- a/consoleme/lib/aws.py
+++ b/consoleme/lib/aws.py
@@ -1896,10 +1896,15 @@ def allowed_to_sync_role(
     if role_arn in allowed_arns:
         return True
 
-    # If any allowed_tag_keys exist in the role_tags this condition will pass
-    if allowed_tag_keys and any(
-        x for x in role_tags for y in allowed_tag_keys if x["Key"] == y
-    ):
+    # Convert list of role tag dicts to an array of tag keys
+    # ex:
+    # role_tags = [{'Key': 'consoleme-authorized', 'Value': 'consoleme_admins'},
+    # {'Key': 'Description', 'Value': 'ConsoleMe OSS Demo Role'}]
+    # so: actual_tag_keys = ['consoleme-authorized', 'Description']
+    actual_tag_keys = [d['Key'] for d in role_tags]
+
+    # If any allowed tag key exists in the role's actual_tags this condition will pass
+    if allowed_tag_keys and any(x in allowed_tag_keys for x in actual_tag_keys):
         return True
 
     # Convert list of role tag dicts to a single key/value dict of tags

--- a/consoleme/lib/aws.py
+++ b/consoleme/lib/aws.py
@@ -1896,15 +1896,10 @@ def allowed_to_sync_role(
     if role_arn in allowed_arns:
         return True
 
-    # Convert list of role tag dicts to an array of tag keys
-    # ex:
-    # role_tags = [{'Key': 'consoleme-authorized', 'Value': 'consoleme_admins'},
-    # {'Key': 'Description', 'Value': 'ConsoleMe OSS Demo Role'}]
-    # so: actual_tag_keys = ['consoleme-authorized', 'Description']
-    actual_tag_keys = [d['Key'] for d in role_tags]
-
-    # If any allowed tag key exists in the role's actual_tags this condition will pass
-    if allowed_tag_keys and any(x in allowed_tag_keys for x in actual_tag_keys):
+    # If any allowed_tag_keys exist in the role_tags this condition will pass
+    if allowed_tag_keys and any(
+        x for x in role_tags for y in allowed_tag_keys if x["Key"] == y
+    ):
         return True
 
     # Convert list of role tag dicts to a single key/value dict of tags

--- a/docs/gitbook/configuration/resource-syncing.md
+++ b/docs/gitbook/configuration/resource-syncing.md
@@ -25,6 +25,16 @@ roles:
     tag1: value1
     tag2: value2
 ```
+Note that all tag keys and values must match for a role to be allowed.
+
+You can also allow roles based on a list of tag keys. The role will be allowed if any of the tag keys exist against it.
+
+```text
+roles:
+  allowed_tag_keys:
+    - consoleme-authorized
+    - consoleme-authorized-cli-only
+```
 
 Alternatively, you can provide an explicit list of roles you want managed by Consoleme by adding this configuration:
 

--- a/example_config/example_config_base.yaml
+++ b/example_config/example_config_base.yaml
@@ -184,9 +184,11 @@ challenge_url:
 # Parameters:
 #  allowed_tags: map[string]string: if non-empty, consoleme will only consider roles tags mapped here
 #  allowed_arns: list[string]:  if non-empty, consoleme will only consider the role arns in this list
+#  allowed_tag_keys: list[string]:  if non-empty, consoleme will only consider roles with a tag key mapped here
 # roles:
 #   allowed_tags: {}
 #   allowed_arns: []
+#   allows_tag_keys: []
 
 # This section provides an opt-out for caching in the policies table on the /policies page. You can
 # opt-out of each resource type that's typically cached. By default, nothing is skipped; everything

--- a/tests/lib/test_aws.py
+++ b/tests/lib/test_aws.py
@@ -341,6 +341,26 @@ class TestAwsLib(TestCase):
 
         self.assertEqual(allowed_to_sync_role(test_role_arn, test_role_tags), True)
 
+        # Allow - allowed_tag_keys exists in role
+        CONFIG.config = {
+            **CONFIG.config,
+            "roles": {
+                "allowed_tag_keys": ["testtag"],
+            },
+        }
+
+        self.assertEqual(allowed_to_sync_role(test_role_arn, test_role_tags), True)
+
+        # Reject - No tag key
+        CONFIG.config = {
+            **CONFIG.config,
+            "roles": {
+                "allowed_tag_keys": ["unknown"],
+            },
+        }
+
+        self.assertEqual(allowed_to_sync_role(test_role_arn, test_role_tags), False)
+
         CONFIG.config = old_config
 
     def test_remove_temp_policies(self):


### PR DESCRIPTION
We have lots of historical roles from multiple AWS accounts and wanted to hide those from being able to be used via ConsoleMe

The idea is that we'd just show ones created specifically for using via via consoleme that have appropriate tags.

Looked at the roles.allowed_tags option. But it was a bit too tight of a match with having to match all the specified key/value pairs.

To get around this, I've added a new config option called roles.allowed_tag_keys. 

For example
```
roles:
  allowed_tag_keys:
    - consoleme-authorized
    - consoleme-authorized-cli-only
```

When set if the role has a tag with any key that exists in the allowed_tag_keys list then it is allowed and shown on the policy list.

I'm not a python developer and this is the first time I've done anything in python so let me know if anything needs tweaked/changed 😃 

Thanks

Paul