### PR TITLE
9354 Fix Bitnami Chart Versioning

### DIFF
--- a/helm/consoleme/Chart.yaml
+++ b/helm/consoleme/Chart.yaml
@@ -10,6 +10,6 @@ appVersion: "1.16.0"
 
 dependencies:
   - name: redis
-    repository: https://charts.bitnami.com/bitnami
+    repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
     version: 14.3.1
     condition: redis.deployLocal


### PR DESCRIPTION
Fix to Bitnami's missing Chart version. #9354 

This change references the full chart version list for Bitnami instead of the hosted YAML which only keeps 6 months of versions. 

More information can be found here: https://github.com/bitnami/charts/issues/10539

Testing: 

1. `helm repo add consoleme "git+ssh://git@github.com/johnknapprs/consoleme@helm?ref=9354-fix-bitnami-chart-versioning"`
2. `helm repo update`
3. `helm install my-consoleme consoleme/consoleme`

Previously the first step would fail. See #9354 for more information about issue