### PR TITLE
Fix Terraform deployer

### DIFF
--- a/.github/workflows/build-and-package.yml
+++ b/.github/workflows/build-and-package.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      ASYNC_TEST_TIMEOUT: 120
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python 3.10.5

--- a/terraform/central-account/.terraform.lock.hcl
+++ b/terraform/central-account/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   constraints = ">= 2.65.0, >= 2.70.0, >= 3.0.0"
   hashes = [
     "h1:1ud3VckbhSQ250tv58JCM9i1HKP05eijG4PEnU5PH7s=",
+    "h1:DFUb87/IK9l6anGAagwkDZ3x62p18JCljU8he5SfLrM=",
     "zh:0cedd84ba908ba7190052b16cd7f70c41b0e2c2e914e54eecf2e3dae193f47fa",
     "zh:14b89bac6412e20d415fe67d5f2eaa1414d9bbf75a5bd8fc963f6ab8e3b8b1a0",
     "zh:159131129edab7ea118dee7d6daf1bfe4615f200a2d5120deb8369cbd2c4b598",
@@ -25,6 +26,7 @@ provider "registry.terraform.io/hashicorp/local" {
   constraints = ">= 1.3.0"
   hashes = [
     "h1:EYZdckuGU3n6APs97nS2LxZm3dDtGqyM4qaIvsmac8o=",
+    "h1:PaQTpxHMbZB9XV+c1od1eaUvndQle3ZZHx79hrI6C3k=",
     "zh:0f1ec65101fa35050978d483d6e8916664b7556800348456ff3d09454ac1eae2",
     "zh:36e42ac19f5d68467aacf07e6adcf83c7486f2e5b5f4339e9671f68525fc87ab",
     "zh:6db9db2a1819e77b1642ec3b5e95042b202aee8151a0256d289f2e141bf3ceb3",
@@ -43,6 +45,7 @@ provider "registry.terraform.io/hashicorp/null" {
   version     = "3.1.0"
   constraints = ">= 2.0.0"
   hashes = [
+    "h1:grYDj8/Lvp1OwME+g1AsECPN1czO5ssSf+8fCluCHQY=",
     "h1:vpC6bgUQoJ0znqIKVFevOdq+YQw42bRq0u+H3nto8nA=",
     "zh:02a1675fd8de126a00460942aaae242e65ca3380b5bb192e8773ef3da9073fd2",
     "zh:53e30545ff8926a8e30ad30648991ca8b93b6fa496272cd23b26763c8ee84515",
@@ -61,6 +64,7 @@ provider "registry.terraform.io/hashicorp/null" {
 provider "registry.terraform.io/hashicorp/random" {
   version = "3.1.0"
   hashes = [
+    "h1:9cCiLO/Cqr6IUvMDSApCkQItooiYNatZpEXmcu0nnng=",
     "h1:BZMEPucF+pbu9gsPk0G0BHx7YP04+tKdq2MrRDF1EDM=",
     "zh:2bbb3339f0643b5daa07480ef4397bd23a79963cc364cdfbb4e86354cb7725bc",
     "zh:3cd456047805bf639fbf2c761b1848880ea703a054f76db51852008b11008626",
@@ -79,6 +83,7 @@ provider "registry.terraform.io/hashicorp/random" {
 provider "registry.terraform.io/hashicorp/tls" {
   version = "3.1.0"
   hashes = [
+    "h1:U+kgPLboCrcs4eZV87esP7iydF8mjMyHKE/mDsrwfkQ=",
     "h1:fUJX8Zxx38e2kBln+zWr1Tl41X+OuiE++REjrEyiOM4=",
     "zh:3d46616b41fea215566f4a957b6d3a1aa43f1f75c26776d72a98bdba79439db6",
     "zh:623a203817a6dafa86f1b4141b645159e07ec418c82fe40acd4d2a27543cbaa2",

--- a/terraform/central-account/main.tf
+++ b/terraform/central-account/main.tf
@@ -1,13 +1,13 @@
 module "server" {
   source = "git::https://github.com/terraform-aws-modules/terraform-aws-ec2-instance?ref=v2.16.0"
 
-  name                 = module.compute_label.id
-  instance_count       = 1
-  ami                  = data.aws_ami.amazon_linux.id
-  instance_type        = var.instance_type
-  key_name             = var.key_name
-  iam_instance_profile = aws_iam_instance_profile.ConsoleMeInstanceProfile.name
-  subnet_id            = var.associate_public_ip_address_to_ec2 ?  module.network.public_subnets[0] : module.network.private_subnets[0]
+  name                        = module.compute_label.id
+  instance_count              = 1
+  ami                         = data.aws_ami.amazon_linux.id
+  instance_type               = var.instance_type
+  key_name                    = var.key_name
+  iam_instance_profile        = aws_iam_instance_profile.ConsoleMeInstanceProfile.name
+  subnet_id                   = var.associate_public_ip_address_to_ec2 ? module.network.public_subnets[0] : module.network.private_subnets[0]
   associate_public_ip_address = var.associate_public_ip_address_to_ec2
   user_data = templatefile("${path.module}/templates/userdata.sh", tomap({
     bucket                  = aws_s3_bucket.consoleme_files_bucket.bucket

--- a/terraform/central-account/main.tf
+++ b/terraform/central-account/main.tf
@@ -7,7 +7,8 @@ module "server" {
   instance_type        = var.instance_type
   key_name             = var.key_name
   iam_instance_profile = aws_iam_instance_profile.ConsoleMeInstanceProfile.name
-  subnet_id            = module.network.private_subnets[0]
+  subnet_id            = var.associate_public_ip_address_to_ec2 ?  module.network.public_subnets[0] : module.network.private_subnets[0]
+  associate_public_ip_address = var.associate_public_ip_address_to_ec2
   user_data = templatefile("${path.module}/templates/userdata.sh", tomap({
     bucket                  = aws_s3_bucket.consoleme_files_bucket.bucket
     current_account_id      = data.aws_caller_identity.current.account_id

--- a/terraform/central-account/security_group.tf
+++ b/terraform/central-account/security_group.tf
@@ -26,7 +26,7 @@ resource "aws_security_group_rule" "external_ingress_8081" {
 
 # SSH
 resource "aws_security_group_rule" "external_ingress_ssh" {
-  count     = var.associate_public_ip_address_to_ec2 ? 1 : 0
+  count             = var.associate_public_ip_address_to_ec2 ? 1 : 0
   from_port         = 22
   protocol          = "tcp"
   security_group_id = aws_security_group.server.id

--- a/terraform/central-account/security_group.tf
+++ b/terraform/central-account/security_group.tf
@@ -24,6 +24,17 @@ resource "aws_security_group_rule" "external_ingress_8081" {
   cidr_blocks       = var.allowed_inbound_cidr_blocks
 }
 
+# SSH
+resource "aws_security_group_rule" "external_ingress_ssh" {
+  count     = var.associate_public_ip_address_to_ec2 ? 1 : 0
+  from_port         = 22
+  protocol          = "tcp"
+  security_group_id = aws_security_group.server.id
+  to_port           = 22
+  type              = "ingress"
+  cidr_blocks       = var.allowed_inbound_cidr_blocks
+}
+
 resource "aws_security_group_rule" "external_egress_allow_all" {
   type              = "egress"
   from_port         = 0

--- a/terraform/central-account/templates/userdata.sh
+++ b/terraform/central-account/templates/userdata.sh
@@ -25,9 +25,7 @@ systemctl restart rsyslog
 # ---------------------------------------------------------------------------------------------------------------------
 
 sudo yum update -y
-yum -y erase python3
-sudo amazon-linux-extras enable python3.8 # consoleme requires 3.8
-yum -y install git python3.8 python38-pip python38-devel
+yum -y install git python3.9 python3.9-pip python3.9-devel
 yum -y install libcurl-devel
 yum -y install libxml2-devel xmlsec1-devel xmlsec1-openssl-devel libtool-ltdl-devel
 sudo yum install -y gcc-c++
@@ -49,22 +47,22 @@ useradd -r -s /bin/false flower
 usermod -aG flower flower
 mkdir -p /apps/flower
 chown -R flower:flower /apps/flower
-python3.8 -m venv /apps/flower/env --copies
+python3.9 -m venv /apps/flower/env --copies
 source /apps/flower/env/bin/activate
-pip3.8 install flower redis
+pip3.9 install flower redis
 
 # Set up a new Virtualenv in the Consoleme directory
-python3.8 -m venv /apps/consoleme/env
+python3.9 -m venv /apps/consoleme/env
 source /apps/consoleme/env/bin/activate
 chown -R consoleme:consoleme /apps/consoleme
 chown -R consoleme:consoleme /logs
 # Install it
 cd /apps/consoleme
-pip3.8 install xmlsec
+pip3.9 install xmlsec
 
-# Make uses "pip" and "python", assuming they are 3.8, but they actually point to python2 (because yum uses it)
-alias python=python3.8
-alias pip=pip3.8
+# Make uses "pip" and "python", assuming they are 3.9, but they actually point to python2 (because yum uses it)
+alias python=python3.9
+alias pip=pip3.9
 make env_install
 
 make dynamo
@@ -81,7 +79,7 @@ systemctl start redis
 cd /apps/consoleme
 
 # Install nvm
-curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh > /tmp/nvm-install.sh
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh > /tmp/nvm-install.sh
 chmod +x /tmp/nvm-install.sh
 bash /tmp/nvm-install.sh
 echo 'export NVM_DIR="/root/.nvm"' >> /root/.bashrc
@@ -89,8 +87,8 @@ echo '[ -s "\$NVM_DIR/nvm.sh" ] && . "\$NVM_DIR/nvm.sh"  # This loads nvm' >> /r
 . ~/.nvm/nvm.sh
 . ~/.bashrc
 cd /apps/consoleme
-nvm install 12.18.2
-nvm use 12.18.2
+nvm install 16.16.0
+nvm use 16.16.0
 node -e "console.log('Running Node.js ' + process.version)"
 npm install yarn -g
 yarn --cwd ui
@@ -123,7 +121,7 @@ Restart=always
 RestartSec=1
 User=consoleme
 Group=consoleme
-ExecStart=/usr/bin/env /apps/consoleme/env/bin/python3.8 /apps/consoleme/consoleme/__main__.py
+ExecStart=/usr/bin/env /apps/consoleme/env/bin/python /apps/consoleme/consoleme/__main__.py
 
 [Install]
 WantedBy=multi-user.target
@@ -144,7 +142,7 @@ RestartSec=1
 WorkingDirectory=/apps/consoleme
 Environment=CONFIG_LOCATION=${CONFIG_LOCATION}
 Environment=EC2_REGION=${region}
-ExecStart=/usr/bin/env /apps/consoleme/env/bin/python3.8 /apps/consoleme/env/bin/celery -A consoleme.celery_tasks.celery_tasks worker -l DEBUG -B -E --concurrency=15
+ExecStart=/usr/bin/env /apps/consoleme/env/bin/python /apps/consoleme/env/bin/celery -A consoleme.celery_tasks.celery_tasks worker -l DEBUG -B -E --concurrency=15
 
 [Install]
 WantedBy=multi-user.target
@@ -175,7 +173,7 @@ export EC2_REGION=${region}
 EOF
 
 # Run script to decode and write a custom ConsoleMe configuration. This won't do anything unless CONSOLEME_CONFIG_S3 is defined.
-sudo -u consoleme bash -c '. /home/consoleme/.bashrc ; /apps/consoleme/env/bin/python3.8 /apps/consoleme/scripts/retrieve_or_decode_configuration.py'
+sudo -u consoleme bash -c '. /home/consoleme/.bashrc ; /apps/consoleme/env/bin/python /apps/consoleme/scripts/retrieve_or_decode_configuration.py'
 # Make sure it is listed
 systemctl list-unit-files | grep celery.service
 systemctl list-unit-files | grep consoleme.service
@@ -185,7 +183,7 @@ systemctl enable celery
 systemctl enable consoleme
 systemctl start consoleme
 
-sudo -u consoleme bash -c '. /home/consoleme/.bashrc ; /apps/consoleme/env/bin/python3.8 /apps/consoleme/scripts/initialize_redis_oss.py'
+sudo -u consoleme bash -c '. /home/consoleme/.bashrc ; /apps/consoleme/env/bin/python /apps/consoleme/scripts/initialize_redis_oss.py'
 
 echo "Running custom userdata script"
 ${custom_user_data_script}

--- a/terraform/central-account/terraform.tfvars.example
+++ b/terraform/central-account/terraform.tfvars.example
@@ -11,6 +11,7 @@ subnet_azs          = ["us-east-1a", "us-east-1b"]
 application_admin   = "teamemail@example.com"
 
 allowed_inbound_cidr_blocks = []  // NOTE: Do not open this up to 0.0.0.0/0. Restrict access to your IP address for the demo.
+associate_public_ip_address_to_ec2 = false // Set this to true if you want to provide a public IP to the EC2 instance
 allow_internet_access = false // Set this to true if you want to be able to access the server from the Internet.
 bucket_name_prefix = "your-name-prefix"
 

--- a/terraform/central-account/variables.tf
+++ b/terraform/central-account/variables.tf
@@ -80,9 +80,15 @@ variable "lb_port" {
 }
 
 # Compute
+variable "associate_public_ip_address_to_ec2" {
+  description = "Whether to provide a public IP to the ConsoleMe EC2 instance"
+  default = false
+  type = bool
+}
+
 variable "instance_type" {
-  description = "The size of the Ec2 instance. Defaults to t2.medium"
-  default     = "t2.medium"
+  description = "The size of the EC2 instance. Defaults to t4g.medium"
+  default     = "t4g.medium"
 }
 
 variable "volume_size" {
@@ -106,8 +112,8 @@ variable "ec2_ami_owner_filter" {
 }
 
 variable "ec2_ami_name_filter" {
-  description = "The name of the AMI to search for. Defaults to amzn2-ami-hvm-2.0.2020*-x86_64-ebs"
-  default     = "amzn2-ami-hvm-2.0.2020*-x86_64-ebs" # Need a release post Jan 2020 to support IMDSv2
+  description = "The name of the AMI to search for. Defaults to al2022-ami*-arm64"
+  default     = "al2022-ami*-arm64" # Need a release post Jan 2020 to support IMDSv2
   type        = string
 }
 

--- a/terraform/central-account/variables.tf
+++ b/terraform/central-account/variables.tf
@@ -82,8 +82,8 @@ variable "lb_port" {
 # Compute
 variable "associate_public_ip_address_to_ec2" {
   description = "Whether to provide a public IP to the ConsoleMe EC2 instance"
-  default = false
-  type = bool
+  default     = false
+  type        = bool
 }
 
 variable "instance_type" {


### PR DESCRIPTION
This PR fixes the Terraform deployer.

- [X] Upgrade to Amazon Linux 2022
- [X] Upgrade to Python 3.9 (Versus trying to install Py310 on AL2022)
- [X] Graviton (ARM) Instances by default (Save $$)
- [X] Support public subnet / publicly accessible EC2 for SSH
- [X] Update to Node 16.16.0 (Resolves #9328)
- [X] Tested briefly to confirm it worked for me