### PR TITLE
[fix] configure hpa api version dynamically

### DIFF
--- a/helm/consoleme/Chart.yaml
+++ b/helm/consoleme/Chart.yaml
@@ -5,7 +5,7 @@ maintainers:
   - email: ccastrapel@netflix.com
     name: Curtis Castrapel
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "1.16.0"
 
 dependencies:

--- a/helm/consoleme/templates/_helpers.tpl
+++ b/helm/consoleme/templates/_helpers.tpl
@@ -60,3 +60,14 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Return the appropriate apiVersion for HPA APIs.
+*/}}
+{{- define "apiVersionHPA" -}}
+{{- if semverCompare "< 1.23-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "autoscaling/v2beta2" }}
+{{- else if semverCompare ">=1.23-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "autoscaling/v2" }}
+{{- end -}}
+{{- end -}}

--- a/helm/consoleme/templates/hpa.yaml
+++ b/helm/consoleme/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: {{ template "apiVersionHPA" . }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "consoleme.fullname" . }}


### PR DESCRIPTION
## WHAT
Configure HorizontalPodAutoscaler (HPA) according kubernetes version

## WHY
The autoscaling/v2beta2 API version of HorizontalPodAutoscaler is no longer served as of v1.26.
The autoscaling/v2 API version available since v1.23.

# Ref
https://kubernetes.io/docs/reference/using-api/deprecation-guide/#horizontalpodautoscaler-v126