### PR TITLE
Update duplicated dynamodb configuration property

### DIFF
--- a/consoleme/lib/dynamo.py
+++ b/consoleme/lib/dynamo.py
@@ -251,7 +251,7 @@ class UserDynamoHandler(BaseDynamoHandler):
                 config.get("aws.group_log_dynamo_table", "consoleme_audit_global")
             )
             self.dynamic_config = self._get_dynamo_table(
-                config.get("aws.group_log_dynamo_table", "consoleme_config_global")
+                config.get("aws.config_dynamo_table", "consoleme_config_global")
             )
             self.policy_requests_table = self._get_dynamo_table(
                 config.get(


### PR DESCRIPTION
DynamoDB table config keys are duplicated.
* consoleme_config_global
* consoleme_audit_global