### PR TITLE
9356 update autoscaling version (#1)

### DIFF
--- a/.github/workflows/build-and-package.yml
+++ b/.github/workflows/build-and-package.yml
@@ -15,10 +15,10 @@ jobs:
       ASYNC_TEST_TIMEOUT: 120
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python 3.10.5
+      - name: Set up Python 3.10.10
         uses: actions/setup-python@v1
         with:
-          python-version: 3.10.5
+          python-version: 3.10.10
       - name: Install Terraform
         uses: hashicorp/setup-terraform@v1
       - name: Install dependencies
@@ -62,10 +62,10 @@ jobs:
       # master builds don't have tags, which breaks setupmeta versioning. This retrieves the tags.
       - run: git fetch --prune --unshallow --tags
         if: github.ref == 'refs/heads/master'
-      - name: Set up Python 3.10.5
+      - name: Set up Python 3.10.10
         uses: actions/setup-python@v1
         with:
-          python-version: 3.10.5
+          python-version: 3.10.10
       - name: Build UI assets
         run: |
           curl -sL https://deb.nodesource.com/setup_14.x | sudo bash

--- a/helm/consoleme/templates/hpa.yaml
+++ b/helm/consoleme/templates/hpa.yaml
@@ -1,5 +1,9 @@
 {{- if .Values.autoscaling.enabled }}
+{{- if semverCompare ">=1.23-0" .Capabilities.KubeVersion.Version }}
+apiVersion: autoscaling/v2
+{{- else }}
 apiVersion: autoscaling/v2beta1
+{{- end }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "consoleme.fullname" . }}


### PR DESCRIPTION
Related to issue: https://github.com/Netflix/consoleme/issues/9356
**Describe the bug**
HorizontalPodAutoscaler v2beta1 is deprecated in v1.22+ and causes failures deploying on updated clusters

>   Error: unable to build kubernetes objects from release manifest: resource mapping not found for name: "consoleme" namespace: "" from "": no matches for kind "HorizontalPodAutoscaler" in version "autoscaling/v2beta1"

**Expected behavior**
HPA autoscaler should successfully deploy with the application when `autoscaling.enabled: true`

This PR updates the python build package to one that is available & adds a check for newer KubeVersion to utilize the stable version: `autoscaling/v2`
