### PR TITLE
Switch to Math.ceil() for page count calculation

### DIFF
--- a/ui/src/components/blocks/datatable/DataTableComponent.js
+++ b/ui/src/components/blocks/datatable/DataTableComponent.js
@@ -47,7 +47,7 @@ const DataTableComponent = ({ config }) => {
   };
 
   const rowsPerPage = tableConfig.rowsPerPage || DEFAULT_ROWS_PER_PAGE;
-  const totalPages = parseInt(filteredData.length / rowsPerPage, 10);
+  const totalPages = Math.ceil(filteredData.length / rowsPerPage);
 
   if (isLoading) {
     return (


### PR DESCRIPTION
During our rollout of ConsoleMe, users reported some of their roles missing in the ui, and it turned out to be an entire page of roles wasn't being displayed (user with 105 roles & 50 roles per page, but only 2 pages displayed). Switching to `Math.ceil()` to round up the division result produces the expected number of role pages. 