### PR TITLE
Bump gh-actions python ver 3.10.5 -> 3.10.6

### DIFF
--- a/.github/workflows/build-and-package.yml
+++ b/.github/workflows/build-and-package.yml
@@ -15,10 +15,10 @@ jobs:
       ASYNC_TEST_TIMEOUT: 120
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python 3.10.5
+      - name: Set up Python 3.10.6
         uses: actions/setup-python@v1
         with:
-          python-version: 3.10.5
+          python-version: 3.10.6
       - name: Install Terraform
         uses: hashicorp/setup-terraform@v1
       - name: Install dependencies
@@ -62,10 +62,10 @@ jobs:
       # master builds don't have tags, which breaks setupmeta versioning. This retrieves the tags.
       - run: git fetch --prune --unshallow --tags
         if: github.ref == 'refs/heads/master'
-      - name: Set up Python 3.10.5
+      - name: Set up Python 3.10.6
         uses: actions/setup-python@v1
         with:
-          python-version: 3.10.5
+          python-version: 3.10.6
       - name: Build UI assets
         run: |
           curl -sL https://deb.nodesource.com/setup_14.x | sudo bash


### PR DESCRIPTION
Updates gh-actions build-and-package workflow python version to fix CI errors on #9320 

<details><summary>Error Log:</summary>

```
Run actions/setup-python@v1
Error: Version 3.10.5 with arch x64 not found
Available versions:

2.7.18 (x64)
3.10.6 (x64)
3.6.15 (x64)
3.7.13 (x64)
3.8.13 (x64)
3.9.13 (x64)
```

</details>