### PR TITLE
Fix Decoding OIDC tokens with No Verify

### DIFF
--- a/consoleme/lib/oidc.py
+++ b/consoleme/lib/oidc.py
@@ -250,8 +250,8 @@ async def authenticate_user_by_oidc(request):
                     log.debug(log_data, exc_info=True)
                     groups = []
         else:
-            decoded_id_token = jwt.decode(id_token, verify=jwt_verify)
-            decoded_access_token = jwt.decode(access_token, verify=jwt_verify)
+            decoded_id_token = jwt.decode(id_token, options={"verify_signature": False})
+            decoded_access_token = jwt.decode(access_token, options={"verify_signature": False})
 
         email = email or decoded_id_token.get(
             config.get("get_user_by_oidc_settings.jwt_email_key", "email")


### PR DESCRIPTION
# Description
An error occurs on current PyJWT versions of lib/oidcy.py when verification is not enforced. This change only updates the decode methods with the correct argument parameters.

as before:
```shell
packages/jwt/api_jwt.py", line 148, in decode_complete
    raise DecodeError(
jwt.exceptions.DecodeError: It is required that you pass in a value for the "algorithms" argument when calling decode(
```

to an actual decoded value with no verification required.